### PR TITLE
Remove Wiki, Support nav, 40% stat, and price comparison

### DIFF
--- a/v2/src/app/community/page.tsx
+++ b/v2/src/app/community/page.tsx
@@ -439,10 +439,6 @@ function ImpactSection() {
             <div className="text-4xl font-bold text-accent-foreground">20+</div>
             <div className="text-sm text-accent-foreground/80 mt-1">Washing machines</div>
           </div>
-          <div>
-            <div className="text-4xl font-bold text-accent-foreground">40%</div>
-            <div className="text-sm text-accent-foreground/80 mt-1">Back to community</div>
-          </div>
         </div>
         <Button size="lg" variant="secondary" asChild>
           <Link href="/partner">Partner With Us</Link>

--- a/v2/src/app/page.tsx
+++ b/v2/src/app/page.tsx
@@ -100,20 +100,6 @@ export default async function HomePage() {
               {/* Right: Assembly sequence + price comparison */}
               <div>
                 <AssemblySequence />
-                <div className="grid grid-cols-3 gap-3 mt-8">
-                  <div className="text-center p-3 rounded-xl border border-border">
-                    <div className="text-xl font-bold text-primary">$350</div>
-                    <div className="text-xs text-muted-foreground mt-0.5">to make</div>
-                  </div>
-                  <div className="text-center p-3 rounded-xl border border-border">
-                    <div className="text-xl font-bold text-primary">$600</div>
-                    <div className="text-xs text-muted-foreground mt-0.5">RRP</div>
-                  </div>
-                  <div className="text-center p-3 rounded-xl border border-border">
-                    <div className="text-xl font-bold text-primary">$1,500</div>
-                    <div className="text-xs text-muted-foreground mt-0.5">regular bed in community</div>
-                  </div>
-                </div>
               </div>
             </div>
           </div>

--- a/v2/src/app/partner/page.tsx
+++ b/v2/src/app/partner/page.tsx
@@ -81,7 +81,6 @@ const partnerOptions = [
 const impactMetrics = [
   { value: '369+', label: 'Beds delivered' },
   { value: '8+', label: 'Communities' },
-  { value: '40%', label: 'Returns to community' },
   { value: '14kg', label: 'Plastic diverted per bed' },
 ];
 

--- a/v2/src/app/pitch/document/page.tsx
+++ b/v2/src/app/pitch/document/page.tsx
@@ -265,10 +265,6 @@ export default function PitchDocumentPage() {
 
           <div className="grid grid-cols-3 gap-6 mb-12">
             <div className="avoid-break text-center border border-neutral-200 rounded-lg p-6">
-              <p className="text-4xl font-bold text-black mb-1">40%</p>
-              <p className="text-sm text-neutral-600">of every sale returns to communities</p>
-            </div>
-            <div className="avoid-break text-center border border-neutral-200 rounded-lg p-6">
               <p className="text-4xl font-bold text-black mb-1">100%</p>
               <p className="text-sm text-neutral-600">community ownership is the goal</p>
             </div>

--- a/v2/src/app/process/page.tsx
+++ b/v2/src/app/process/page.tsx
@@ -144,10 +144,6 @@ export default function ProcessPage() {
                 <div className="text-3xl font-bold text-primary">5 min</div>
                 <div className="text-sm text-muted-foreground mt-1">Assembly time, no tools required</div>
               </div>
-              <div>
-                <div className="text-3xl font-bold text-primary">40%</div>
-                <div className="text-sm text-muted-foreground mt-1">Of every sale returns to community</div>
-              </div>
             </div>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Button size="lg" asChild>

--- a/v2/src/app/story/page.tsx
+++ b/v2/src/app/story/page.tsx
@@ -741,7 +741,6 @@ export default async function StoryPage() {
                 {[
                   { value: '369+', label: 'beds delivered' },
                   { value: '8+', label: 'communities served' },
-                  { value: '40%', label: 'back to community' },
                   { value: '14kg', label: 'plastic per bed diverted' },
                 ].map((stat) => (
                   <div key={stat.label} className="text-center p-6 rounded-xl bg-white/5 border border-white/10">
@@ -789,10 +788,6 @@ export default async function StoryPage() {
                 Our job is to become unnecessary.
               </p>
               <div className="grid gap-4 md:grid-cols-3 mb-12">
-                <div className="bg-accent-foreground/10 rounded-2xl p-8">
-                  <div className="text-5xl font-bold text-accent-foreground mb-2">40%</div>
-                  <div className="text-accent-foreground/70">of every sale goes directly back to communities</div>
-                </div>
                 <div className="bg-accent-foreground/10 rounded-2xl p-8">
                   <div className="text-5xl font-bold text-accent-foreground mb-2">100%</div>
                   <div className="text-accent-foreground/70">community ownership is the end goal</div>

--- a/v2/src/components/layout/impact-banner.tsx
+++ b/v2/src/components/layout/impact-banner.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link';
 const stats = [
   { value: '369+', label: 'beds delivered' },
   { value: '8', label: 'communities' },
-  { value: '40%', label: 'back to community' },
   { value: '14kg', label: 'plastic diverted per bed' },
 ];
 

--- a/v2/src/components/layout/site-header.tsx
+++ b/v2/src/components/layout/site-header.tsx
@@ -12,9 +12,7 @@ const navigation = [
   { name: 'How It\'s Made', href: '/process' },
   { name: 'Our Story', href: '/story' },
   { name: 'Community', href: '/community' },
-  { name: 'Wiki', href: '/wiki' },
   { name: 'Dashboard', href: '/dashboard' },
-  { name: 'Support', href: '/support' },
 ];
 
 export function SiteHeader() {


### PR DESCRIPTION
## Summary
- Remove Wiki and Support from site header navigation
- Remove "40% back to community" stat from all pages (header banner, story, community, partner, pitch, process)
- Remove $350/$600/$1,500 price comparison grid from homepage

## Revert
If anything looks wrong, revert with one click using the "Revert" button on this PR after merge.

## Test plan
- [ ] Verify header nav shows only: The Stretch Bed, How It's Made, Our Story, Community, Dashboard
- [ ] Verify impact banner shows: 369+ beds, 8 communities, 14kg plastic
- [ ] Verify homepage no longer shows price comparison boxes
- [ ] Check story, community, partner, pitch pages no longer show 40% stat