### PR TITLE
feat: host videos on Supabase Storage CDN

### DIFF
--- a/v2/src/app/auth/phone-login/page.tsx
+++ b/v2/src/app/auth/phone-login/page.tsx
@@ -5,6 +5,8 @@ import { createClient } from '@/lib/supabase/server';
 import { PhoneLoginForm } from '@/components/auth/phone-login-form';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
+export const dynamic = 'force-dynamic';
+
 export const metadata = {
   title: 'Sign In - Goods on Country',
   description: 'Sign in to access your items, messages, and requests',

--- a/v2/src/app/dashboard/page.tsx
+++ b/v2/src/app/dashboard/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = 'force-dynamic';
+
 import { Suspense } from 'react';
 import { Card } from '@/components/ui/card';
 import { KPICard } from '@/components/dashboard/kpi-card';

--- a/v2/src/app/media/layout.tsx
+++ b/v2/src/app/media/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from 'next';
 
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: 'Media & Partner Pack',
   description: 'Everything funders and partners need: project overview, team bios, key stats, photos, videos, brand assets, and key links.',

--- a/v2/src/app/page.tsx
+++ b/v2/src/app/page.tsx
@@ -5,6 +5,7 @@ import { CyclingImage } from '@/components/pitch/cycling-image';
 import { MediaSlot } from '@/components/ui/media-slot';
 import { Button } from '@/components/ui/button';
 import { brand } from '@/lib/data/content';
+import { videoUrl } from '@/lib/data/media';
 
 export default async function HomePage() {
   return (
@@ -16,8 +17,8 @@ export default async function HomePage() {
         primaryCta={{ text: 'Shop the Stretch Bed', href: '/shop/stretch-bed-single' }}
         secondaryCta={{ text: 'How It\'s Made', href: '/process' }}
         videoSrc={{
-          desktop: '/video/hero-desktop.mp4',
-          mobile: '/video/hero-mobile.mp4',
+          desktop: videoUrl('hero-desktop.mp4'),
+          mobile: videoUrl('hero-mobile.mp4'),
           poster: '/video/hero-poster.jpg',
         }}
         imageSrc="https://cdn.prod.website-files.com/64ea91d86ff3fda1ff23fb95/686f06aca919ac39a08c6cbc_20250629-IMG_7731.jpg"

--- a/v2/src/app/story/page.tsx
+++ b/v2/src/app/story/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { brand, story, quotes, communityPartnerships, videoTestimonials } from '@/lib/data/content';
-import { media } from '@/lib/data/media';
+import { media, videoUrl } from '@/lib/data/media';
 import { empathyLedger } from '@/lib/empathy-ledger';
 import { MediaSlot, VideoSlot } from '@/components/ui/media-slot';
 import { Button } from '@/components/ui/button';
@@ -24,37 +24,37 @@ const codesignQuote = quotes.find(q => q.author === 'Dianne Stokes');
 const STORY_VIDEOS = {
   // Hero: community people arriving + assembling beds (0:20-1:20 from Stretch Bed Overlay)
   heroCommunity: {
-    desktop: '/video/community-desktop.mp4',
-    mobile: '/video/community-mobile.mp4',
+    desktop: videoUrl('community-desktop.mp4'),
+    mobile: videoUrl('community-mobile.mp4'),
     poster: '/video/community-poster.jpg',
   },
   // Stretch Bed: close-up assembly/weave detail (1:10-2:30 from Stretch Bed Overlay)
   stretchBed: {
-    desktop: '/video/stretch-bed-desktop.mp4',
-    mobile: '/video/stretch-bed-mobile.mp4',
+    desktop: videoUrl('stretch-bed-desktop.mp4'),
+    mobile: videoUrl('stretch-bed-mobile.mp4'),
     poster: '/video/stretch-bed-poster.jpg',
   },
   // Young person helping build: group building (0:35-1:10 from Stretch Bed Overlay)
   buildingTogether: {
-    desktop: '/video/building-together-desktop.mp4',
-    mobile: '/video/building-together-mobile.mp4',
+    desktop: videoUrl('building-together-desktop.mp4'),
+    mobile: videoUrl('building-together-mobile.mp4'),
     poster: '/video/building-together-poster.jpg',
   },
   // Jaquilane: overlay background (silent, 0:05-0:35 from Jaquilane mum full)
   jaquilaneOverlay: {
-    desktop: '/video/jaquilane-overlay-desktop.mp4',
-    mobile: '/video/jaquilane-overlay-mobile.mp4',
+    desktop: videoUrl('jaquilane-overlay-desktop.mp4'),
+    mobile: videoUrl('jaquilane-overlay-mobile.mp4'),
     poster: '/video/jaquilane-poster.jpg',
   },
   // Jaquilane: full testimony with audio (0:10-2:10 from Jaquilane mum full)
-  jaquilaneTestimony: '/video/jaquilane-testimony.mp4',
+  jaquilaneTestimony: videoUrl('jaquilane-testimony.mp4'),
   washingMachine: undefined as string | undefined,      // Replace with washing machine background video
   projectStats: undefined as string | undefined,         // Full-page stats overlay video
   dianneStokes: undefined as string | undefined,         // Dianne Stokes washing machine video (Descript)
   // Recycling plant: containerised factory footage (0:00-0:50 from recycling gear.mp4)
   recyclingPlant: {
-    desktop: '/video/recycling-plant-desktop.mp4',
-    mobile: '/video/recycling-plant-mobile.mp4',
+    desktop: videoUrl('recycling-plant-desktop.mp4'),
+    mobile: videoUrl('recycling-plant-mobile.mp4'),
     poster: '/video/recycling-plant-poster.jpg',
   },
   cliffPlummer: videoTestimonials[0]?.embedUrl,           // Cliff Plummer — beds and dignity

--- a/v2/src/lib/data/content.ts
+++ b/v2/src/lib/data/content.ts
@@ -1,3 +1,5 @@
+import { videoUrl } from '@/lib/data/media';
+
 // Core content and messaging for Goods on Country
 // Source: COMPENDIUM_JANUARY_2026.md
 
@@ -937,7 +939,7 @@ export const videoGallery = [
     id: 'jaquilane-testimony',
     title: 'Jaquilane\'s Story',
     description: 'A community member shares their experience with Goods on Country.',
-    src: '/video/jaquilane-testimony.mp4',
+    src: videoUrl('jaquilane-testimony.mp4'),
     poster: '/video/jaquilane-poster.jpg',
     type: 'local' as const,
     category: 'testimony',
@@ -955,7 +957,7 @@ export const videoGallery = [
     id: 'building-together',
     title: 'Building Together',
     description: 'Community members assembling beds together on country.',
-    src: '/video/building-together-desktop.mp4',
+    src: videoUrl('building-together-desktop.mp4'),
     poster: '/video/building-together-poster.jpg',
     type: 'local' as const,
     category: 'process',
@@ -964,7 +966,7 @@ export const videoGallery = [
     id: 'community-gathering',
     title: 'Community',
     description: 'Community gathering for bed delivery and assembly.',
-    src: '/video/community-desktop.mp4',
+    src: videoUrl('community-desktop.mp4'),
     poster: '/video/community-poster.jpg',
     type: 'local' as const,
     category: 'community',
@@ -973,7 +975,7 @@ export const videoGallery = [
     id: 'recycling-plant',
     title: 'The Recycling Plant',
     description: 'Inside the containerised factory where community plastic becomes beds.',
-    src: '/video/recycling-plant-desktop.mp4',
+    src: videoUrl('recycling-plant-desktop.mp4'),
     poster: '/video/recycling-plant-poster.jpg',
     type: 'local' as const,
     category: 'process',
@@ -982,7 +984,7 @@ export const videoGallery = [
     id: 'stretch-bed-assembly',
     title: 'The Stretch Bed',
     description: 'Close-up of the bed assembly — no tools, under 5 minutes.',
-    src: '/video/stretch-bed-desktop.mp4',
+    src: videoUrl('stretch-bed-desktop.mp4'),
     poster: '/video/stretch-bed-poster.jpg',
     type: 'local' as const,
     category: 'product',
@@ -1175,7 +1177,7 @@ export const mediaPack = {
       title: 'The Recycling Plant',
       description: 'Inside the containerised factory where community plastic becomes beds.',
       embedUrl: 'https://share.descript.com/embed/haRZJbfJadJ',
-      downloadSrc: '/video/recycling-plant-desktop.mp4',
+      downloadSrc: videoUrl('recycling-plant-desktop.mp4'),
     },
     {
       title: 'Community Voices — Bed Recipient, Alice Springs',

--- a/v2/src/lib/data/media.ts
+++ b/v2/src/lib/data/media.ts
@@ -1,4 +1,17 @@
 /**
+ * Returns a public Supabase Storage URL for a video file.
+ * Videos are stored in the "video" bucket on Supabase Storage.
+ * Falls back to local /video/ path if NEXT_PUBLIC_SUPABASE_URL is not set.
+ */
+export function videoUrl(filename: string): string {
+  const base = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  if (base) {
+    return `${base}/storage/v1/object/public/video/${filename}`;
+  }
+  return `/video/${filename}`;
+}
+
+/**
  * Media map — single source of truth for all image/video paths.
  *
  * Resolution order:


### PR DESCRIPTION
## Summary
- Videos uploaded to Supabase Storage public `video` bucket (~125MB total)
- Added `videoUrl()` helper in `media.ts` that resolves filenames to Supabase CDN URLs
- Updated all mp4 references across homepage, story page, and content data
- Fixed pre-existing build errors: force-dynamic for dashboard, phone-login, and media pages

## Why
Video mp4 files were gitignored (too large for repo) so they never deployed to Vercel. Now served from Supabase Storage CDN.

## Test plan
- [ ] Vercel build succeeds
- [ ] Homepage hero video plays
- [ ] Story page videos play
- [ ] Dashboard page loads (dynamic rendering)