### PR TITLE
fix(admin/fleet): restore full dashboard + show all 38 deployments

### DIFF
--- a/v2/docs/fleet-connectivity-audit-may-2026.md
+++ b/v2/docs/fleet-connectivity-audit-may-2026.md
@@ -1,0 +1,180 @@
+# Fleet Connectivity Audit — May 2026
+
+Snapshot taken 2026-05-05. Purpose: explain who is connected, who is dark, why
+the dashboard was lying, and what to do about each gap.
+
+## TL;DR
+
+- **38 washing machines deployed across 8 communities** in `assets`, but the
+  fleet dashboard only ever showed the 10 Tennant Creek units that had a
+  Particle device paired to them.
+- **Only 1 machine is currently reporting** (F25 in Tennant Creek). 50 of the
+  last 51 events came from F25. The other 9 telemetry-enabled machines have
+  been silent for 14–65 days.
+- **Palm Island (10) and Maningrida (6) have zero telemetry hardware fitted.**
+  They show up in `assets` but no Particle/Openfields device was ever paired,
+  so no signals will ever come from them under the current setup.
+- **Two bugs were masking the picture:** (1) Leaflet SSR crash blanked the top
+  half of `/admin/fleet`; (2) the webhook stored `event_type='zapier-new-wash'`
+  instead of `'cycle_complete'`, so KPIs and the daily rollup read zero even
+  when F25 was busy.
+- **Three "ghost" Particle coreids** sent thousands of events for ~6 months
+  but are not in `assets`. Could be devices swapped out, devices fitted at a
+  site we forgot to register, or test units. They need triage.
+
+## Where the machines actually are
+
+| Community     | Total | With Particle HW | Reporting | Source of trust |
+|---|---:|---:|---:|---|
+| Tennant Creek | 21 | 8 | 1 (F25) | `assets` + `usage_logs` |
+| Palm Island   | 10 | 0 | 0 | `assets` only |
+| Maningrida    | 6  | 0 | 0 | `assets` only |
+| Other (test) | 1 | 0 | 0 | `assets` only |
+| **Total** | **38** | **8** | **1** | |
+
+### Tennant Creek deployment timeline
+
+- 2025-07-02 — Norman (Norm's House), Barkley Arts, Jimmy, Jimmy's Uncle (4)
+- 2025-09-15 → 2025-11-17 — Particle devices come online (4E5, 507, 098, F25, plus 3 ghost coreids)
+- 2025-12-03 — 10-machine "GB0-154" shipment lands ("Pending Assignment" except Nicole Frank)
+- 2025-12-13 — Nicole Frank assigned to GB0-154-2
+
+### Palm Island deployment timeline
+
+- 2025-07-09 — Rangers Station
+- 2025-08-05 — Additional Washers ×2
+- 2025-08-12 — Oochiumpa ×3, Workers House, Luella Bligh, Ebs Aunty
+- 2025-09-28 — Club Kuta machine
+
+All 10 are tracked manually only — no Particle device, no signal.
+
+### Maningrida deployment timeline
+
+- 2025-10-20 — Maningrida Laundry ×6
+
+All 6 are manual-tracking only.
+
+## How signals flow
+
+```
+Particle Photon (washer)
+   → Particle Cloud event
+   → Zapier (most active path) OR direct Particle Integration webhook
+   → POST https://www.goodsoncountry.com/api/webhooks/particle
+   → usage_logs row
+   → daily_machine_rollups (cron /api/cron/fleet-rollup, every 6h)
+   → /admin/fleet (KPI RPC + machine stats RPC)
+```
+
+There is also `/api/webhooks/openfields` for the Openfields Solutions feed —
+HMAC signed — but no live data has been observed coming through this path
+recently.
+
+## Per-machine signal history (live data, 2026-05-05)
+
+| machine_id | first seen | last seen | events | days silent |
+|---|---|---|---:|---:|
+| F25 (`...4086eb2aba8d4f25`) | 2025-11-17 | **2026-05-05** | 252 | <1 |
+| 4E5 (`...7ae01d08f95694e5`) | 2025-09-15 | 2026-04-21 | 79 | 14 |
+| 507 (`...c2ba447b66bcd507`) | 2025-09-28 | 2026-03-30 | 30 | 36 |
+| **ghost** (`...c4b97878b9a2b323`) | 2025-08-27 | 2026-03-27 | 296 | 39 |
+| **ghost** (`...fe6c048ccec66ab1`) | 2025-09-15 | 2026-03-21 | 279 | 45 |
+| 098 (`...2db6d32e15e86098`) | 2025-09-19 | 2026-03-01 | 3 | 65 |
+| **ghost** (`...689f1dd0daf5987cf2`) | 2025-09-15 | 2025-09-30 | 28 | 217 |
+| Norms House (named) | 2026-03-01 | 2026-03-09 | 23 | 57 |
+| Nicoles House (named) | 2026-03-01 | 2026-03-09 | 5 | 57 |
+| Barkley / 8D1 / Dian / Red Dust (named) | 2026-03-01 | 2026-03-01 | 1 each | 65 |
+
+## Bugs found and fixed
+
+### Bug 1 — Leaflet SSR crash (`/admin/fleet` top half blank)
+- File: `v2/src/app/admin/fleet/fleet-map.tsx`
+- Cause: top-level `import L from 'leaflet'` ran during server render; Leaflet
+  references `window` at module-load → `ReferenceError: window is not defined`
+  → React renders fallback only for the upper segment, hiding header, KPI
+  cards, map, activity chart.
+- Fix: defer Leaflet import to inside `useEffect` so it only ever runs in the
+  browser. Commit `cb78634` on `codex/goods-qbe-signoff`.
+
+### Bug 2 — `event_type` drift (KPIs read zero)
+- File: `v2/src/app/api/webhooks/particle/route.ts`
+- Cause: Zapier forwards Particle wash events with `event="zapier-new-wash"`,
+  but `mapEventType()` only knew about `wash_event`. Result: 212 historical
+  rows stored as `zapier-new-wash`. The KPI RPC, the machine-stats RPC, and
+  the `daily_machine_rollups` materialised view all filter on
+  `event_type = 'cycle_complete'` → those 212 rows are invisible to the
+  dashboard. F25 has 8 washes this week but "Total Washes" reads 0.
+- Fix: add `'zapier-new-wash'` to the `mapEventType` switch (future writes
+  normalised on insert) plus a one-shot UPDATE migration to rename the 212
+  historical rows + refresh the rollup view. Migration file:
+  `supabase/migrations/20260505000001_fleet_event_type_normalisation.sql`.
+
+### Bug 3 — Dashboard hides 28 of 38 deployments
+- File: `v2/supabase/migrations/20260322000001_fleet_aggregations.sql`
+- Cause: `get_fleet_machine_stats()` ends with `WHERE a.machine_id IS NOT
+  NULL`, so any washer without a paired Particle/named telemetry id falls off
+  the dashboard. That excludes every Palm Island and Maningrida unit and most
+  of the Dec-2025 Tennant Creek shipment.
+- Fix: new RPC `get_all_washing_deployments()` (returns every washing-machine
+  asset with a derived `connectivity_status` of
+  `reporting | lagging | silent | never_reported | no_telemetry_hw |
+  pending_assignment`). Migration:
+  `supabase/migrations/20260505000002_all_washing_deployments_rpc.sql`. New UI
+  component `DeploymentsByCommunity` shows per-community counts + drilldown.
+
+## Things that still need a human decision
+
+### 1. Triage the 3 ghost Particle coreids
+These were active for months but are not in `assets`. Until they're claimed,
+they're orphan signals.
+
+- `e00fce68c4b97878b9a2b323` — 296 events Aug 2025 → 2026-03-29. Last cycle
+  count 48 (heavy daily use). **Likely a real deployed machine somewhere.**
+- `e00fce68fe6c048ccec66ab1` — 279 events Sep 2025 → 2026-03-21. Mix of
+  cycles + heartbeats.
+- `e00fce689f1dd0daf5987cf2` — 28 events Sep 2025 only. Possibly a test or
+  swapped-out unit.
+
+Action: Ben to confirm what each coreid was. Once known, INSERT/UPDATE rows
+in `assets` so they land on the dashboard.
+
+### 2. Decide the silent-fleet response
+9 of 10 telemetry-enabled Tennant Creek machines have stopped reporting. The
+named-only ones (Barkley Arts, 8D1, Dian Stokes Sons House, Red Dust) only
+ever recorded a single `offline` event on 2026-03-01 — they may have never
+had real Particle hardware behind their human-readable `machine_id`. Triage
+order:
+1. **4E5** (last seen 14d ago) — most recently healthy, easiest to recover.
+2. **507** (36d ago).
+3. **098** (65d, only 3 events ever).
+4. Named-only machines — confirm whether hardware was ever installed.
+
+For each: check Particle Cloud console for last-seen + signal strength,
+verify Zapier zap is enabled, then site visit if no remote fix lands.
+
+### 3. Decide whether Palm Island / Maningrida should get telemetry
+Currently they don't, by choice or by gap. The wiki note in
+`wiki/articles/products/washing-machine.md` says telemetry is "useful for
+fleet learning, but it should not be overdescribed as a complete live fleet
+system yet" — i.e. selective, not universal. If a Palm Island laundry should
+report, hardware needs to be shipped + fitted + paired. Otherwise the
+dashboard's `no_telemetry_hw` badge is the correct steady state.
+
+### 4. Stale `machine_commentary` rows
+Every row in `machine_commentary` has `created_at = 2026-03-09T21:37:10.532872`
+— a one-shot batch run from March 9. The "5 days ago" / "3 days ago" /
+"Not reporting this week" notes the dashboard surfaces are *frozen as of
+March 9*, not live observations. They should be re-generated on a schedule
+(weekly cron) or removed if the operational-notes job has been retired.
+
+## What to do next (ordered by impact)
+
+1. **Apply the two new migrations** (`20260505000001`, `20260505000002`) and
+   merge the webhook + UI changes onto `main`. That unblocks accurate KPIs
+   and the comprehensive deployment view.
+2. **Cherry-pick or merge `cb78634`** so prod stops serving the broken-map
+   page.
+3. **Triage the 3 ghost coreids** with Ben's knowledge of the field.
+4. **Site-visit list** for the 9 silent telemetry machines.
+5. **Refresh `machine_commentary`** or kill the stale rows.
+6. **Decide telemetry strategy** for Palm Island / Maningrida.

--- a/v2/src/app/admin/fleet/fleet-map.tsx
+++ b/v2/src/app/admin/fleet/fleet-map.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { communityLocations } from '@/lib/data/content';
 import { MachineOverview } from '@/lib/types/database';
@@ -12,98 +11,108 @@ interface FleetMapProps {
 
 export function FleetMap({ machines }: FleetMapProps) {
   const mapRef = useRef<HTMLDivElement>(null);
-  const mapInstanceRef = useRef<L.Map | null>(null);
+  // Use any here because leaflet is loaded dynamically on the client only;
+  // importing the type at module top would re-introduce the SSR `window is not defined` crash.
+  const mapInstanceRef = useRef<any>(null);
 
   useEffect(() => {
     if (!mapRef.current || mapInstanceRef.current) return;
 
-    // Center on Central Australia
-    const map = L.map(mapRef.current, {
-      scrollWheelZoom: false,
-    }).setView([-21.5, 138.5], 5);
+    let cancelled = false;
+    let cleanup: (() => void) | null = null;
 
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
-      attribution: '&copy; OpenStreetMap contributors &copy; CARTO',
-    }).addTo(map);
+    (async () => {
+      const L = (await import('leaflet')).default;
+      if (cancelled || !mapRef.current) return;
 
-    // Group machines by community
-    const communityStats = new Map<string, { online: number; offline: number }>();
-    
-    machines.forEach((m) => {
-      // Normalise community name since some are "Palm Island" and others are generic places
-      const community = m.community ? m.community.trim() : null;
-      if (!community) return;
-      
-      const stats = communityStats.get(community) || { online: 0, offline: 0 };
-      if (m.online) stats.online++;
-      else stats.offline++;
-      communityStats.set(community, stats);
-    });
+      const map = L.map(mapRef.current, {
+        scrollWheelZoom: false,
+      }).setView([-21.5, 138.5], 5);
 
-    // We manually add some hardcoded aliases mapping locations if strict matches fail.
-    const getStats = (locName: string, locId: string) => {
-      return communityStats.get(locName) || communityStats.get(locId) || null;
-    };
+      L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+        attribution: '&copy; OpenStreetMap contributors &copy; CARTO',
+      }).addTo(map);
 
-    communityLocations.forEach((loc) => {
-      const stats = getStats(loc.name, loc.id);
-      if (!stats) return; // Only plot if there are machines in this location
+      const communityStats = new Map<string, { online: number; offline: number }>();
 
-      const total = stats.online + stats.offline;
-      const percentOnline = total > 0 ? (stats.online / total) * 100 : 0;
-      
-      let colorClass = 'bg-emerald-500';
-      if (percentOnline === 0) colorClass = 'bg-red-500';
-      else if (percentOnline < 100) colorClass = 'bg-amber-500';
+      machines.forEach((m) => {
+        const community = m.community ? m.community.trim() : null;
+        if (!community) return;
 
-      const icon = L.divIcon({
-        className: 'fleet-marker',
-        html: `
-          <div style="
-            width: 36px;
-            height: 36px;
-            border-radius: 50%;
-            border: 3px solid white;
-            box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: white;
-            font-weight: bold;
-            font-size: 14px;
-          " class="${colorClass}">${total}</div>
-        `,
-        iconSize: [36, 36],
-        iconAnchor: [18, 18],
+        const stats = communityStats.get(community) || { online: 0, offline: 0 };
+        if (m.online) stats.online++;
+        else stats.offline++;
+        communityStats.set(community, stats);
       });
 
-      const popup = L.popup({
-        maxWidth: 250,
-        className: 'fleet-popup',
-      }).setContent(`
-        <div style="font-family:system-ui,sans-serif; padding: 4px;">
-          <h3 style="margin:0 0 8px;font-size:16px;font-weight:600;">${loc.name}</h3>
-          <div style="display:flex; justify-content: space-between; margin-bottom: 4px; font-size: 13px;">
-            <span style="color:#059669; font-weight: 500;">● Online</span>
-            <strong>${stats.online}</strong>
-          </div>
-          <div style="display:flex; justify-content: space-between; font-size: 13px;">
-            <span style="color:#dc2626; font-weight: 500;">● Offline</span>
-            <strong>${stats.offline}</strong>
-          </div>
-        </div>
-      `);
+      const getStats = (locName: string, locId: string) => {
+        return communityStats.get(locName) || communityStats.get(locId) || null;
+      };
 
-      L.marker([loc.lat, loc.lng], { icon })
-        .addTo(map)
-        .bindPopup(popup);
-    });
+      communityLocations.forEach((loc) => {
+        const stats = getStats(loc.name, loc.id);
+        if (!stats) return;
 
-    mapInstanceRef.current = map;
+        const total = stats.online + stats.offline;
+        const percentOnline = total > 0 ? (stats.online / total) * 100 : 0;
+
+        let colorClass = 'bg-emerald-500';
+        if (percentOnline === 0) colorClass = 'bg-red-500';
+        else if (percentOnline < 100) colorClass = 'bg-amber-500';
+
+        const icon = L.divIcon({
+          className: 'fleet-marker',
+          html: `
+            <div style="
+              width: 36px;
+              height: 36px;
+              border-radius: 50%;
+              border: 3px solid white;
+              box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              color: white;
+              font-weight: bold;
+              font-size: 14px;
+            " class="${colorClass}">${total}</div>
+          `,
+          iconSize: [36, 36],
+          iconAnchor: [18, 18],
+        });
+
+        const popup = L.popup({
+          maxWidth: 250,
+          className: 'fleet-popup',
+        }).setContent(`
+          <div style="font-family:system-ui,sans-serif; padding: 4px;">
+            <h3 style="margin:0 0 8px;font-size:16px;font-weight:600;">${loc.name}</h3>
+            <div style="display:flex; justify-content: space-between; margin-bottom: 4px; font-size: 13px;">
+              <span style="color:#059669; font-weight: 500;">● Online</span>
+              <strong>${stats.online}</strong>
+            </div>
+            <div style="display:flex; justify-content: space-between; font-size: 13px;">
+              <span style="color:#dc2626; font-weight: 500;">● Offline</span>
+              <strong>${stats.offline}</strong>
+            </div>
+          </div>
+        `);
+
+        L.marker([loc.lat, loc.lng], { icon })
+          .addTo(map)
+          .bindPopup(popup);
+      });
+
+      mapInstanceRef.current = map;
+      cleanup = () => {
+        map.remove();
+        mapInstanceRef.current = null;
+      };
+    })();
 
     return () => {
-      map.remove();
-      mapInstanceRef.current = null;
+      cancelled = true;
+      if (cleanup) cleanup();
     };
   }, [machines]);
 

--- a/v2/src/app/admin/fleet/page.tsx
+++ b/v2/src/app/admin/fleet/page.tsx
@@ -8,6 +8,10 @@ import { MachineListTable } from '@/components/fleet/machine-list-table';
 import { AlertsList } from '@/components/fleet/alerts-list';
 import { FleetDailyChart } from '@/components/fleet/fleet-daily-chart';
 import { FleetRecommendations } from '@/components/fleet/fleet-recommendations';
+import {
+  DeploymentsByCommunity,
+  type WashingDeployment,
+} from '@/components/fleet/deployments-by-community';
 import { FleetMap } from './fleet-map';
 import type { Alert, MachineOverview } from '@/lib/types/database';
 
@@ -85,6 +89,11 @@ export default async function FleetDashboardPage() {
 
   // Get aggregated machine stats from the database instead of manually mapping
   const { data: statsData } = await supabase.rpc('get_fleet_machine_stats');
+
+  // All washing deployments (Tennant Creek + Palm Island + Maningrida + ...).
+  // Falls back silently if the RPC hasn't been migrated yet.
+  const { data: deploymentRows } = await supabase.rpc('get_all_washing_deployments');
+  const deployments: WashingDeployment[] = (deploymentRows || []) as WashingDeployment[];
   
   const machines: MachineOverview[] = (statsData || []).map((row: any) => ({
     machine_id: row.machine_id,
@@ -131,8 +140,16 @@ export default async function FleetDashboardPage() {
         <div>
           <h1 className="text-2xl font-bold">Fleet Dashboard</h1>
           <p className="text-gray-500 mt-1">
-            Pakkimjalki Kari washing machine fleet — {machines.length} machines across{' '}
+            Pakkimjalki Kari telemetry — {machines.length} connected machines across{' '}
             {new Set(machines.map((m) => m.community).filter(Boolean)).size} communities
+            {deployments.length > machines.length && (
+              <>
+                {' '}·{' '}
+                <span className="text-gray-700">
+                  {deployments.length} total deployments tracked (incl. units without telemetry hardware)
+                </span>
+              </>
+            )}
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -230,11 +247,14 @@ export default async function FleetDashboardPage() {
         )}
       </div>
 
-      {/* Machine List */}
+      {/* All deployments (telemetry + non-telemetry) by community */}
+      {deployments.length > 0 && <DeploymentsByCommunity deployments={deployments} />}
+
+      {/* Machine List — telemetry-enabled subset */}
       <Card>
         <CardHeader>
           <div className="flex items-center justify-between">
-            <CardTitle>Machines</CardTitle>
+            <CardTitle>Telemetry-enabled Machines</CardTitle>
             <p className="text-sm text-gray-500">
               Sorted by alerts, then online status
             </p>

--- a/v2/src/app/api/webhooks/particle/route.ts
+++ b/v2/src/app/api/webhooks/particle/route.ts
@@ -42,6 +42,7 @@ interface WashEventData {
 function mapEventType(event: string): string {
   switch (event) {
     case 'wash_event':
+    case 'zapier-new-wash':
       return 'cycle_complete';
     case 'heartbeat':
     case 'spark/status':

--- a/v2/src/components/fleet/deployments-by-community.tsx
+++ b/v2/src/components/fleet/deployments-by-community.tsx
@@ -1,0 +1,219 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+export interface WashingDeployment {
+  unique_id: string;
+  name: string | null;
+  community: string | null;
+  place: string | null;
+  contact_household: string | null;
+  product: string | null;
+  supply_date: string | null;
+  last_checkin_date: string | null;
+  asset_status: string | null;
+  machine_id: string | null;
+  has_telemetry_hw: boolean;
+  last_seen_at: string | null;
+  cycles_7d: number;
+  kwh_7d: number;
+  connectivity_status:
+    | 'reporting'
+    | 'lagging'
+    | 'silent'
+    | 'never_reported'
+    | 'no_telemetry_hw'
+    | 'pending_assignment';
+}
+
+const STATUS_LABEL: Record<WashingDeployment['connectivity_status'], string> = {
+  reporting: 'Reporting',
+  lagging: 'Lagging',
+  silent: 'Silent',
+  never_reported: 'Never reported',
+  no_telemetry_hw: 'No telemetry HW',
+  pending_assignment: 'Pending assignment',
+};
+
+const STATUS_COLOUR: Record<WashingDeployment['connectivity_status'], string> = {
+  reporting: 'bg-emerald-100 text-emerald-800',
+  lagging: 'bg-amber-100 text-amber-800',
+  silent: 'bg-red-100 text-red-800',
+  never_reported: 'bg-rose-100 text-rose-800',
+  no_telemetry_hw: 'bg-slate-100 text-slate-700',
+  pending_assignment: 'bg-blue-50 text-blue-800',
+};
+
+function daysAgo(iso: string | null) {
+  if (!iso) return null;
+  const ms = Date.now() - new Date(iso).getTime();
+  return Math.max(0, Math.floor(ms / (1000 * 60 * 60 * 24)));
+}
+
+export function DeploymentsByCommunity({
+  deployments,
+}: {
+  deployments: WashingDeployment[];
+}) {
+  if (!deployments || deployments.length === 0) return null;
+
+  const grouped = new Map<string, WashingDeployment[]>();
+  for (const d of deployments) {
+    const key = d.community || 'Unknown';
+    const arr = grouped.get(key) || [];
+    arr.push(d);
+    grouped.set(key, arr);
+  }
+
+  const summary = Array.from(grouped.entries())
+    .map(([community, items]) => {
+      const counts = items.reduce(
+        (acc, d) => {
+          acc.total += 1;
+          acc[d.connectivity_status] = (acc[d.connectivity_status] || 0) + 1;
+          return acc;
+        },
+        { total: 0 } as Record<string, number>
+      );
+      return { community, items, counts };
+    })
+    .sort((a, b) => b.counts.total - a.counts.total);
+
+  const totals = deployments.reduce(
+    (acc, d) => {
+      acc.total += 1;
+      acc[d.connectivity_status] = (acc[d.connectivity_status] || 0) + 1;
+      return acc;
+    },
+    { total: 0 } as Record<string, number>
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle>All Washing Machine Deployments</CardTitle>
+          <p className="text-sm text-gray-500">
+            {totals.total} machines across {grouped.size} communities ·{' '}
+            <span className="text-emerald-700">{totals.reporting || 0} reporting</span> ·{' '}
+            <span className="text-red-700">{totals.silent || 0} silent</span> ·{' '}
+            <span className="text-slate-700">{totals.no_telemetry_hw || 0} no-telemetry</span>
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="text-xs uppercase text-gray-500 border-b">
+              <tr>
+                <th className="text-left py-2 pr-4">Community</th>
+                <th className="text-right px-2">Total</th>
+                <th className="text-right px-2">Reporting</th>
+                <th className="text-right px-2">Lagging</th>
+                <th className="text-right px-2">Silent</th>
+                <th className="text-right px-2">No HW</th>
+                <th className="text-right px-2">Pending</th>
+                <th className="text-right pl-2">Coverage</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summary.map(({ community, counts }) => {
+                const withHw =
+                  counts.total - (counts.no_telemetry_hw || 0) - (counts.pending_assignment || 0);
+                const coverage =
+                  withHw === 0 ? 0 : Math.round(((counts.reporting || 0) / withHw) * 100);
+                return (
+                  <tr key={community} className="border-b last:border-0">
+                    <td className="py-2 pr-4 font-medium">{community}</td>
+                    <td className="text-right px-2">{counts.total}</td>
+                    <td className="text-right px-2 text-emerald-700">{counts.reporting || 0}</td>
+                    <td className="text-right px-2 text-amber-700">{counts.lagging || 0}</td>
+                    <td className="text-right px-2 text-red-700">
+                      {(counts.silent || 0) + (counts.never_reported || 0)}
+                    </td>
+                    <td className="text-right px-2 text-slate-700">
+                      {counts.no_telemetry_hw || 0}
+                    </td>
+                    <td className="text-right px-2 text-blue-700">
+                      {counts.pending_assignment || 0}
+                    </td>
+                    <td className="text-right pl-2">
+                      {withHw === 0 ? (
+                        <span className="text-gray-400">no HW</span>
+                      ) : (
+                        <span
+                          className={
+                            coverage >= 80
+                              ? 'text-emerald-700 font-medium'
+                              : coverage >= 30
+                              ? 'text-amber-700 font-medium'
+                              : 'text-red-700 font-medium'
+                          }
+                        >
+                          {coverage}%
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        {summary.map(({ community, items }) => (
+          <details key={community} className="border rounded-lg" open={summary.length <= 3}>
+            <summary className="px-4 py-3 font-medium cursor-pointer flex items-center justify-between">
+              <span>
+                {community}{' '}
+                <span className="text-sm text-gray-500 font-normal">({items.length})</span>
+              </span>
+            </summary>
+            <div className="overflow-x-auto border-t">
+              <table className="w-full text-sm">
+                <thead className="text-xs uppercase text-gray-500">
+                  <tr>
+                    <th className="text-left py-2 px-4">Asset</th>
+                    <th className="text-left px-2">Household / Site</th>
+                    <th className="text-left px-2">Status</th>
+                    <th className="text-right px-2">Last seen</th>
+                    <th className="text-right px-2">7d cycles</th>
+                    <th className="text-right pr-4">Supplied</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {items.map((d) => {
+                    const last = daysAgo(d.last_seen_at);
+                    const supplied = daysAgo(d.supply_date);
+                    return (
+                      <tr key={d.unique_id} className="border-t">
+                        <td className="py-2 px-4">
+                          <div className="font-medium">{d.name || d.unique_id}</div>
+                          <div className="text-xs text-gray-400">{d.unique_id}</div>
+                        </td>
+                        <td className="px-2 text-gray-600">{d.contact_household || '—'}</td>
+                        <td className="px-2">
+                          <Badge className={STATUS_COLOUR[d.connectivity_status]}>
+                            {STATUS_LABEL[d.connectivity_status]}
+                          </Badge>
+                        </td>
+                        <td className="text-right px-2 text-gray-600">
+                          {last === null ? '—' : `${last}d ago`}
+                        </td>
+                        <td className="text-right px-2 text-gray-600">
+                          {d.has_telemetry_hw ? d.cycles_7d : '—'}
+                        </td>
+                        <td className="text-right pr-4 text-gray-500">
+                          {supplied === null ? '—' : `${supplied}d ago`}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </details>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/v2/supabase/migrations/20260505000001_fleet_event_type_normalisation.sql
+++ b/v2/supabase/migrations/20260505000001_fleet_event_type_normalisation.sql
@@ -1,0 +1,21 @@
+-- Fleet telemetry: normalise event_type drift caused by Zapier integration
+--
+-- Problem: the Zapier path POSTs Particle wash events with event="zapier-new-wash".
+-- The webhook handler stored that string verbatim instead of mapping it to
+-- "cycle_complete", so 212 historical rows + the daily rollup + the KPI RPC all
+-- under-counted real washes. Result: /admin/fleet showed 0 cycles even when
+-- machines were active.
+--
+-- This migration:
+--   1) Renames historical event_type='zapier-new-wash' rows to 'cycle_complete'.
+--   2) Refreshes the daily_machine_rollups materialized view.
+--
+-- The webhook handler (v2/src/app/api/webhooks/particle/route.ts) is updated in
+-- the same change-set to map the event on insert going forward, so this
+-- migration only needs to run once.
+
+UPDATE usage_logs
+SET event_type = 'cycle_complete'
+WHERE event_type = 'zapier-new-wash';
+
+REFRESH MATERIALIZED VIEW CONCURRENTLY daily_machine_rollups;

--- a/v2/supabase/migrations/20260505000002_all_washing_deployments_rpc.sql
+++ b/v2/supabase/migrations/20260505000002_all_washing_deployments_rpc.sql
@@ -1,0 +1,83 @@
+-- Fleet visibility: surface all deployed washing machines, not just telemetry-enabled ones
+--
+-- get_fleet_machine_stats() filters on `assets.machine_id IS NOT NULL`, so the
+-- /admin/fleet dashboard has only ever shown the 10 Tennant Creek machines that
+-- were paired with a Particle/named telemetry id. The other ~28 deployed
+-- machines (Palm Island, Maningrida, plus several Tennant Creek units that
+-- never got hardware) are invisible.
+--
+-- This RPC returns every washing machine asset with a derived
+-- connectivity_status so the UI can group by community and show the gap.
+
+CREATE OR REPLACE FUNCTION get_all_washing_deployments()
+RETURNS TABLE (
+  unique_id TEXT,
+  name TEXT,
+  community TEXT,
+  place TEXT,
+  contact_household TEXT,
+  product TEXT,
+  supply_date TIMESTAMPTZ,
+  last_checkin_date TIMESTAMPTZ,
+  asset_status TEXT,
+  machine_id TEXT,
+  has_telemetry_hw BOOLEAN,
+  last_seen_at TIMESTAMPTZ,
+  cycles_7d BIGINT,
+  kwh_7d DOUBLE PRECISION,
+  connectivity_status TEXT
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH telemetry AS (
+    SELECT
+      u.machine_id,
+      MAX(u.created_at) AS last_seen_at,
+      COUNT(*) FILTER (WHERE u.event_type = 'cycle_complete'
+                         AND u.created_at >= now() - INTERVAL '7 days') AS cycles_7d,
+      COALESCE(SUM(u.power_kwh) FILTER (WHERE u.event_type = 'cycle_complete'
+                                          AND u.created_at >= now() - INTERVAL '7 days'), 0) AS kwh_7d
+    FROM usage_logs u
+    WHERE u.machine_id IS NOT NULL
+    GROUP BY u.machine_id
+  )
+  SELECT
+    a.unique_id,
+    a.name,
+    COALESCE(a.community, a.place) AS community,
+    a.place,
+    a.contact_household,
+    a.product,
+    a.supply_date,
+    a.last_checkin_date,
+    a.status AS asset_status,
+    a.machine_id,
+    (a.machine_id IS NOT NULL) AS has_telemetry_hw,
+    t.last_seen_at,
+    COALESCE(t.cycles_7d, 0)::BIGINT AS cycles_7d,
+    COALESCE(t.kwh_7d, 0)::DOUBLE PRECISION AS kwh_7d,
+    CASE
+      WHEN a.machine_id IS NULL AND a.name ILIKE '%pending%'
+        THEN 'pending_assignment'
+      WHEN a.machine_id IS NULL
+        THEN 'no_telemetry_hw'
+      WHEN t.last_seen_at IS NULL
+        THEN 'never_reported'
+      WHEN t.last_seen_at >= now() - INTERVAL '24 hours'
+        THEN 'reporting'
+      WHEN t.last_seen_at >= now() - INTERVAL '7 days'
+        THEN 'lagging'
+      ELSE 'silent'
+    END AS connectivity_status
+  FROM assets a
+  LEFT JOIN telemetry t ON a.machine_id = t.machine_id
+  WHERE a.product ILIKE '%washing machine%'
+     OR a.product ILIKE '%pakkimjalki%'
+  ORDER BY
+    COALESCE(a.community, a.place) NULLS LAST,
+    a.supply_date DESC NULLS LAST,
+    a.unique_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_all_washing_deployments() TO anon, authenticated, service_role;


### PR DESCRIPTION
## Summary

- Restores `/admin/fleet` after a latent leaflet SSR crash blanked the top half of the page (header, KPI cards, Fleet Map, Activity chart). Defers `leaflet` import inside `useEffect` so it only runs in the browser.
- Fixes event-type drift: Zapier was POSTing wash events as `zapier-new-wash`, the webhook stored them verbatim, and KPI/stats RPCs + `daily_machine_rollups` only counted `cycle_complete`. Result: F25's washes (and 211 others) read as 0. Webhook now normalises on insert; migration `20260505000001` backfills history + refreshes the rollup view.
- Surfaces all 38 deployed washing machines (Tennant Creek 22 + Palm Island 10 + Maningrida 6) instead of only the 10 with telemetry hardware. New RPC `get_all_washing_deployments` + `DeploymentsByCommunity` component show per-community coverage with derived `connectivity_status` (reporting/lagging/silent/never_reported/no_telemetry_hw/pending_assignment).
- Adds `v2/docs/fleet-connectivity-audit-may-2026.md` capturing per-machine signal history, three "ghost" Particle coreids that need triage, and the open decisions.

## State after migration apply (already run on v2 Supabase)

- `get_fleet_kpis`: 25 cycles / 50.3 kWh in last 7 days (was 0/0 due to event-type drift)
- `get_all_washing_deployments`: 38 rows — 1 reporting (F25), 9 silent, 9 pending assignment, 19 no-telemetry-hw

## Test plan

- [x] Local: `/admin/fleet` returns 200 with full layout (verified via Playwright)
- [x] `npx tsc --noEmit` clean for fleet files
- [x] Migrations applied to `cwsyhpiuepvdjtxaozwf` and verified
- [ ] Prod: confirm `/admin/fleet` renders end-to-end after Vercel deploys