### PR TITLE
Fix: revenue chart formatter name param also undefined

### DIFF
--- a/v2/src/components/dashboard/revenue-chart.tsx
+++ b/v2/src/components/dashboard/revenue-chart.tsx
@@ -54,7 +54,7 @@ export function RevenueChart({ data }: RevenueChartProps) {
               border: '1px solid #e5e5e5',
               borderRadius: '8px',
             }}
-            formatter={(value: number | undefined, name: string) => {
+            formatter={(value: number | undefined, name: string | undefined) => {
               if (name === 'revenue') {
                 return [`$${(value ?? 0).toFixed(2)}`, 'Revenue'];
               }


### PR DESCRIPTION
## Summary
- Recharts Tooltip formatter `name` param can also be `undefined`, not just `value`
- Follows up on #9

## Test plan
- [ ] Vercel build succeeds