### PR TITLE
feat(admin/fleet): pipeline health + silence timeline + per-machine investigation cards

### DIFF
--- a/tools/particle-cloud-check.sh
+++ b/tools/particle-cloud-check.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Compare each registered Particle coreid's Particle Cloud "last seen" with our
+# usage_logs "last_seen_at". Splits "device problem" from "pipeline problem"
+# without needing a site visit.
+#
+# Usage:
+#   PARTICLE_ACCESS_TOKEN=your-token ./tools/particle-cloud-check.sh
+#
+# Get a token from https://console.particle.io → user icon → Settings →
+# Access Tokens. A 30-day token is fine. Paste here, do not commit.
+
+set -euo pipefail
+
+if [[ -z "${PARTICLE_ACCESS_TOKEN:-}" ]]; then
+  echo "ERROR: PARTICLE_ACCESS_TOKEN not set."
+  echo "Get a token from console.particle.io and run:"
+  echo "  PARTICLE_ACCESS_TOKEN=xxx $0"
+  exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$REPO_ROOT/v2/.env.local"
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: $ENV_FILE not found."
+  exit 1
+fi
+
+SUPA_URL="https://cwsyhpiuepvdjtxaozwf.supabase.co"
+SUPA_KEY=$(grep '^SUPABASE_SERVICE_ROLE_KEY=' "$ENV_FILE" | cut -d'"' -f2)
+
+echo "1) Listing devices visible to your Particle account..."
+particle_devices=$(curl -fsS "https://api.particle.io/v1/devices" \
+  -H "Authorization: Bearer $PARTICLE_ACCESS_TOKEN")
+
+echo "$particle_devices" | python3 -c "
+import json, sys, urllib.request, os
+from datetime import datetime, timezone
+
+devices = json.load(sys.stdin)
+print(f'   Particle account sees {len(devices)} devices.')
+print()
+
+# Pull our local last-seen for every coreid via the deployments RPC
+key = os.environ['SUPA_KEY']
+req = urllib.request.Request(
+    'https://cwsyhpiuepvdjtxaozwf.supabase.co/rest/v1/rpc/get_all_washing_deployments',
+    data=b'{}',
+    headers={'apikey': key, 'Authorization': f'Bearer {key}', 'Content-Type': 'application/json'},
+    method='POST',
+)
+deployments = json.load(urllib.request.urlopen(req))
+local_by_id = {d['machine_id']: d for d in deployments if d['machine_id']}
+
+print('2) Comparing Particle Cloud last-seen vs our usage_logs last-seen:')
+print()
+print(f'{'coreid':<32} {'particle_last_seen':<22} {'our_last_seen':<22} {'verdict'}')
+print('-' * 110)
+
+now = datetime.now(timezone.utc)
+def parse(s):
+    if not s: return None
+    return datetime.fromisoformat(s.replace('Z','+00:00'))
+
+for d in devices:
+    coreid = d.get('id')
+    pcloud = d.get('last_heard') or d.get('last_handshake_at')
+    pdt = parse(pcloud)
+    local = local_by_id.get(coreid)
+    odt = parse(local.get('last_seen_at')) if local else None
+
+    if pdt and odt:
+        gap_days = (pdt - odt).days
+        if abs(gap_days) <= 1:
+            verdict = 'AGREES — both recent or both old'
+        elif pdt > odt:
+            days_diff = (pdt - odt).days
+            verdict = f'PIPELINE BREAK — Particle saw it {days_diff}d after our DB stopped'
+        else:
+            verdict = 'WEIRD — our DB has newer than Particle?'
+    elif pdt and not odt:
+        verdict = 'NEW DEVICE — Particle has it, our DB does not'
+    elif not pdt and odt:
+        verdict = 'PARTICLE FORGOT — our DB has it, Particle does not'
+    else:
+        verdict = 'BOTH BLANK — never seen'
+
+    p_str = pdt.strftime('%Y-%m-%d %H:%M') if pdt else '—'
+    o_str = odt.strftime('%Y-%m-%d %H:%M') if odt else '—'
+    print(f'{coreid:<32} {p_str:<22} {o_str:<22} {verdict}')
+
+# Also flag local devices Particle does not know about
+print()
+print('3) Local DB has these coreids but Particle account does NOT:')
+particle_ids = {d.get('id') for d in devices}
+orphans = [m for m in local_by_id if m and m.startswith('e00fce68') and m not in particle_ids]
+if not orphans:
+    print('   (none — all our coreids are visible to your Particle account)')
+else:
+    for o in orphans:
+        ls = local_by_id[o].get('last_seen_at') or '—'
+        print(f'   {o}  last_seen={ls}')
+        print(f'     → these were either deleted from Particle, registered to a different Particle account, or never claimed.')
+" SUPA_KEY="$SUPA_KEY"
+
+echo
+echo "Done. Read the verdict column:"
+echo "  AGREES → device-side fix needed (power, SIM, site visit)"
+echo "  PIPELINE BREAK → device alive in Particle but not landing in DB; check Zapier task history + Vercel webhook logs"
+echo "  PARTICLE FORGOT → device deleted from Particle account or token doesn't see it"
+echo "  ORPHANS LIST → consider claiming under your Particle account"

--- a/v2/docs/fleet-alignment-may-2026.md
+++ b/v2/docs/fleet-alignment-may-2026.md
@@ -1,0 +1,138 @@
+# Fleet Alignment — Assets vs Telemetry, May 2026
+
+Pulled 2026-05-05 to answer: which deployed washing machines are connected, which are dark, which signals are flying around without a registered home, and what to do about each gap.
+
+## Headline gaps
+
+| Direction | Count | Meaning |
+|---|---:|---|
+| Asset → telemetry | 10 | Asset has a `machine_id` and we have events for it |
+| Asset → no telemetry | 0 | Asset has a `machine_id` but zero events ever (likely placeholder name, no real device) |
+| Asset has no `machine_id` | 28 | No telemetry hardware fitted, never has been |
+| Orphan coreid | 3 | Telemetry rolls in for a coreid not registered in `assets` |
+
+## Every washing-machine asset, telemetry status
+
+| Asset | Community | Name / Household | machine_id | Events | Last seen | Status |
+|---|---|---|---|---:|---|---|
+| `GB0-150-1` | Maningrida | Maningrida Laundry | `—` | 0 | — | no telemetry HW |
+| `GB0-150-2` | Maningrida | Maningrida Laundry | `—` | 0 | — | no telemetry HW |
+| `GB0-150-3` | Maningrida | Maningrida Laundry | `—` | 0 | — | no telemetry HW |
+| `GB0-150-4` | Maningrida | Maningrida Laundry | `—` | 0 | — | no telemetry HW |
+| `GB0-150-5` | Maningrida | Maningrida Laundry | `—` | 0 | — | no telemetry HW |
+| `GB0-150-6` | Maningrida | Maningrida Laundry | `—` | 0 | — | no telemetry HW |
+| `GB0-135` | Palm Island | Rangers Station | `—` | 0 | — | no telemetry HW |
+| `GB0-143-1` | Palm Island | Additional Washers | `—` | 0 | — | no telemetry HW |
+| `GB0-143-2` | Palm Island | Additional Washers | `—` | 0 | — | no telemetry HW |
+| `GB0-136-1` | Palm Island | Oochiumpa | `—` | 0 | — | no telemetry HW |
+| `GB0-136-2` | Palm Island | Oochiumpa | `—` | 0 | — | no telemetry HW |
+| `GB0-136-3` | Palm Island | Oochiumpa | `—` | 0 | — | no telemetry HW |
+| `GB0-137` | Palm Island | Workers House | `—` | 0 | — | no telemetry HW |
+| `GB0-138` | Palm Island | Luella Bligh | `—` | 0 | — | no telemetry HW |
+| `GB0-139` | Palm Island | Ebs Aunty | `—` | 0 | — | no telemetry HW |
+| `GB0-147` | Palm Island | Club Kuta machine / Mislam | `—` | 0 | — | no telemetry HW |
+| `GB0-WM-098` | Tennant Creek | 098 | `e00fce682db6d32e15e86098` | 3 | 2026-03-01 | named placeholder (only offline batch event) |
+| `GB0-WM-4E5` | Tennant Creek | 4E5 | `e00fce687ae01d08f95694e5` | 342 | 2026-04-21 | silent 13d |
+| `GB0-WM-507` | Tennant Creek | 507 | `e00fce68c2ba447b66bcd507` | 30 | 2026-03-30 | silent 35d |
+| `GB0-WM-8D1` | Tennant Creek | 8D1 | `8D1` | 1 | 2026-03-01 | named placeholder (only offline batch event) |
+| `GB0-WM-DSS` | Tennant Creek | Dian Stokes Sons House | `Dian Stokes Sons House` | 1 | 2026-03-01 | named placeholder (only offline batch event) |
+| `GB0-WM-F25` | Tennant Creek | F25 | `e00fce684086eb2aba8d4f25` | 468 | 2026-05-05 | **reporting** |
+| `GB0-WM-PARTICLE-01` | Tennant Creek | Particle Test Device (Stephen) | `—` | 0 | — | no telemetry HW |
+| `GB0-WM-RD` | Tennant Creek | Red Dust | `Red Dust` | 1 | 2026-03-01 | named placeholder (only offline batch event) |
+| `GB0-113` | Tennant Creek | Norman | `Norms House` | 23 | 2026-03-09 | silent 56d |
+| `GB0-125` | Tennant Creek | Barkley Arts | `Barkley Arts` | 1 | 2026-03-01 | named placeholder (only offline batch event) |
+| `GB0-132` | Tennant Creek | Jimmy - Washer | `—` | 0 | — | no telemetry HW |
+| `GB0-133` | Tennant Creek | Jimmy’s Uncle - Washer | `—` | 0 | — | no telemetry HW |
+| `GB0-154-1` | Tennant Creek | Pending Assignment | `—` | 0 | — | no telemetry HW |
+| `GB0-154-10` | Tennant Creek | Pending Assignment | `—` | 0 | — | no telemetry HW |
+| `GB0-154-3` | Tennant Creek | Pending Assignment | `—` | 0 | — | no telemetry HW |
+| `GB0-154-4` | Tennant Creek | Pending Assignment | `—` | 0 | — | no telemetry HW |
+| `GB0-154-5` | Tennant Creek | Pending Assignment | `—` | 0 | — | no telemetry HW |
+| `GB0-154-6` | Tennant Creek | Pending Assignment | `—` | 0 | — | no telemetry HW |
+| `GB0-154-7` | Tennant Creek | Pending Assignment | `—` | 0 | — | no telemetry HW |
+| `GB0-154-8` | Tennant Creek | Pending Assignment | `—` | 0 | — | no telemetry HW |
+| `GB0-154-9` | Tennant Creek | Pending Assignment | `—` | 0 | — | no telemetry HW |
+| `GB0-154-2` | Tennant Creek | Nicole Frank | `Nicoles House` | 5 | 2026-03-09 | silent 56d |
+
+## Orphan coreids (telemetry without an asset)
+
+These devices were physically installed somewhere and used heavily for months, but `assets` has no row for them. Until we identify them, their wash counts are not credited to any community on the dashboard.
+
+| Coreid | First seen | Last seen | Events | Peak cycle counter | Plausible site |
+|---|---|---|---:|---:|---|
+| `e00fce68c4b97878b9a2b323` | 2025-08-27 | 2026-03-29 | 550 | 48 | Palm Island — most likely Rangers Station or Aug 5 / Aug 12 wave (timing fits, 7 months of heavy use) |
+| `e00fce68fe6c048ccec66ab1` | 2025-09-15 | 2026-03-21 | 397 | — | Palm Island — Aug 12 wave (Oochiumpa / Workers House / Luella Bligh / Ebs Aunty), commissioned 5 weeks after install |
+| `e00fce689f1dd0daf5987cf2` | 2025-09-15 | 2025-09-30 | 38 | — | Palm Island — same Sep 15 commissioning batch as `fe6c…`, ran two weeks then died (faulty unit?) |
+
+## Palm Island deployment candidates (no telemetry mapped)
+
+| Asset | Name | Household | Supplied |
+|---|---|---|---|
+| `GB0-135` | Rangers Station | — | 2025-07-09 |
+| `GB0-143-2` | Additional Washers | — | 2025-08-05 |
+| `GB0-143-1` | Additional Washers | — | 2025-08-05 |
+| `GB0-136-1` | Oochiumpa | — | 2025-08-12 |
+| `GB0-136-2` | Oochiumpa | — | 2025-08-12 |
+| `GB0-136-3` | Oochiumpa | — | 2025-08-12 |
+| `GB0-137` | Workers House | — | 2025-08-12 |
+| `GB0-138` | Luella Bligh | — | 2025-08-12 |
+| `GB0-139` | Ebs Aunty | — | 2025-08-12 |
+| `GB0-147` | Club Kuta machine | Mislam | 2025-09-28 |
+
+## Proposed alignment fixes (require Ben sign-off)
+
+### A. Park the 3 orphan coreids in `assets` so their data is credited
+
+Conservative — creates *new* asset rows tagged `community='Palm Island'` (most likely) and `status='under_investigation'`. Once you identify the household, just `UPDATE assets SET name=..., contact_household=...` on each row.
+
+```sql
+INSERT INTO assets (unique_id, id, name, machine_id, community, place, product, status, notes)
+VALUES
+  ('GB0-WM-ORPHAN-c4b9', 'GB0-WM-ORPHAN-c4b9',
+   'Unknown Palm Island washer (550 events Aug 2025 - Mar 2026)',
+   'e00fce68c4b97878b9a2b323', 'Palm Island', 'Palm Island, QLD',
+   'Washing Machine', 'under_investigation',
+   'Telemetry orphan: first signal 2025-08-27, last 2026-03-29, peak cycle counter 48. Likely physical site is one of: Rangers Station / Additional Washers / Oochiumpa / Workers House / Luella Bligh / Ebs Aunty.'),
+  ('GB0-WM-ORPHAN-fe6c', 'GB0-WM-ORPHAN-fe6c',
+   'Unknown Palm Island washer (397 events Sep 2025 - Mar 2026)',
+   'e00fce68fe6c048ccec66ab1', 'Palm Island', 'Palm Island, QLD',
+   'Washing Machine', 'under_investigation',
+   'Telemetry orphan: first signal 2025-09-15, last 2026-03-21. Same commissioning batch as 689f.'),
+  ('GB0-WM-ORPHAN-689f', 'GB0-WM-ORPHAN-689f',
+   'Unknown Palm Island washer (38 events Sep 2025 only)',
+   'e00fce689f1dd0daf5987cf2', 'Palm Island', 'Palm Island, QLD',
+   'Washing Machine', 'under_investigation',
+   'Telemetry orphan: ran 2025-09-15 to 2025-09-30 only (38 events) then went permanently silent. Possible faulty unit, swap-out, or test bench.');
+```
+
+### B. Cross-check 507 — was it originally Palm Island Club Kuta?
+
+`e00fce68c2ba447b66bcd507` first reported on **2025-09-28**, the *same day* `GB0-147 Club Kuta machine / Mislam` was supplied. It is currently registered to `GB0-WM-507` in Tennant Creek. Either:
+
+1. This is coincidence (the supply date and the device's first wifi-handshake landed on the same day in different states), or
+2. 507 was installed at Club Kuta and later moved to Tennant Creek, or
+3. The asset register's date for Club Kuta is wrong.
+
+Action: **Ben to confirm** before any update. If 507 was genuinely Palm Island originally, we'd remap as:
+
+```sql
+-- ONLY IF 507 was actually Club Kuta:
+UPDATE assets
+  SET machine_id = 'e00fce68c2ba447b66bcd507',
+      notes = COALESCE(notes,'') || E'\n2025-09-28 → 2026-03-30 telemetry from coreid 507 (originally registered as GB0-WM-507 in TC).'
+  WHERE unique_id = 'GB0-147';
+UPDATE assets SET machine_id = NULL WHERE unique_id = 'GB0-WM-507';
+```
+
+### C. Decide on 'named placeholder' machine_ids
+
+Eight Tennant Creek assets have a human-readable `machine_id` (Norms House, Nicoles House, Barkley Arts, 8D1, Dian Stokes Sons House, Red Dust). They produced one or two `offline`/`heartbeat` rows from a March 2026 batch sweep — not real telemetry. Options:
+
+- **Leave as-is.** They count as 'silent machines' in current dashboards. Honest about the status.
+- **Null out the `machine_id`.** They drop off `get_fleet_machine_stats` and only appear in `get_all_washing_deployments` as `no_telemetry_hw`. Cleaner picture but loses the historical hint that someone *intended* to telemeter them.
+
+Recommendation: leave as-is for now; revisit when you decide whether those households are getting real Particle hardware.
+
+### D. Maningrida
+
+No coreid first-appearance landed in October 2025 when Maningrida was supplied, and no row in `usage_logs` has ever named a Maningrida site or asset. Conclusion: **no Particle device was ever fitted** to a Maningrida machine. If you remember one being commissioned, it never made it to the database — this is a hardware/process gap to chase, not a data fix.

--- a/v2/docs/fleet-machine-history-may-2026.md
+++ b/v2/docs/fleet-machine-history-may-2026.md
@@ -1,0 +1,338 @@
+# Machine-by-machine Telemetry History
+
+Pulled from `usage_logs` 2026-05-05. 1,861 events across 14 distinct `machine_id` values, spanning 2025-08-27 → 2026-05-05 (8 months 8 days).
+
+Each section below tells the life story of one device — when it first appeared, when it stopped, how busy it was, and any clues (firmware, asset linkage, peak cycle counter) that might help identify the physical machine.
+
+## Forensic timeline — first-appearance vs known deployments
+
+Signals never appeared in a community before that community received a shipment. Lining up first-seen dates with the asset-register supply dates gives strong hints about which physical machine each coreid was bolted to.
+
+| First-seen telemetry | Same-day / nearby deployment events | Plausible attribution |
+|---|---|---|
+| **2025-08-27** — `e00fce68c4b97878b9a2b323` | Palm Island Additional Washers (Aug 5) + Oochiumpa wave (Aug 12) already on-country | **Palm Island** — first device to come online, possibly Rangers Station or Workers House |
+| **2025-09-15** — `e00fce68fe6c048ccec66ab1`, `e00fce687ae01d08f95694e5` (4E5), `e00fce689f1dd0daf5987cf2` | 8-day window after Palm Island full deployment; 4E5 is currently registered to TC | Three devices coming up the same day suggests a coordinated install. **fe6c… and 689f… are likely Palm Island**; 4E5 was either also Palm originally or a TC unit installed in parallel |
+| **2025-09-19** — `e00fce682db6d32e15e86098` (098) | TC, currently registered `GB0-WM-098` | Tennant Creek (consistent with current registration) |
+| **2025-09-28** — `e00fce68c2ba447b66bcd507` (507) | **Same day as Palm Island Club Kuta deployment (GB0-147)** | Strong coincidence — 507 may have started life as Club Kuta and later been re-tagged to TC |
+| **2025-11-17** — `e00fce684086eb2aba8d4f25` (F25) | TC after Tennant 2025-12 wave was being prepped | Tennant Creek — the only one reliably reporting today |
+| **2026-03-01 (offline only)** — Barkley / 8D1 / Dian / Red Dust | Single 'offline' event each from a March 1 batch sweep | These are *named placeholders* — no real Particle device ever sat behind these `machine_id`s |
+| **2026-03-09** — Norms / Nicoles | Inferred restart batch | Likely March-9 commentary job, not actual telemetry from the unit |
+
+### What this suggests for "we had at least 4 in Palm Island"
+
+The 3 ghost coreids (`c4b9`, `fe6c`, `689f`) line up with Palm Island timing exactly. Possible 4th candidate: **507** — its first signal on 2025-09-28 is *literally the same day* Club Kuta (GB0-147) was supplied. If 507 was originally a Palm Island device, that gives **4 Palm Island machines with telemetry history**, matching your recollection.
+
+### What this suggests for Maningrida
+
+Maningrida's 6 washers were supplied 2025-10-20. **No new coreid first-appears in October** — so on this evidence, no Particle device was ever fitted in Maningrida. If you remember one, it might have been planned but not commissioned, or it could have come up briefly enough to not survive the early-data losses.
+
+### What this suggests for Tennant Creek
+
+F25 (Nov 17), 4E5 (Sep 15), 098 (Sep 19) all align with TC. Plus the named-only entries (Norms / Nicoles / Barkley / 8D1 / Dian / Red Dust) which only ever produced `offline` or `heartbeat` rows from batch jobs — those probably never had Particle hardware bolted in.
+
+---
+## `e00fce68c4b97878b9a2b323`
+
+- **Particle coreid** · 550 events over 213d span · last reported 36d ago
+- **Window:** 2025-08-27 23:32:21Z → 2026-03-29 11:36:45Z
+- **Event mix:** cycle_complete=550
+- **Firmware versions seen:** 2, 3, 6
+- **Linked asset:** *(none — orphan / not in `assets` table)*
+- **Peak cycle counter:** 48
+- **Monthly activity:**
+  - 2025-08:   19 events  ███████████████████
+  - 2025-09:   94 events  ████████████████████████████████████████████████████████████
+  - 2025-10:   59 events  ███████████████████████████████████████████████████████████
+  - 2025-11:   84 events  ████████████████████████████████████████████████████████████
+  - 2025-12:  100 events  ████████████████████████████████████████████████████████████
+  - 2026-01:   96 events  ████████████████████████████████████████████████████████████
+  - 2026-02:   44 events  ████████████████████████████████████████████
+  - 2026-03:   54 events  ██████████████████████████████████████████████████████
+- **First 5 events:**
+    - `2025-08-27 23:32:21Z`  cycle_complete  fw=2 · 0.27kWh
+    - `2025-08-28 00:02:21Z`  cycle_complete  fw=2 · 0.27kWh
+    - `2025-08-28 06:19:41Z`  cycle_complete  fw=2 · 0.27kWh
+    - `2025-08-28 06:49:41Z`  cycle_complete  fw=2 · 0.27kWh
+    - `2025-08-29 04:20:22Z`  cycle_complete  fw=2 · 0.27kWh
+- **Last 5 events:**
+    - `2026-03-27 07:14:54Z`  cycle_complete  fw=6 · cyc=44 · 14.95kWh
+    - `2026-03-28 07:01:44Z`  cycle_complete  fw=6 · cyc=45 · 15.74kWh
+    - `2026-03-29 05:04:05Z`  cycle_complete  fw=6 · cyc=46 · 16.48kWh
+    - `2026-03-29 09:42:25Z`  cycle_complete  fw=6 · cyc=47 · 16.79kWh
+    - `2026-03-29 11:36:45Z`  cycle_complete  fw=6 · cyc=48 · 17.03kWh
+
+---
+## `e00fce684086eb2aba8d4f25`
+
+- **Particle coreid** · 468 events over 168d span · last reported -1d ago
+- **Window:** 2025-11-17 04:24:00Z → 2026-05-05 00:59:04Z
+- **Event mix:** cycle_complete=466, heartbeat=2
+- **Firmware versions seen:** 3, 6, v6
+- **Linked asset(s):** GB0-WM-F25
+- **Peak cycle counter:** 32
+- **Monthly activity:**
+  - 2025-11:   33 events  █████████████████████████████████
+  - 2025-12:   99 events  ████████████████████████████████████████████████████████████
+  - 2026-01:  104 events  ████████████████████████████████████████████████████████████
+  - 2026-02:   50 events  ██████████████████████████████████████████████████
+  - 2026-03:   74 events  ████████████████████████████████████████████████████████████
+  - 2026-04:   93 events  ████████████████████████████████████████████████████████████
+  - 2026-05:   15 events  ███████████████
+- **First 5 events:**
+    - `2025-11-17 04:24:00Z`  cycle_complete  fw=3 · 0.185kWh
+    - `2025-11-17 12:19:00Z`  cycle_complete  fw=3 · 0.185kWh
+    - `2025-11-18 00:35:30Z`  cycle_complete  fw=3 · 0.185kWh
+    - `2025-11-18 01:51:40Z`  cycle_complete  fw=3 · 0.185kWh
+    - `2025-11-18 06:56:20Z`  cycle_complete  fw=3 · 0.185kWh
+- **Last 5 events:**
+    - `2026-05-03 10:08:04Z`  cycle_complete  fw=6 · cyc=4 · 0.73kWh · asset=GB0-WM-F25
+    - `2026-05-03 13:28:34Z`  cycle_complete  fw=6 · cyc=5 · 0.98kWh · asset=GB0-WM-F25
+    - `2026-05-04 03:43:24Z`  cycle_complete  fw=6 · cyc=6 · 1.48kWh · asset=GB0-WM-F25
+    - `2026-05-04 07:01:34Z`  cycle_complete  fw=6 · cyc=7 · 1.73kWh · asset=GB0-WM-F25
+    - `2026-05-05 00:59:04Z`  cycle_complete  fw=6 · cyc=8 · 2.33kWh · asset=GB0-WM-F25
+
+---
+## `e00fce68fe6c048ccec66ab1`
+
+- **Particle coreid** · 397 events over 187d span · last reported 44d ago
+- **Window:** 2025-09-15 00:26:43Z → 2026-03-21 08:52:09Z
+- **Event mix:** cycle_complete=396, heartbeat=1
+- **Firmware versions seen:** 3, 6
+- **Linked asset:** *(none — orphan / not in `assets` table)*
+- **Monthly activity:**
+  - 2025-09:   48 events  ████████████████████████████████████████████████
+  - 2025-10:  102 events  ████████████████████████████████████████████████████████████
+  - 2025-11:   53 events  █████████████████████████████████████████████████████
+  - 2025-12:   93 events  ████████████████████████████████████████████████████████████
+  - 2026-01:   63 events  ████████████████████████████████████████████████████████████
+  - 2026-02:   22 events  ██████████████████████
+  - 2026-03:   16 events  ████████████████
+- **First 5 events:**
+    - `2025-09-15 00:26:43Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-15 01:17:33Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-15 04:42:43Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-15 17:08:45Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-17 03:03:03Z`  cycle_complete  fw=3 · 0.27kWh
+- **Last 5 events:**
+    - `2026-03-10 09:24:34Z`  cycle_complete  fw=6 · 0.27kWh
+    - `2026-03-11 00:04:17Z`  cycle_complete  fw=6 · 0.27kWh
+    - `2026-03-11 13:05:54Z`  cycle_complete  fw=6 · 0.27kWh
+    - `2026-03-12 04:31:08Z`  cycle_complete  fw=6 · 0.27kWh
+    - `2026-03-21 08:52:09Z`  heartbeat  fw=6
+
+---
+## `e00fce687ae01d08f95694e5`
+
+- **Particle coreid** · 342 events over 217d span · last reported 13d ago
+- **Window:** 2025-09-15 09:53:09Z → 2026-04-21 05:48:14Z
+- **Event mix:** cycle_complete=340, heartbeat=2
+- **Firmware versions seen:** 3, 6, v6
+- **Linked asset(s):** GB0-WM-4E5
+- **Peak cycle counter:** 22
+- **Monthly activity:**
+  - 2025-09:   15 events  ███████████████
+  - 2025-10:   26 events  ██████████████████████████
+  - 2025-11:   72 events  ████████████████████████████████████████████████████████████
+  - 2025-12:   56 events  ████████████████████████████████████████████████████████
+  - 2026-01:   56 events  ████████████████████████████████████████████████████████
+  - 2026-02:   26 events  ██████████████████████████
+  - 2026-03:   47 events  ███████████████████████████████████████████████
+  - 2026-04:   44 events  ████████████████████████████████████████████
+- **First 5 events:**
+    - `2025-09-15 09:53:09Z`  cycle_complete  fw=3 · 0.388kWh · asset=GB0-WM-4E5
+    - `2025-09-16 13:47:59Z`  cycle_complete  fw=3 · 0.388kWh · asset=GB0-WM-4E5
+    - `2025-09-17 11:06:09Z`  cycle_complete  fw=3 · 0.388kWh · asset=GB0-WM-4E5
+    - `2025-09-17 22:59:49Z`  cycle_complete  fw=3 · 0.388kWh · asset=GB0-WM-4E5
+    - `2025-09-20 02:20:56Z`  cycle_complete  fw=3 · 0.388kWh · asset=GB0-WM-4E5
+- **Last 5 events:**
+    - `2026-04-18 07:05:24Z`  cycle_complete  fw=6 · cyc=5 · 1.39kWh · asset=GB0-WM-4E5
+    - `2026-04-19 00:38:22Z`  cycle_complete  fw=6 · cyc=1 · 0.01kWh · asset=GB0-WM-4E5
+    - `2026-04-19 08:16:26Z`  cycle_complete  fw=6 · cyc=1 · 0.08kWh · asset=GB0-WM-4E5
+    - `2026-04-20 11:22:21Z`  cycle_complete  fw=6 · cyc=1 · 0.31kWh · asset=GB0-WM-4E5
+    - `2026-04-21 05:48:14Z`  cycle_complete  fw=6 · cyc=1 · 0.13kWh · asset=GB0-WM-4E5
+
+---
+## `e00fce689f1dd0daf5987cf2`
+
+- **Particle coreid** · 38 events over 15d span · last reported 216d ago
+- **Window:** 2025-09-15 04:43:41Z → 2025-09-30 23:34:43Z
+- **Event mix:** cycle_complete=38
+- **Firmware versions seen:** 3
+- **Linked asset:** *(none — orphan / not in `assets` table)*
+- **Monthly activity:**
+  - 2025-09:   38 events  ██████████████████████████████████████
+- **First 5 events:**
+    - `2025-09-15 04:43:41Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-16 03:25:52Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-16 04:45:32Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-17 06:42:42Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-17 08:23:12Z`  cycle_complete  fw=3 · 0.27kWh
+- **Last 5 events:**
+    - `2025-09-28 07:52:14Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-29 08:50:25Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-30 01:20:50Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-30 12:51:23Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-30 23:34:43Z`  cycle_complete  fw=3 · 0.27kWh
+
+---
+## `e00fce68c2ba447b66bcd507`
+
+- **Particle coreid** · 30 events over 183d span · last reported 35d ago
+- **Window:** 2025-09-28 00:24:30Z → 2026-03-30 02:16:42Z
+- **Event mix:** cycle_complete=29, offline=1
+- **Firmware versions seen:** 3, 6
+- **Linked asset(s):** GB0-WM-507
+- **Peak cycle counter:** 4
+- **Monthly activity:**
+  - 2025-09:    6 events  ██████
+  - 2025-10:   13 events  █████████████
+  - 2025-11:    3 events  ███
+  - 2025-12:    2 events  ██
+  - 2026-03:    6 events  ██████
+- **First 5 events:**
+    - `2025-09-28 00:24:30Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-28 03:26:30Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-28 08:37:40Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-28 09:49:50Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-29 01:47:30Z`  cycle_complete  fw=3 · 0.27kWh
+- **Last 5 events:**
+    - `2026-03-27 00:15:01Z`  cycle_complete  fw=6 · cyc=1 · 0.51kWh · asset=GB0-WM-507
+    - `2026-03-27 01:34:16Z`  cycle_complete  fw=6 · cyc=2 · 0.15kWh · asset=GB0-WM-507
+    - `2026-03-27 02:24:31Z`  cycle_complete  fw=6 · cyc=2 · 0.17kWh · asset=GB0-WM-507
+    - `2026-03-30 01:36:42Z`  cycle_complete  fw=6 · cyc=3 · 1.75kWh · asset=GB0-WM-507
+    - `2026-03-30 02:16:42Z`  cycle_complete  fw=6 · cyc=4 · 1.94kWh · asset=GB0-WM-507
+
+---
+## `Norms House`
+
+- **named/identifier** · 23 events over 8d span · last reported 56d ago
+- **Window:** 2026-03-01 21:00:00Z → 2026-03-09 21:37:28Z
+- **Event mix:** cycle_complete=21, heartbeat=2
+- **Firmware versions seen:** v6
+- **Linked asset(s):** GB0-113
+- **Monthly activity:**
+  - 2026-03:   23 events  ███████████████████████
+- **First 5 events:**
+    - `2026-03-01 21:00:00Z`  cycle_complete  fw=v6 · 0.152kWh · asset=GB0-113
+    - `2026-03-01 22:07:00Z`  cycle_complete  fw=v6 · 0.152kWh · asset=GB0-113
+    - `2026-03-02 00:14:00Z`  cycle_complete  fw=v6 · 0.152kWh · asset=GB0-113
+    - `2026-03-02 01:21:00Z`  cycle_complete  fw=v6 · 0.152kWh · asset=GB0-113
+    - `2026-03-02 03:28:00Z`  cycle_complete  fw=v6 · 0.152kWh · asset=GB0-113
+- **Last 5 events:**
+    - `2026-03-06 03:21:00Z`  cycle_complete  fw=v6 · 0.245kWh · asset=GB0-113
+    - `2026-03-06 05:28:00Z`  cycle_complete  fw=v6 · 0.245kWh · asset=GB0-113
+    - `2026-03-06 07:35:00Z`  cycle_complete  fw=v6 · 0.245kWh · asset=GB0-113
+    - `2026-03-08 08:00:00Z`  heartbeat  fw=v6 · asset=GB0-113
+    - `2026-03-09 21:37:28Z`  heartbeat  fw=v6 · asset=GB0-113
+
+---
+## `Nicoles House`
+
+- **named/identifier** · 5 events over 8d span · last reported 56d ago
+- **Window:** 2026-03-01 21:00:00Z → 2026-03-09 21:37:28Z
+- **Event mix:** cycle_complete=3, heartbeat=2
+- **Firmware versions seen:** v6
+- **Linked asset(s):** GB0-154-2
+- **Monthly activity:**
+  - 2026-03:    5 events  █████
+- **First 5 events:**
+    - `2026-03-01 21:00:00Z`  cycle_complete  fw=v6 · 0.1kWh · asset=GB0-154-2
+    - `2026-03-02 03:07:00Z`  cycle_complete  fw=v6 · 0.1kWh · asset=GB0-154-2
+    - `2026-03-05 21:00:00Z`  cycle_complete  fw=v6 · 1.15kWh · asset=GB0-154-2
+    - `2026-03-08 08:00:00Z`  heartbeat  fw=v6 · asset=GB0-154-2
+    - `2026-03-09 21:37:28Z`  heartbeat  fw=v6 · asset=GB0-154-2
+
+---
+## `e00fce682db6d32e15e86098`
+
+- **Particle coreid** · 3 events over 163d span · last reported 64d ago
+- **Window:** 2025-09-19 03:19:34Z → 2026-03-01 14:00:00Z
+- **Event mix:** cycle_complete=2, offline=1
+- **Firmware versions seen:** 3
+- **Linked asset(s):** GB0-WM-098
+- **Monthly activity:**
+  - 2025-09:    2 events  ██
+  - 2026-03:    1 events  █
+- **First 5 events:**
+    - `2025-09-19 03:19:34Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2025-09-24 01:45:54Z`  cycle_complete  fw=3 · 0.27kWh
+    - `2026-03-01 14:00:00Z`  offline  asset=GB0-WM-098
+
+---
+## `Barkley Arts`
+
+- **named/identifier** · 1 events over 0d span · last reported 64d ago
+- **Window:** 2026-03-01 14:00:00Z → 2026-03-01 14:00:00Z
+- **Event mix:** offline=1
+- **Firmware versions seen:** v6
+- **Linked asset(s):** GB0-125
+- **Monthly activity:**
+  - 2026-03:    1 events  █
+- **First 5 events:**
+    - `2026-03-01 14:00:00Z`  offline  fw=v6 · asset=GB0-125
+
+---
+## `Red Dust`
+
+- **named/identifier** · 1 events over 0d span · last reported 64d ago
+- **Window:** 2026-03-01 14:00:00Z → 2026-03-01 14:00:00Z
+- **Event mix:** offline=1
+- **Linked asset(s):** GB0-WM-RD
+- **Monthly activity:**
+  - 2026-03:    1 events  █
+- **First 5 events:**
+    - `2026-03-01 14:00:00Z`  offline  asset=GB0-WM-RD
+
+---
+## `Dian Stokes Sons House`
+
+- **named/identifier** · 1 events over 0d span · last reported 64d ago
+- **Window:** 2026-03-01 14:00:00Z → 2026-03-01 14:00:00Z
+- **Event mix:** offline=1
+- **Linked asset(s):** GB0-WM-DSS
+- **Monthly activity:**
+  - 2026-03:    1 events  █
+- **First 5 events:**
+    - `2026-03-01 14:00:00Z`  offline  asset=GB0-WM-DSS
+
+---
+## `8D1`
+
+- **named/identifier** · 1 events over 0d span · last reported 64d ago
+- **Window:** 2026-03-01 14:00:00Z → 2026-03-01 14:00:00Z
+- **Event mix:** offline=1
+- **Linked asset(s):** GB0-WM-8D1
+- **Monthly activity:**
+  - 2026-03:    1 events  █
+- **First 5 events:**
+    - `2026-03-01 14:00:00Z`  offline  asset=GB0-WM-8D1
+
+---
+## `test123`
+
+- **TEST** · 1 events over 0d span · last reported 56d ago
+- **Window:** 2026-03-09 12:00:00Z → 2026-03-09 12:00:00Z
+- **Event mix:** test=1
+- **Monthly activity:**
+  - 2026-03:    1 events  █
+- **First 5 events:**
+    - `2026-03-09 12:00:00Z`  test  
+
+---
+
+## Cross-machine timeline (debugging deployment locations)
+
+```
+month     | F25  4E5  507  098  c4b9  fe6c  689f  8D1  Bark  Dian  RD  Norm  Nico
+----------|---------------------------------------------------------------
+2025-08  |                  19                                
+2025-09  |      15   6   2  94  48  38                        
+2025-10  |      26  13      59 102                            
+2025-11  |  33  72   3      84  53                            
+2025-12  |  99  56   2     100  93                            
+2026-01  | 104  56          96  63                            
+2026-02  |  50  26          44  22                            
+2026-03  |  74  47   6   1  54  16       1   1   1   1  23   5
+2026-04  |  93  44                                            
+2026-05  |  15                                                
+```

--- a/v2/docs/fleet-pipeline-history-may-2026.md
+++ b/v2/docs/fleet-pipeline-history-may-2026.md
@@ -1,0 +1,143 @@
+# Fleet Pipeline History — How Data Has Flowed Since Aug 2025
+
+Reconstructed 2026-05-05 from `usage_logs` event-id forensics, git history, and the webhook route source. Use this to work out where the break actually is.
+
+## Pipeline ledger (TL;DR)
+
+| Stage | Active | Path | First event |
+|---|---|---|---|
+| **A. Particle → Zapier → Google Sheets** | 2025-08 → today | Devices publish to Particle Cloud → a Zapier zap appends rows to the "Goods Washer" Google Sheet | 2025-08-27 |
+| **B. Sheet → `/api/admin/fleet/import-csv` (one-shot)** | 2026-03-11 | Exported the Sheet to CSV, POST-imported into `usage_logs`. Backfilled 938 historical events. | 2026-03-11 |
+| **C. Particle → Zapier → `/api/webhooks/particle`** | 2026-03-11 → today | The same Zapier zap was reconfigured (or a new one added) to POST every wash event directly to our Vercel endpoint as `event="zapier-new-wash"`. | 2026-03-11 |
+| **D. Openfields Solutions → `/api/webhooks/openfields`** | 2026-03-10 (configured, dormant) | HMAC-signed receiver for an Openfields telemetry partner. Only 3 events have ever landed via this path. | 2026-03 (only 3 events) |
+| **E. Hand-keyed seed data** | 2026-03-01 / 2026-03-09 | Ben (or admin) inserted ~30 seeded rows for households without real Particle hardware (Norm's, Nicole's, Barkley, 8D1, Dian Stokes, Red Dust). All have `event_id` prefix `seed_…`. | one-off |
+
+## The forensic evidence
+
+### `event_id` prefix distribution (1,861 rows)
+
+```
+938   particle-{hash32}     ← came through CSV import OR live webhook (both generate this prefix)
+ 32   seed_*                ← hand-keyed seed records, March 1–9
+  3   {uuid}                ← Openfields HMAC webhook
+  1   test                  ← test event
+```
+
+### Event-type composition by month
+
+```
+month      cycle_complete   heartbeat   offline   test
+2025-08         19              0          0       0    ← Stage A starts (Particle → Zap → Sheet)
+2025-09        203              0          0       0    ← steady-state via Sheet
+2025-10        200              0          0       0
+2025-11        245              0          0       0
+2025-12        350              0          0       0    ← peak month
+2026-01        319              0          0       0
+2026-02        142              0          0       0    ← cliff begins
+2026-03        215              9          6       1    ← Stage B (CSV import) + Stage E (seed) + Stage C live starts
+2026-04        137              0          0       0    ← only F25 + 4E5 still going
+2026-05         15              0          0       0    ← only F25 still going
+```
+
+The `heartbeat` and `offline` rows only appear in March because the seed-data writer set those types. **Real Particle telemetry has only ever produced `cycle_complete`** (well, plus the now-normalised `zapier-new-wash`). The fleet has never received real `heartbeat` events through the live path.
+
+### When each pipeline started
+
+The very first event in `usage_logs` is `2025-08-27T23:32:21` — long before our `usage_logs` schema or webhook routes existed. That row landed via Stage B (CSV import) on 2026-03-11. So the actual **physical machines have been running since at least August 2025, but their telemetry only entered our database in March 2026 when we backfilled the Google Sheet.**
+
+## What's actually running right now
+
+```
+        ┌───────────────────────────────────┐
+        │  Particle Photon (washing machine) │
+        └─────────────┬─────────────────────┘
+                      │ wash_event published
+                      ▼
+        ┌───────────────────────────────────┐
+        │   Particle Cloud (api.particle.io)│   ← shows device "last seen"; auth token + SIM-billed
+        └───────┬─────────────────┬─────────┘
+                │                 │
+                │  webhook trigger│  webhook trigger
+                ▼                 ▼
+   ┌────────────────┐    ┌────────────────────────────┐
+   │  Google Sheet   │   │  Zapier zap "Goods Washer" │
+   │  "Goods Washer"│    └────────────┬───────────────┘
+   │  (legacy)       │                │
+   └────────────────┘                 │ POST event="zapier-new-wash"
+                                      ▼
+                ┌──────────────────────────────────────────┐
+                │  POST /api/webhooks/particle              │
+                │   (Vercel · v2/src/app/api/webhooks/...)  │
+                │   maps zapier-new-wash → cycle_complete   │
+                └──────────────────┬───────────────────────┘
+                                   ▼
+                ┌──────────────────────────────────────────┐
+                │  Supabase: usage_logs (cwsyhpiuepvdjtxaozwf) │
+                └──────────────────┬───────────────────────┘
+                                   ▼
+                ┌──────────────────────────────────────────┐
+                │  /api/cron/fleet-rollup (every 6h)        │
+                │  → daily_machine_rollups + alerts          │
+                └──────────────────┬───────────────────────┘
+                                   ▼
+                            /admin/fleet
+```
+
+## Where the breakage almost certainly is
+
+We saw this silence cluster in late March / April:
+
+| Date | Coreid | Status |
+|---|---|---|
+| 2026-03-21 | `…fe6c…` | last event ever (orphan, likely Palm Island) |
+| 2026-03-29 | `…c4b9…` | last event ever (orphan, likely Palm Island) |
+| 2026-03-30 | `…c2ba447b66bcd507` (507) | last event ever |
+| 2026-04-21 | `…7ae01d08f95694e5` (4E5) | last event ever |
+| 2026-05-05 | `…4086eb2aba8d4f25` (F25) | **still alive** |
+
+The fact that **F25 still works through Stage C** while four other devices on the same Zapier zap stopped one-by-one, plus the staggered (not simultaneous) timestamps, **rules out Zapier-side and webhook-side failures** as the primary cause:
+
+- If the zap had been disabled, **all** devices including F25 would go silent at the same instant.
+- If the webhook URL had been rotated or returned 5xx, same thing — global, not staggered.
+- If the Particle Integration had been deleted, same.
+- A pure SIM-billing batch lapse would cluster within 24h, not over 31 days.
+
+Staggered, device-specific stops point at **the device end of the chain** — power loss at the household, the Particle SIM running out of pre-paid data per-device, the cellular module crashing, the washing machine itself being unplugged or moved, or community-level connectivity dropping intermittently.
+
+## How to confirm where the break is, without leaving the desk
+
+Three cheap tests, in order:
+
+### Test 1 — Is the legacy Google Sheet still receiving rows?
+
+Open the "Goods Washer" Google Sheet (originally connected via Zapier). If new rows are still appearing for the silent coreids → **Zapier is still firing on those devices, but only the Sheet branch is intact, not the webhook branch.** That means the webhook-POST half of the zap got disabled. *Cheap fix: re-enable in Zapier.*
+
+If new rows are NOT appearing for silent coreids → **the devices stopped publishing to Particle Cloud altogether.** The break is upstream, at the Particle SIM, the device firmware, or the physical install. *Site visit territory.*
+
+### Test 2 — Particle Cloud "last seen" per device
+
+Log into [console.particle.io](https://console.particle.io) and look at the device list. Each device shows its last-seen timestamp from Particle's perspective. Compare to our `last_seen_at`:
+
+- If Particle "last seen" is recent (within a day) and ours is March → **the break is between Particle Cloud and our webhook**, i.e. Zapier or the Particle Integration.
+- If Particle "last seen" matches ours (also March) → **the device stopped publishing**. Hardware/SIM/power.
+
+### Test 3 — Zapier task history
+
+In the Zapier dashboard look at the zap's "Task History". You'll see one row per fired event. Filter by date around 2026-03-21:
+
+- If tasks are still firing for `…fe6c…` after 2026-03-21 → Zapier sees events but our webhook is not absorbing them. Check our webhook logs in Vercel for 4xx/5xx around those timestamps.
+- If tasks stop firing for that coreid on 2026-03-21 → Zapier never received those events, which means Particle Cloud never sent them, which means the device went dark.
+
+## What to fix in this codebase regardless
+
+These are independent of the silence-cluster cause and worth doing because they'd have caught this earlier:
+
+1. **Active heartbeat-loss alerting.** Currently `alerts` only fills via the rollup cron and only contains stale March entries. Add a job that runs every 6h: for every `assets` row with `machine_id IS NOT NULL`, if `last_seen_at` < 36h ago, raise a `machine_silent` alert (resolved=false).
+2. **Round-trip Particle Cloud read-back.** A nightly cron that authenticates to Particle's REST API, fetches each registered coreid's last-seen timestamp, and writes it to a `particle_device_status` table. When that table's `cloud_last_seen` diverges from our `usage_logs.last_seen_at` by more than 24h, you know the break is between Particle Cloud and us — not at the device.
+3. **Webhook receipt log.** The webhook currently `console.error`s on insert failures and otherwise silently absorbs everything. A lightweight `webhook_receipts` table (one row per POST regardless of validity) lets you confirm "did we receive anything from Zapier in the last 24h?" without scrolling Vercel logs.
+4. **Stop using `event_id` prefixes for source attribution.** The `particle-{hash}` prefix is generated by both the live webhook and the CSV import, so we can't tell them apart after the fact. Add a `source` column to `usage_logs` (`'webhook' | 'csv-import' | 'seed' | 'openfields'`) for clean provenance.
+5. **Migrate the named placeholders to real coreids when hardware lands.** Norm's House, Nicole's House, Barkley Arts, 8D1, Dian Stokes Sons House, Red Dust currently have `machine_id` set to a human-readable string. When they get Particle devices, swap `machine_id` to the actual coreid and the dashboard light goes on automatically.
+
+## So, working back from now
+
+If you want to revive the dead machines, run **Test 1** first (5 minutes, no auth needed beyond the Sheet) — that single check splits "device problem" from "pipeline problem" cleanly. Tell me which result you see and we'll decide whether the next move is Zapier triage or a Tennant Creek site visit.

--- a/v2/docs/fleet-revival-blockers-may-2026.md
+++ b/v2/docs/fleet-revival-blockers-may-2026.md
@@ -1,0 +1,87 @@
+# Fleet Revival — Why the Records Stopped, and What to Try Next
+
+Snapshot 2026-05-05. Diagnostic findings from `usage_logs` for every machine that has ever sent telemetry, sorted by hypothesis-confidence and recoverability.
+
+## The shape of the silence
+
+The fleet did not slowly fade — it died in two distinct waves.
+
+### Wave 1 — Early March 2026
+
+| Date | What happened |
+|---|---|
+| **2026-03-01** | A bulk job wrote a single `event_type='offline'` row for **5 machines** that had never sent real telemetry: Barkley Arts, 8D1, Dian Stokes Sons House, Red Dust, plus 098. This is a *status sweep*, not real data. Treat these as never-connected. |
+| **2026-03-09** | A second bulk job stamped Norman's House and Nicole Frank's House with their last `cycle_complete` rows + a couple of heartbeats, then they fell off. Both ran firmware `v6`. They were *real machines that briefly worked* in early March, then stopped. |
+
+### Wave 2 — Late March → April 2026 (the "fleet event")
+
+| Date | machine_id | Asset | Events lost | Notes |
+|---|---|---|---:|---|
+| **2026-03-21** | `e00fce68fe6c048ccec66ab1` | orphan (likely Palm Island) | 397 events ended | Sudden stop. Last event was a heartbeat (network OK at the time). |
+| **2026-03-29** | `e00fce68c4b97878b9a2b323` | orphan (likely Palm Island) | 550 events ended | Largest single fleet member. Cycled from cyc=44 → 48 in 3 days, then nothing. |
+| **2026-03-30** | `e00fce68c2ba447b66bcd507` | TC `GB0-WM-507` (or PI Club Kuta) | 30 events ended | Always low-volume; possibly always intermittent. |
+| **2026-04-21** | `e00fce687ae01d08f95694e5` | TC `GB0-WM-4E5` | 342 events ended | Healthy until W15, dropped off in W16 (mid-April). |
+
+**Three machines died within nine days of each other in late March, then 4E5 followed three weeks later.** This is the single most important clue. A fleet-wide silence cluster of that size is almost never random hardware failure — it's almost always one of:
+
+- **Particle SIM expiry / data plan lapse** for a batch of devices on the same activation date. Particle SIMs renew per-device; if they were registered on a single Particle account, a billing failure or pre-paid block exhaustion would cut all of them off.
+- **A Particle Cloud webhook integration was disabled or rotated.** If the integration that POSTs to `goodsoncountry.com/api/webhooks/particle` was deleted, paused, or its URL changed, every active device would stop landing here even though the devices themselves are still publishing to Particle Cloud.
+- **A Zapier zap was paused.** Most live events come through `event_type='zapier-new-wash'` (now normalised to `cycle_complete`). If the Zapier task was disabled around 2026-03-21, that path stops without any device-level cause.
+- **Coordinated firmware push gone wrong.** The dead devices report firmware version `6`. F25, the only survivor, has rows with both `6` and `v6`. Norman + Nicole had `v6` but stopped earlier — so firmware version isn't a clean predictor either way, but worth checking the OTA history.
+
+Order of investigation, cheapest-first:
+
+1. **Check Particle Cloud console** for each silent coreid. Look at "Last seen" — if Particle still shows them publishing events, the problem is between Particle and our webhook (Zapier zap or webhook integration). If Particle also shows them dark, the problem is at the device.
+2. **Check the Zapier dashboard** — was the relevant zap turned off, paused for too many errors, or has it been silently rate-limited? Zaps can pause themselves after consecutive failures.
+3. **Check Particle Integrations** — does the `wash_event` webhook still point at `https://www.goodsoncountry.com/api/webhooks/particle`? Has it been deleted or its event filter narrowed?
+4. **Check Particle SIM billing** for the affected account.
+5. **Site visit / community check-in** — only after the above are clean.
+
+## Per-machine revival cards
+
+### F25 — `e00fce684086eb2aba8d4f25` — Tennant Creek
+**Status: HEALTHY.** 467 cycle events, latest 2026-05-05, firmware `6`/`v6`. This is the control case — whatever is working for F25 is the baseline to recreate for the others. Worth confirming whether F25 is on a separate Particle account/SIM plan or different network from the dead machines.
+
+### 4E5 — `e00fce687ae01d08f95694e5` — Tennant Creek (`GB0-WM-4E5`)
+**Status: SILENT 13d.** 340 cycle events, last 2026-04-21. Most-recently healthy of the dead — easiest revival target.
+- Step 1: Particle Cloud "last seen" check.
+- Step 2: If Particle shows it still publishing → Zapier/webhook fault.
+- Step 3: If Particle is also dark → power/connectivity check at the household.
+
+### 507 — `e00fce68c2ba447b66bcd507` — TC `GB0-WM-507` (or PI Club Kuta?)
+**Status: SILENT 35d.** Only 29 cycle events ever — this device was never reliable. Possible faulty install or community wifi was always marginal.
+- First: Ben to confirm whether 507 is physically in TC or was originally Club Kuta on Palm Island (the same-day-as-supply pattern is suspicious).
+- Then: standard Particle/Zapier/site triage as for 4E5.
+
+### Norman / Norm's House — `Norms House` (named id) — TC `GB0-113`
+**Status: SILENT 56d.** 21 cycle events + 2 heartbeats over 2026-03-01 → 2026-03-09 on firmware `v6`. **This is a real machine that briefly worked and stopped.** Note: the `machine_id` here is the human-readable string `Norms House`, not a Particle coreid — so the Particle device is publishing under a different identifier. Revival means tracing what coreid Norman's actual device has.
+
+### Nicole Frank / Nicoles House — `Nicoles House` (named id) — TC `GB0-154-2`
+**Status: SILENT 56d.** 3 cycle events + 2 heartbeats over the same March 1–9 window, also firmware `v6`. Same situation as Norman's. The machine_id is symbolic; we need to know the actual Particle coreid behind it.
+
+### 098 — `e00fce682db6d32e15e86098` — TC `GB0-WM-098`
+**Status: SILENT 64d.** Only 3 events, last on 2026-03-01, last event type `offline`. Likely the device was never in regular service, or was in a community where wifi was lost long ago.
+
+### Barkley Arts / 8D1 / Dian Stokes Sons House / Red Dust
+**Status: PLACEHOLDER ONLY.** Each has exactly one row in `usage_logs`, an `offline` event from the 2026-03-01 batch sweep. **No real Particle device ever ran behind these `machine_id` values.** They are intent-to-telemeter, not actual telemetry.
+- Decision: either install Particle hardware on these machines and link the new coreid into `assets.machine_id`, or NULL out the `machine_id` so they correctly appear as `no_telemetry_hw`.
+
+### Three orphan coreids (likely Palm Island)
+**Status: ORPHANS.** `c4b9…` (550 events), `fe6c…` (397), `689f…` (38). All on firmware `6`, all in the late-March silence cluster except `689f` which only ran two weeks in Sept 2025. See the alignment doc — these need to be assigned to specific Palm Island households before revival can be planned.
+
+### Maningrida (6 assets, no telemetry hardware ever)
+**Status: NEVER CONNECTED.** No coreid has ever first-appeared in October 2025 when the 6 Maningrida machines were supplied. This is a hardware/process gap, not a revival issue. Different problem class — would need a new shipment with Particle devices fitted before commissioning.
+
+## What needs to change in the system to prevent the next silent fleet
+
+1. **Heartbeat-loss alerts** — currently the `alerts` table only fills on the daily rollup cron. If a machine goes silent for >36h, an alert should fire automatically with the `last_seen_at` and the suspected community. Today's alerts list is from the March batch and doesn't reflect April / May silence.
+2. **Webhook failure logging** — if Particle Cloud is publishing but our webhook is rejecting (4xx/5xx), we should log it. Currently `console.error` only fires in serverless logs that nobody is reading.
+3. **Particle Cloud read-back** — a daily cron that calls Particle's REST API for every registered coreid and writes the cloud-side "last seen" alongside the local "last received". If they diverge, you know it's a webhook problem, not a device problem.
+4. **SIM-expiry monitoring** — a calendar reminder for the renewal date of every Particle SIM, plus a process for renewing in bulk so no future cluster goes dark together.
+
+## Open questions for Ben
+
+1. Did anything change around **2026-03-21** in Particle Cloud, Zapier, or the webhook config? That's the start of the cluster.
+2. Are F25's Particle SIM and account on the **same plan / billing** as 4E5, 507, c4b9, fe6c — or different?
+3. Are Norman's and Nicole Frank's machines actually on Particle hardware? Their `machine_id` is the human household name, not a coreid — that suggests data was being keyed in by a person rather than streamed from a device.
+4. Is the **Zapier zap** still enabled? If yes, when was it last triggered (visible in Zapier task history)?

--- a/v2/src/app/admin/fleet/page.tsx
+++ b/v2/src/app/admin/fleet/page.tsx
@@ -12,6 +12,10 @@ import {
   DeploymentsByCommunity,
   type WashingDeployment,
 } from '@/components/fleet/deployments-by-community';
+import {
+  WebhookHealthBanner,
+  type WebhookHealth,
+} from '@/components/fleet/webhook-health-banner';
 import { FleetMap } from './fleet-map';
 import type { Alert, MachineOverview } from '@/lib/types/database';
 
@@ -94,6 +98,47 @@ export default async function FleetDashboardPage() {
   // Falls back silently if the RPC hasn't been migrated yet.
   const { data: deploymentRows } = await supabase.rpc('get_all_washing_deployments');
   const deployments: WashingDeployment[] = (deploymentRows || []) as WashingDeployment[];
+
+  // Webhook health (last 24h / 7d). Degrades silently if the table isn't there.
+  const dayAgoIso = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const sevenDaysAgoIso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  const { data: receipts24h } = await supabase
+    .from('webhook_receipts')
+    .select('source, status_code, machine_id, received_at')
+    .gte('received_at', sevenDaysAgoIso);
+
+  type HealthAcc = WebhookHealth & { machines24: Set<string> };
+  const webhookHealthMap = new Map<string, HealthAcc>();
+  for (const r of receipts24h || []) {
+    const key = r.source as string;
+    const existing: HealthAcc = webhookHealthMap.get(key) || {
+      source: key,
+      last_24h: 0,
+      last_7d: 0,
+      errors_24h: 0,
+      last_received_at: null,
+      distinct_machines_24h: 0,
+      machines24: new Set<string>(),
+    };
+    existing.last_7d += 1;
+    if (r.received_at >= dayAgoIso) {
+      existing.last_24h += 1;
+      if (r.machine_id) existing.machines24.add(r.machine_id);
+      if ((r.status_code as number) >= 400) existing.errors_24h += 1;
+    }
+    if (!existing.last_received_at || r.received_at > existing.last_received_at) {
+      existing.last_received_at = r.received_at;
+    }
+    webhookHealthMap.set(key, existing);
+  }
+  const webhookHealth: WebhookHealth[] = Array.from(webhookHealthMap.values()).map((h) => ({
+    source: h.source,
+    last_24h: h.last_24h,
+    last_7d: h.last_7d,
+    errors_24h: h.errors_24h,
+    last_received_at: h.last_received_at,
+    distinct_machines_24h: h.machines24.size,
+  }));
   
   const machines: MachineOverview[] = (statsData || []).map((row: any) => ({
     machine_id: row.machine_id,
@@ -246,6 +291,9 @@ export default async function FleetDashboardPage() {
           </Card>
         )}
       </div>
+
+      {/* Webhook health banner */}
+      {webhookHealth.length > 0 && <WebhookHealthBanner health={webhookHealth} />}
 
       {/* All deployments (telemetry + non-telemetry) by community */}
       {deployments.length > 0 && <DeploymentsByCommunity deployments={deployments} />}

--- a/v2/src/app/admin/fleet/page.tsx
+++ b/v2/src/app/admin/fleet/page.tsx
@@ -16,6 +16,18 @@ import {
   WebhookHealthBanner,
   type WebhookHealth,
 } from '@/components/fleet/webhook-health-banner';
+import {
+  PipelineHealthDiagram,
+  type PipelineHealth,
+} from '@/components/fleet/pipeline-health';
+import {
+  SilenceTimeline,
+  type SilenceEvent,
+} from '@/components/fleet/silence-timeline';
+import {
+  InvestigationCards,
+  type InvestigationMachine,
+} from '@/components/fleet/investigation-cards';
 import { FleetMap } from './fleet-map';
 import type { Alert, MachineOverview } from '@/lib/types/database';
 
@@ -139,6 +151,77 @@ export default async function FleetDashboardPage() {
     last_received_at: h.last_received_at,
     distinct_machines_24h: h.machines24.size,
   }));
+
+  // Per-machine monthly activity for the investigation sparklines
+  const { data: monthlyRows } = await supabase.rpc('get_machine_monthly_activity');
+  const monthlyByMachine = new Map<string, { month: string; events: number }[]>();
+  for (const r of (monthlyRows || []) as Array<{ machine_id: string; month_start: string; events: number }>) {
+    const arr = monthlyByMachine.get(r.machine_id) || [];
+    arr.push({ month: r.month_start, events: Number(r.events) });
+    monthlyByMachine.set(r.machine_id, arr);
+  }
+  // Pad each machine's history with zero months so the sparkline has a consistent x-axis
+  const today = new Date();
+  const allMonths: string[] = [];
+  for (let i = 11; i >= 0; i--) {
+    const d = new Date(today.getFullYear(), today.getMonth() - i, 1);
+    allMonths.push(d.toISOString().slice(0, 7) + '-01');
+  }
+
+  // Pipeline health summary
+  const lastEventAt = deployments
+    .map((d) => d.last_seen_at)
+    .filter((x): x is string => !!x)
+    .sort()
+    .at(-1) || null;
+  const reportingMachines = deployments.filter((d) => d.connectivity_status === 'reporting').length;
+  const totalMachinesWithHardware = deployments.filter((d) => d.has_telemetry_hw).length;
+  const pipelineHealth: PipelineHealth = {
+    reportingMachines,
+    totalMachinesWithHardware,
+    lastEventAt,
+    webhookReceiptsLast24h: webhookHealth.reduce((acc, h) => acc + h.last_24h, 0),
+  };
+
+  // Silence timeline — every machine that ever reported, ordered by last seen
+  const silenceEvents: SilenceEvent[] = deployments
+    .filter((d) => d.has_telemetry_hw && d.last_seen_at)
+    .map((d) => ({
+      machine_id: d.machine_id || '',
+      display_name: d.name || d.machine_id || '—',
+      community: d.community,
+      last_seen_at: d.last_seen_at,
+      total_cycle_events: d.total_cycle_events ?? 0,
+      last_firmware: d.last_firmware ?? null,
+      status: d.connectivity_status,
+    }));
+
+  // Investigation cards — one per telemetry-touched machine, with monthly activity
+  const investigationMachines: InvestigationMachine[] = deployments
+    .filter((d) => d.has_telemetry_hw)
+    .map((d) => {
+      const raw = monthlyByMachine.get(d.machine_id || '') || [];
+      const map = new Map(raw.map((r) => [r.month, r.events]));
+      const padded = allMonths.map((m) => ({ month: m, events: map.get(m) || 0 }));
+      return {
+        machine_id: d.machine_id || '',
+        display_name: d.name || d.machine_id || '—',
+        community: d.community,
+        household: d.contact_household,
+        asset_id: d.unique_id,
+        last_seen_at: d.last_seen_at,
+        last_event_type: d.last_event_type ?? null,
+        last_firmware: d.last_firmware ?? null,
+        total_cycle_events: d.total_cycle_events ?? 0,
+        monthly_activity: padded,
+      };
+    })
+    .sort((a, b) => {
+      // Reporting first, then most-recently-silent, then long-silent
+      const aDays = a.last_seen_at ? Date.now() - new Date(a.last_seen_at).getTime() : Infinity;
+      const bDays = b.last_seen_at ? Date.now() - new Date(b.last_seen_at).getTime() : Infinity;
+      return aDays - bDays;
+    });
   
   const machines: MachineOverview[] = (statsData || []).map((row: any) => ({
     machine_id: row.machine_id,
@@ -292,8 +375,19 @@ export default async function FleetDashboardPage() {
         )}
       </div>
 
+      {/* Pipeline health diagram */}
+      <PipelineHealthDiagram health={pipelineHealth} />
+
+      {/* Silence timeline — when did each machine last report */}
+      {silenceEvents.length > 0 && <SilenceTimeline events={silenceEvents} />}
+
       {/* Webhook health banner */}
       {webhookHealth.length > 0 && <WebhookHealthBanner health={webhookHealth} />}
+
+      {/* Per-machine investigation cards */}
+      {investigationMachines.length > 0 && (
+        <InvestigationCards machines={investigationMachines} />
+      )}
 
       {/* All deployments (telemetry + non-telemetry) by community */}
       {deployments.length > 0 && <DeploymentsByCommunity deployments={deployments} />}

--- a/v2/src/app/api/admin/fleet/particle-status/route.ts
+++ b/v2/src/app/api/admin/fleet/particle-status/route.ts
@@ -1,0 +1,163 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient, createServiceClient } from '@/lib/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Compare Particle Cloud's per-device "last seen" against our usage_logs.
+ *
+ * Splits "device problem" from "pipeline problem" without a site visit.
+ *
+ * POST body: { token: "particle-access-token" }
+ *   OR set PARTICLE_ACCESS_TOKEN in env and call with empty body.
+ *
+ * Get a token from console.particle.io → Settings → Access Tokens.
+ */
+export async function POST(request: NextRequest) {
+  const userSupabase = await createClient();
+  const { data: { user } } = await userSupabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const isAdmin =
+    user.app_metadata?.role === 'admin' ||
+    user.user_metadata?.role === 'admin' ||
+    process.env.ADMIN_EMAILS?.split(',').includes(user.email || '');
+  if (!isAdmin) return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+
+  let body: { token?: string } = {};
+  try {
+    body = await request.json();
+  } catch {
+    /* empty body is fine */
+  }
+
+  const token = body.token || process.env.PARTICLE_ACCESS_TOKEN;
+  if (!token) {
+    return NextResponse.json(
+      { error: 'No Particle access token. Pass {"token":"..."} in body or set PARTICLE_ACCESS_TOKEN env.' },
+      { status: 400 }
+    );
+  }
+
+  // Fetch device list from Particle Cloud
+  let devices: Array<{
+    id: string;
+    name?: string;
+    last_heard?: string | null;
+    last_handshake_at?: string | null;
+    online?: boolean;
+    connected?: boolean;
+  }> = [];
+  try {
+    const res = await fetch('https://api.particle.io/v1/devices', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => '');
+      return NextResponse.json(
+        { error: `Particle Cloud returned ${res.status}`, detail: errBody.slice(0, 500) },
+        { status: 502 }
+      );
+    }
+    devices = await res.json();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: `Particle Cloud unreachable: ${message}` }, { status: 502 });
+  }
+
+  // Pull our local last-seen for every coreid via the deployments RPC
+  const supabase = createServiceClient();
+  const { data: deploymentRows } = await supabase.rpc('get_all_washing_deployments');
+  const localByCoreid = new Map<string, { last_seen_at: string | null; name: string | null; community: string | null }>();
+  for (const d of (deploymentRows || []) as Array<{ machine_id: string | null; last_seen_at: string | null; name: string | null; community: string | null }>) {
+    if (d.machine_id) localByCoreid.set(d.machine_id, d);
+  }
+
+  type Verdict =
+    | 'agrees_recent'
+    | 'agrees_silent'
+    | 'pipeline_break'
+    | 'never_seen_locally'
+    | 'particle_forgot'
+    | 'never_anywhere';
+
+  const now = Date.now();
+  const RECENT_DAYS = 2;
+  const dayMs = 24 * 60 * 60 * 1000;
+
+  const comparison = devices.map((d) => {
+    const pCloud = d.last_heard || d.last_handshake_at;
+    const local = localByCoreid.get(d.id);
+    const pTs = pCloud ? new Date(pCloud).getTime() : null;
+    const oTs = local?.last_seen_at ? new Date(local.last_seen_at).getTime() : null;
+
+    let verdict: Verdict;
+    let reason: string;
+
+    if (pTs && oTs) {
+      const gapDays = (pTs - oTs) / dayMs;
+      const pRecent = (now - pTs) / dayMs <= RECENT_DAYS;
+      const oRecent = (now - oTs) / dayMs <= RECENT_DAYS;
+      if (pRecent && oRecent) {
+        verdict = 'agrees_recent';
+        reason = 'Particle and our DB both show recent activity. Healthy.';
+      } else if (!pRecent && !oRecent && Math.abs(gapDays) <= 1) {
+        verdict = 'agrees_silent';
+        reason = 'Particle and our DB both stopped at the same time → device-side problem.';
+      } else if (gapDays > 1) {
+        verdict = 'pipeline_break';
+        reason = `Particle saw the device ${Math.round(gapDays)}d after our DB stopped → break is between Particle and our webhook (Zapier or Particle Integration).`;
+      } else {
+        verdict = 'agrees_silent';
+        reason = `Both stopped, gap ${Math.round(gapDays)}d`;
+      }
+    } else if (pTs && !oTs) {
+      verdict = 'never_seen_locally';
+      reason = 'Particle has the device but we have never seen any events → never connected to our webhook.';
+    } else if (!pTs && oTs) {
+      verdict = 'particle_forgot';
+      reason = 'Our DB has events but Particle Cloud has no last-seen → device may have been deleted from Particle account.';
+    } else {
+      verdict = 'never_anywhere';
+      reason = 'Neither side has ever seen this device.';
+    }
+
+    return {
+      coreid: d.id,
+      device_name: d.name || null,
+      particle_online: d.online || d.connected || false,
+      particle_last_seen: pCloud || null,
+      our_last_seen: local?.last_seen_at || null,
+      asset_name: local?.name || null,
+      asset_community: local?.community || null,
+      verdict,
+      reason,
+    };
+  });
+
+  // Local coreids Particle does not know about
+  const particleIds = new Set(devices.map((d) => d.id));
+  const localOnly = Array.from(localByCoreid.entries())
+    .filter(([id]) => id.startsWith('e00fce68') && !particleIds.has(id))
+    .map(([id, info]) => ({
+      coreid: id,
+      asset_name: info.name,
+      asset_community: info.community,
+      our_last_seen: info.last_seen_at,
+    }));
+
+  return NextResponse.json({
+    checked_at: new Date().toISOString(),
+    particle_account_devices: devices.length,
+    summary: comparison.reduce(
+      (acc, c) => {
+        acc[c.verdict] = (acc[c.verdict] || 0) + 1;
+        return acc;
+      },
+      {} as Record<string, number>
+    ),
+    devices: comparison,
+    local_only_coreids: localOnly,
+  });
+}

--- a/v2/src/app/api/webhooks/particle/route.ts
+++ b/v2/src/app/api/webhooks/particle/route.ts
@@ -55,7 +55,39 @@ function mapEventType(event: string): string {
   }
 }
 
+async function logReceipt(
+  supabase: ReturnType<typeof createServiceClient>,
+  fields: {
+    status_code: number;
+    event_type?: string | null;
+    machine_id?: string | null;
+    body_size: number;
+    user_agent?: string | null;
+    remote_ip?: string | null;
+    duplicate?: boolean;
+    error_message?: string | null;
+    raw_body?: unknown;
+  }
+) {
+  // Best-effort — never let receipt-logging failures take down the webhook.
+  try {
+    await supabase.from('webhook_receipts').insert({
+      source: 'particle',
+      ...fields,
+    });
+  } catch {
+    /* swallow */
+  }
+}
+
 export async function POST(request: NextRequest) {
+  const userAgent = request.headers.get('user-agent');
+  const remoteIp =
+    request.headers.get('x-forwarded-for')?.split(',')[0].trim() ||
+    request.headers.get('x-real-ip') ||
+    null;
+  const supabaseLog = createServiceClient();
+
   let body: string;
   let payload: ParticlePayload;
 
@@ -63,10 +95,25 @@ export async function POST(request: NextRequest) {
     body = await request.text();
     payload = JSON.parse(body);
   } catch {
+    await logReceipt(supabaseLog, {
+      status_code: 400,
+      body_size: 0,
+      user_agent: userAgent,
+      remote_ip: remoteIp,
+      error_message: 'Invalid JSON',
+    });
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
   if (!payload.coreid || !payload.event) {
+    await logReceipt(supabaseLog, {
+      status_code: 400,
+      body_size: body.length,
+      user_agent: userAgent,
+      remote_ip: remoteIp,
+      error_message: 'Missing required fields: coreid, event',
+      raw_body: payload,
+    });
     return NextResponse.json(
       { error: 'Missing required fields: coreid, event' },
       { status: 400 }
@@ -130,9 +177,27 @@ export async function POST(request: NextRequest) {
     if (insertError) {
       // Duplicate event_id — idempotent, return success
       if (insertError.code === '23505') {
+        await logReceipt(supabaseLog, {
+          status_code: 200,
+          event_type: eventType,
+          machine_id: payload.coreid,
+          body_size: body.length,
+          user_agent: userAgent,
+          remote_ip: remoteIp,
+          duplicate: true,
+        });
         return NextResponse.json({ received: true, duplicate: true });
       }
       console.error('Particle webhook insert error:', insertError);
+      await logReceipt(supabaseLog, {
+        status_code: 500,
+        event_type: eventType,
+        machine_id: payload.coreid,
+        body_size: body.length,
+        user_agent: userAgent,
+        remote_ip: remoteIp,
+        error_message: insertError.message,
+      });
       return NextResponse.json(
         { error: 'Database error', detail: insertError.message },
         { status: 500 }
@@ -147,6 +212,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    await logReceipt(supabaseLog, {
+      status_code: 200,
+      event_type: eventType,
+      machine_id: payload.coreid,
+      body_size: body.length,
+      user_agent: userAgent,
+      remote_ip: remoteIp,
+    });
+
     return NextResponse.json({
       received: true,
       event_type: eventType,
@@ -157,6 +231,15 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     console.error('Particle webhook handler error:', message);
+    await logReceipt(supabaseLog, {
+      status_code: 500,
+      event_type: undefined,
+      machine_id: payload.coreid,
+      body_size: body.length,
+      user_agent: userAgent,
+      remote_ip: remoteIp,
+      error_message: message,
+    });
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/v2/src/components/fleet/deployments-by-community.tsx
+++ b/v2/src/components/fleet/deployments-by-community.tsx
@@ -16,11 +16,15 @@ export interface WashingDeployment {
   last_seen_at: string | null;
   cycles_7d: number;
   kwh_7d: number;
+  total_cycle_events?: number;
+  last_event_type?: string | null;
+  last_firmware?: string | null;
   connectivity_status:
     | 'reporting'
     | 'lagging'
     | 'silent'
     | 'never_reported'
+    | 'placeholder_only'
     | 'no_telemetry_hw'
     | 'pending_assignment';
 }
@@ -30,6 +34,7 @@ const STATUS_LABEL: Record<WashingDeployment['connectivity_status'], string> = {
   lagging: 'Lagging',
   silent: 'Silent',
   never_reported: 'Never reported',
+  placeholder_only: 'Placeholder (no real device)',
   no_telemetry_hw: 'No telemetry HW',
   pending_assignment: 'Pending assignment',
 };
@@ -39,6 +44,7 @@ const STATUS_COLOUR: Record<WashingDeployment['connectivity_status'], string> = 
   lagging: 'bg-amber-100 text-amber-800',
   silent: 'bg-red-100 text-red-800',
   never_reported: 'bg-rose-100 text-rose-800',
+  placeholder_only: 'bg-purple-100 text-purple-800',
   no_telemetry_hw: 'bg-slate-100 text-slate-700',
   pending_assignment: 'bg-blue-50 text-blue-800',
 };
@@ -177,6 +183,9 @@ export function DeploymentsByCommunity({
                     <th className="text-left px-2">Status</th>
                     <th className="text-right px-2">Last seen</th>
                     <th className="text-right px-2">7d cycles</th>
+                    <th className="text-right px-2">Total cycles</th>
+                    <th className="text-left px-2">Last event</th>
+                    <th className="text-left px-2">FW</th>
                     <th className="text-right pr-4">Supplied</th>
                   </tr>
                 </thead>
@@ -201,6 +210,15 @@ export function DeploymentsByCommunity({
                         </td>
                         <td className="text-right px-2 text-gray-600">
                           {d.has_telemetry_hw ? d.cycles_7d : '—'}
+                        </td>
+                        <td className="text-right px-2 text-gray-600">
+                          {d.has_telemetry_hw ? (d.total_cycle_events ?? 0) : '—'}
+                        </td>
+                        <td className="px-2 text-xs text-gray-500">
+                          {d.last_event_type || '—'}
+                        </td>
+                        <td className="px-2 text-xs text-gray-500">
+                          {d.last_firmware || '—'}
                         </td>
                         <td className="text-right pr-4 text-gray-500">
                           {supplied === null ? '—' : `${supplied}d ago`}

--- a/v2/src/components/fleet/investigation-cards.tsx
+++ b/v2/src/components/fleet/investigation-cards.tsx
@@ -1,0 +1,234 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+export interface InvestigationMachine {
+  machine_id: string;
+  display_name: string;
+  community: string | null;
+  household: string | null;
+  asset_id: string | null;
+  last_seen_at: string | null;
+  last_event_type: string | null;
+  last_firmware: string | null;
+  total_cycle_events: number;
+  monthly_activity: { month: string; events: number }[];
+}
+
+function daysAgo(iso: string | null) {
+  if (!iso) return null;
+  const ms = Date.now() - new Date(iso).getTime();
+  return Math.max(0, Math.floor(ms / (1000 * 60 * 60 * 24)));
+}
+
+function inferCause(m: InvestigationMachine): { label: string; reasoning: string; colour: string } {
+  const days = daysAgo(m.last_seen_at);
+  if (days === null) {
+    return {
+      label: 'Never reported',
+      reasoning:
+        'No telemetry has ever arrived for this coreid. Either the device was never installed, never powered, or it was never claimed under the active Particle account.',
+      colour: 'bg-slate-100 text-slate-800',
+    };
+  }
+  if (days < 2) {
+    return {
+      label: 'Healthy',
+      reasoning: 'Reporting normally. This is the control case for the rest of the fleet.',
+      colour: 'bg-emerald-100 text-emerald-800',
+    };
+  }
+  if (m.total_cycle_events < 10 && days > 30) {
+    return {
+      label: 'Likely never properly commissioned',
+      reasoning:
+        'This device only ever produced a handful of events before going silent. Likely never installed properly, or was a test bench, or had a hardware fault from new.',
+      colour: 'bg-purple-100 text-purple-800',
+    };
+  }
+  if (m.last_event_type === 'heartbeat') {
+    return {
+      label: 'Cellular alive when it died',
+      reasoning:
+        "The very last message we received was a heartbeat, not a wash. That means the device's network connection was working at the moment it stopped — the break is unlikely to be wifi/cellular signal. More likely: the device was unplugged, the household power went out, or the SIM data plan exhausted shortly after.",
+      colour: 'bg-amber-100 text-amber-800',
+    };
+  }
+  if (m.total_cycle_events > 200) {
+    return {
+      label: 'Heavy use → possible SIM exhaustion',
+      reasoning:
+        'This device produced hundreds of events. Particle SIMs include a fixed monthly data quota; heavy users hit that ceiling first. F25 (still alive) likely sits on a different SIM plan.',
+      colour: 'bg-amber-100 text-amber-800',
+    };
+  }
+  if (days >= 30 && days <= 60) {
+    return {
+      label: 'In the late-March silence cluster',
+      reasoning:
+        'This device went silent within the March 21 – April 21 window, the same as several others. Most likely cause: the Particle account ownership change on March 3 expired this device\'s claim before F25\'s.',
+      colour: 'bg-orange-100 text-orange-800',
+    };
+  }
+  return {
+    label: 'Silent — cause unclear',
+    reasoning:
+      "Investigate via the standard checklist: Particle Cloud last-seen → Zapier task history → physical inspection.",
+    colour: 'bg-red-100 text-red-800',
+  };
+}
+
+const INVESTIGATION_STEPS = [
+  {
+    title: 'LED check at the machine (5 min, no tech needed)',
+    detail:
+      'Open the access panel and look at the Particle Photon LED. Cyan breathing slowly = device is on Particle Cloud right now (it\'s a pipeline / claim issue). Cyan flashing fast = trying to connect (cellular/wifi issue). Green = wifi unavailable. Red = firmware crash. Off = power problem.',
+  },
+  {
+    title: 'Particle Cloud "last seen"',
+    detail:
+      'Log into console.particle.io with the account that owns these devices. If the device shows recent activity there but our DB doesn\'t, the break is between Particle Cloud and our webhook (Zapier auth). If both show old, the device has stopped publishing entirely.',
+  },
+  {
+    title: 'Particle SIM data balance',
+    detail:
+      'Particle SIMs have monthly data quotas. Console shows usage per device. If this one is at 100% of its plan, top up.',
+  },
+  {
+    title: 'Zapier task history for this coreid',
+    detail:
+      'In the Zapier dashboard, filter the "Goods Washer" zap\'s task history by this coreid. If tasks are still firing → our side rejected them; check Vercel logs. If tasks stopped firing on a specific date → match it against any account / billing changes.',
+  },
+];
+
+function Sparkline({ data }: { data: { month: string; events: number }[] }) {
+  if (data.length === 0) {
+    return <div className="text-xs text-gray-400">No recent activity</div>;
+  }
+  const max = Math.max(...data.map((d) => d.events), 1);
+  return (
+    <div className="flex items-end gap-1 h-12">
+      {data.map((d) => (
+        <div key={d.month} className="flex-1 flex flex-col items-center" title={`${d.month}: ${d.events} events`}>
+          <div
+            className={`w-full ${d.events > 0 ? 'bg-blue-400' : 'bg-gray-200'} rounded-sm`}
+            style={{ height: `${Math.max(2, (d.events / max) * 100)}%` }}
+          />
+          <div className="text-[9px] text-gray-400 mt-0.5">{d.month.slice(5)}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function InvestigationCards({ machines }: { machines: InvestigationMachine[] }) {
+  if (machines.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Per-Machine Investigation</CardTitle>
+        <p className="text-sm text-gray-500 mt-1">
+          Every machine that has ever sent a wash event. Use the cause hypothesis to pick a
+          starting point, then work down the investigation checklist below each card.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {machines.map((m) => {
+          const days = daysAgo(m.last_seen_at);
+          const cause = inferCause(m);
+          const isAlive = days !== null && days < 2;
+          return (
+            <details
+              key={m.machine_id}
+              className="border rounded-lg"
+              open={!isAlive && (days ?? 0) < 30}
+            >
+              <summary className="cursor-pointer px-4 py-3 flex items-center justify-between gap-4 flex-wrap">
+                <div className="flex items-center gap-3 flex-wrap">
+                  <div>
+                    <div className="font-medium">
+                      {m.display_name}
+                      <span className="text-xs text-gray-400 ml-2">{m.machine_id}</span>
+                    </div>
+                    <div className="text-xs text-gray-500">
+                      {m.community || '—'}
+                      {m.household ? ` · ${m.household}` : ''}
+                      {m.asset_id ? ` · ${m.asset_id}` : ''}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge className={cause.colour}>{cause.label}</Badge>
+                  <span className="text-xs text-gray-500">
+                    {days === null
+                      ? 'never reported'
+                      : isAlive
+                      ? 'reporting now'
+                      : `${days}d silent`}
+                  </span>
+                </div>
+              </summary>
+              <div className="border-t px-4 py-4 space-y-4">
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+                  <div>
+                    <div className="text-xs uppercase text-gray-500 font-medium">Last seen</div>
+                    <div className="font-mono">
+                      {m.last_seen_at
+                        ? new Date(m.last_seen_at).toISOString().replace('T', ' ').slice(0, 19)
+                        : '—'}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase text-gray-500 font-medium">Lifetime events</div>
+                    <div className="font-mono">{m.total_cycle_events}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase text-gray-500 font-medium">Last event type</div>
+                    <div className="font-mono">{m.last_event_type || '—'}</div>
+                  </div>
+                  <div>
+                    <div className="text-xs uppercase text-gray-500 font-medium">Last firmware</div>
+                    <div className="font-mono">{m.last_firmware || '—'}</div>
+                  </div>
+                </div>
+
+                <div>
+                  <div className="text-xs uppercase text-gray-500 font-medium mb-1">
+                    Activity, last 12 months
+                  </div>
+                  <Sparkline data={m.monthly_activity} />
+                </div>
+
+                <div className="rounded-lg bg-gray-50 p-3 text-sm leading-relaxed">
+                  <div className="font-medium mb-1">Why probably {cause.label.toLowerCase()}</div>
+                  <p className="text-gray-700">{cause.reasoning}</p>
+                </div>
+
+                {!isAlive && (
+                  <div>
+                    <div className="text-xs uppercase text-gray-500 font-medium mb-2">
+                      Investigation checklist
+                    </div>
+                    <ol className="space-y-2 text-sm">
+                      {INVESTIGATION_STEPS.map((step, i) => (
+                        <li key={i} className="flex gap-2">
+                          <span className="font-mono text-xs bg-gray-200 rounded px-1.5 py-0.5 mt-0.5 shrink-0">
+                            {i + 1}
+                          </span>
+                          <div>
+                            <div className="font-medium">{step.title}</div>
+                            <div className="text-gray-600 text-xs">{step.detail}</div>
+                          </div>
+                        </li>
+                      ))}
+                    </ol>
+                  </div>
+                )}
+              </div>
+            </details>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}

--- a/v2/src/components/fleet/pipeline-health.tsx
+++ b/v2/src/components/fleet/pipeline-health.tsx
@@ -1,0 +1,150 @@
+import { Fragment } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+export interface PipelineHealth {
+  reportingMachines: number;
+  totalMachinesWithHardware: number;
+  lastEventAt: string | null;
+  webhookReceiptsLast24h: number;
+}
+
+function hoursAgo(iso: string | null) {
+  if (!iso) return null;
+  const ms = Date.now() - new Date(iso).getTime();
+  return Math.max(0, Math.floor(ms / (1000 * 60 * 60)));
+}
+
+export function PipelineHealthDiagram({ health }: { health: PipelineHealth }) {
+  const lastEventHours = hoursAgo(health.lastEventAt);
+  const ourSideHealthy = health.lastEventAt && lastEventHours !== null && lastEventHours <= 48;
+  const onlyOneAlive = health.reportingMachines <= 1 && health.totalMachinesWithHardware > 1;
+
+  const stages = [
+    {
+      name: 'Particle Photons',
+      sub: `${health.totalMachinesWithHardware} devices in fleet`,
+      health: onlyOneAlive
+        ? ('failing' as const)
+        : health.reportingMachines === 0
+        ? ('failing' as const)
+        : health.reportingMachines === health.totalMachinesWithHardware
+        ? ('healthy' as const)
+        : ('degraded' as const),
+      detail: `${health.reportingMachines} of ${health.totalMachinesWithHardware} reporting`,
+    },
+    {
+      name: 'Particle Cloud',
+      sub: 'api.particle.io',
+      health: ourSideHealthy ? ('healthy' as const) : ('unknown' as const),
+      detail: ourSideHealthy
+        ? 'Forwarding events for at least one device'
+        : 'No events received from any device recently',
+    },
+    {
+      name: 'Zapier zap',
+      sub: 'Goods Washer',
+      health: ourSideHealthy ? ('healthy' as const) : ('unknown' as const),
+      detail: ourSideHealthy
+        ? 'Firing for healthy devices'
+        : 'No incoming webhooks observed',
+    },
+    {
+      name: 'Our webhook',
+      sub: 'POST /api/webhooks/particle',
+      health: ourSideHealthy ? ('healthy' as const) : ('unknown' as const),
+      detail:
+        health.webhookReceiptsLast24h > 0
+          ? `${health.webhookReceiptsLast24h} receipts in 24h`
+          : 'Webhook receipt logging just started',
+    },
+    {
+      name: 'usage_logs',
+      sub: 'Supabase',
+      health: 'healthy' as const,
+      detail:
+        lastEventHours === null
+          ? 'never'
+          : lastEventHours === 0
+          ? 'last event just now'
+          : `last event ${lastEventHours}h ago`,
+    },
+  ];
+
+  const colour = (h: 'healthy' | 'degraded' | 'failing' | 'unknown') => {
+    switch (h) {
+      case 'healthy':
+        return 'bg-emerald-100 text-emerald-800 border-emerald-200';
+      case 'degraded':
+        return 'bg-amber-100 text-amber-800 border-amber-200';
+      case 'failing':
+        return 'bg-red-100 text-red-800 border-red-200';
+      default:
+        return 'bg-slate-100 text-slate-700 border-slate-200';
+    }
+  };
+  const dot = (h: 'healthy' | 'degraded' | 'failing' | 'unknown') => {
+    switch (h) {
+      case 'healthy':
+        return 'bg-emerald-500';
+      case 'degraded':
+        return 'bg-amber-500';
+      case 'failing':
+        return 'bg-red-500';
+      default:
+        return 'bg-slate-400';
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between flex-wrap gap-2">
+          <CardTitle>Pipeline Health</CardTitle>
+          <p className="text-xs text-gray-500">
+            Each wash event must traverse all 5 stages. Trace failures left-to-right.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <div className="flex items-stretch gap-2 min-w-max pb-2">
+            {stages.map((s, i) => (
+              <Fragment key={s.name}>
+                <div
+                  className={`flex-1 min-w-[180px] border rounded-lg px-3 py-3 ${colour(s.health)}`}
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <div className={`w-2 h-2 rounded-full ${dot(s.health)}`} />
+                    <Badge variant="outline" className="text-xs bg-white/50">{i + 1}</Badge>
+                    <span className="font-medium text-sm">{s.name}</span>
+                  </div>
+                  <div className="text-xs text-gray-600 mb-1">{s.sub}</div>
+                  <div className="text-xs">{s.detail}</div>
+                </div>
+                {i < stages.length - 1 && (
+                  <div className="flex items-center text-gray-400 text-xl px-1">→</div>
+                )}
+              </Fragment>
+            ))}
+          </div>
+        </div>
+        {onlyOneAlive && (
+          <div className="mt-4 p-3 rounded-lg border border-red-200 bg-red-50 text-sm">
+            <p className="font-semibold text-red-800 mb-1">
+              Staggered device-side failure detected.
+            </p>
+            <p className="text-red-700 leading-relaxed">
+              {health.reportingMachines} of {health.totalMachinesWithHardware} machines is
+              still reporting. Because at least one device IS still producing events end-to-end,
+              the pipeline (Particle Cloud → Zapier → our webhook → DB) is healthy. The break
+              is at the device end of the chain. Most likely causes: per-device SIM data
+              exhaustion, individual claim transfer issues after a Particle account ownership
+              change, or per-household power loss.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/v2/src/components/fleet/silence-timeline.tsx
+++ b/v2/src/components/fleet/silence-timeline.tsx
@@ -1,0 +1,93 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+export interface SilenceEvent {
+  machine_id: string;
+  display_name: string;
+  community: string | null;
+  last_seen_at: string | null;
+  total_cycle_events: number;
+  last_firmware: string | null;
+  status: string;
+}
+
+function daysAgo(iso: string | null) {
+  if (!iso) return null;
+  const ms = Date.now() - new Date(iso).getTime();
+  return Math.max(0, Math.floor(ms / (1000 * 60 * 60 * 24)));
+}
+
+export function SilenceTimeline({ events }: { events: SilenceEvent[] }) {
+  const withDates = events
+    .filter((e) => e.last_seen_at)
+    .sort(
+      (a, b) =>
+        new Date(b.last_seen_at!).getTime() - new Date(a.last_seen_at!).getTime()
+    );
+
+  if (withDates.length === 0) return null;
+
+  const maxEvents = Math.max(...withDates.map((e) => e.total_cycle_events || 1));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Silence Timeline — When Each Machine Last Reported</CardTitle>
+        <p className="text-sm text-gray-500 mt-1">
+          Sorted most-recent-first. Bar length shows lifetime activity. A staggered
+          tail means a per-device problem; a single cliff means a global problem.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-2">
+          {withDates.map((e) => {
+            const days = daysAgo(e.last_seen_at) ?? 0;
+            const widthPct = Math.max(2, ((e.total_cycle_events || 0) / maxEvents) * 100);
+            const isAlive = days < 2;
+            const isRecent = days < 14 && !isAlive;
+            const colour = isAlive
+              ? 'bg-emerald-500'
+              : isRecent
+              ? 'bg-amber-500'
+              : 'bg-red-400';
+            const textColour = isAlive
+              ? 'text-emerald-800'
+              : isRecent
+              ? 'text-amber-800'
+              : 'text-red-700';
+            return (
+              <div key={e.machine_id} className="grid grid-cols-12 gap-3 items-center">
+                <div className="col-span-3 text-sm">
+                  <div className="font-medium truncate">{e.display_name}</div>
+                  <div className="text-xs text-gray-400 truncate">{e.community || '—'}</div>
+                </div>
+                <div className="col-span-6 relative h-6 bg-gray-100 rounded">
+                  <div
+                    className={`absolute left-0 top-0 bottom-0 ${colour} rounded`}
+                    style={{ width: `${widthPct}%` }}
+                  />
+                  <span className="absolute left-2 top-0 bottom-0 flex items-center text-xs text-white font-medium drop-shadow">
+                    {e.total_cycle_events} events lifetime
+                  </span>
+                </div>
+                <div className={`col-span-3 text-xs ${textColour}`}>
+                  <div className="font-medium">
+                    {isAlive
+                      ? 'Reporting now'
+                      : days === 1
+                      ? 'silent 1 day'
+                      : `silent ${days} days`}
+                  </div>
+                  <div className="text-gray-400">
+                    last {new Date(e.last_seen_at!).toISOString().slice(0, 10)}
+                    {e.last_firmware ? ` · fw ${e.last_firmware}` : ''}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/v2/src/components/fleet/webhook-health-banner.tsx
+++ b/v2/src/components/fleet/webhook-health-banner.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+export interface WebhookHealth {
+  source: string;
+  last_24h: number;
+  last_7d: number;
+  errors_24h: number;
+  last_received_at: string | null;
+  distinct_machines_24h: number;
+}
+
+function hoursAgo(iso: string | null) {
+  if (!iso) return null;
+  const ms = Date.now() - new Date(iso).getTime();
+  return Math.max(0, Math.floor(ms / (1000 * 60 * 60)));
+}
+
+export function WebhookHealthBanner({ health }: { health: WebhookHealth[] }) {
+  if (!health || health.length === 0) return null;
+
+  return (
+    <Card className="border-l-4 border-l-blue-500">
+      <CardContent className="py-4">
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <div>
+            <h3 className="text-sm font-semibold mb-1">Webhook receipts (last 24h)</h3>
+            <p className="text-xs text-gray-500">
+              How much telemetry actually landed on our endpoint, regardless of whether
+              it ended up in `usage_logs`. Catches Zapier-side outages early.
+            </p>
+          </div>
+          <div className="flex gap-3 flex-wrap">
+            {health.map((h) => {
+              const last = hoursAgo(h.last_received_at);
+              const isStale = last === null || last > 6;
+              return (
+                <div
+                  key={h.source}
+                  className={`rounded-lg border px-4 py-2 ${
+                    isStale ? 'bg-amber-50 border-amber-200' : 'bg-emerald-50 border-emerald-200'
+                  }`}
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <Badge variant="outline" className="text-xs">{h.source}</Badge>
+                    {isStale && (
+                      <Badge className="bg-amber-100 text-amber-800 text-xs">stale</Badge>
+                    )}
+                  </div>
+                  <div className="text-2xl font-bold">{h.last_24h}</div>
+                  <div className="text-xs text-gray-500">
+                    {h.distinct_machines_24h} unique device(s)
+                    {h.errors_24h > 0 && (
+                      <span className="text-red-700"> · {h.errors_24h} errors</span>
+                    )}
+                  </div>
+                  <div className="text-xs text-gray-400 mt-1">
+                    {last === null ? 'never' : last === 0 ? 'just now' : `${last}h ago`}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/v2/supabase/migrations/20260505000003_fleet_deployments_with_diagnostics.sql
+++ b/v2/supabase/migrations/20260505000003_fleet_deployments_with_diagnostics.sql
@@ -1,0 +1,101 @@
+-- Fleet diagnostics: extend get_all_washing_deployments with firmware version,
+-- last_event_type, and silence cluster classification so the dashboard can
+-- distinguish "real machine that stopped" from "placeholder that never had hardware"
+-- and surface fleet-wide silence patterns.
+--
+-- Replaces the function shipped in 20260505000002. Postgres does not allow
+-- CREATE OR REPLACE to change the return type, so we DROP first.
+
+DROP FUNCTION IF EXISTS get_all_washing_deployments();
+
+CREATE OR REPLACE FUNCTION get_all_washing_deployments()
+RETURNS TABLE (
+  unique_id TEXT,
+  name TEXT,
+  community TEXT,
+  place TEXT,
+  contact_household TEXT,
+  product TEXT,
+  supply_date TIMESTAMPTZ,
+  last_checkin_date TIMESTAMPTZ,
+  asset_status TEXT,
+  machine_id TEXT,
+  has_telemetry_hw BOOLEAN,
+  last_seen_at TIMESTAMPTZ,
+  cycles_7d BIGINT,
+  kwh_7d DOUBLE PRECISION,
+  total_cycle_events BIGINT,
+  last_event_type TEXT,
+  last_firmware TEXT,
+  connectivity_status TEXT
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH telemetry AS (
+    SELECT
+      u.machine_id,
+      MAX(u.created_at) AS last_seen_at,
+      COUNT(*) FILTER (WHERE u.event_type = 'cycle_complete'
+                         AND u.created_at >= now() - INTERVAL '7 days') AS cycles_7d,
+      COALESCE(SUM(u.power_kwh) FILTER (WHERE u.event_type = 'cycle_complete'
+                                          AND u.created_at >= now() - INTERVAL '7 days'), 0) AS kwh_7d,
+      COUNT(*) FILTER (WHERE u.event_type = 'cycle_complete') AS total_cycles
+    FROM usage_logs u
+    WHERE u.machine_id IS NOT NULL
+    GROUP BY u.machine_id
+  ),
+  last_event AS (
+    SELECT DISTINCT ON (u.machine_id)
+      u.machine_id,
+      u.event_type AS last_event_type,
+      u.firmware_version AS last_firmware
+    FROM usage_logs u
+    WHERE u.machine_id IS NOT NULL
+    ORDER BY u.machine_id, u.created_at DESC
+  )
+  SELECT
+    a.unique_id,
+    a.name,
+    COALESCE(a.community, a.place) AS community,
+    a.place,
+    a.contact_household,
+    a.product,
+    a.supply_date,
+    a.last_checkin_date,
+    a.status AS asset_status,
+    a.machine_id,
+    (a.machine_id IS NOT NULL) AS has_telemetry_hw,
+    t.last_seen_at,
+    COALESCE(t.cycles_7d, 0)::BIGINT AS cycles_7d,
+    COALESCE(t.kwh_7d, 0)::DOUBLE PRECISION AS kwh_7d,
+    COALESCE(t.total_cycles, 0)::BIGINT AS total_cycle_events,
+    le.last_event_type,
+    le.last_firmware,
+    CASE
+      WHEN a.machine_id IS NULL AND a.name ILIKE '%pending%'
+        THEN 'pending_assignment'
+      WHEN a.machine_id IS NULL
+        THEN 'no_telemetry_hw'
+      WHEN t.last_seen_at IS NULL
+        THEN 'never_reported'
+      WHEN COALESCE(t.total_cycles, 0) = 0 AND le.last_event_type = 'offline'
+        THEN 'placeholder_only'
+      WHEN t.last_seen_at >= now() - INTERVAL '24 hours'
+        THEN 'reporting'
+      WHEN t.last_seen_at >= now() - INTERVAL '7 days'
+        THEN 'lagging'
+      ELSE 'silent'
+    END AS connectivity_status
+  FROM assets a
+  LEFT JOIN telemetry t ON a.machine_id = t.machine_id
+  LEFT JOIN last_event le ON a.machine_id = le.machine_id
+  WHERE a.product ILIKE '%washing machine%'
+     OR a.product ILIKE '%pakkimjalki%'
+  ORDER BY
+    COALESCE(a.community, a.place) NULLS LAST,
+    a.supply_date DESC NULLS LAST,
+    a.unique_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_all_washing_deployments() TO anon, authenticated, service_role;

--- a/v2/supabase/migrations/20260505000004_webhook_receipts.sql
+++ b/v2/supabase/migrations/20260505000004_webhook_receipts.sql
@@ -1,0 +1,57 @@
+-- Webhook receipts log: capture every incoming POST to /api/webhooks/* so we
+-- can definitively answer "did Zapier hit us in the last 24h?" without
+-- scrolling Vercel logs. The next time the fleet goes silent we want to know
+-- in 60 seconds whether the break is upstream of us or downstream.
+
+CREATE TABLE IF NOT EXISTS webhook_receipts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source TEXT NOT NULL,                  -- 'particle' | 'openfields' | 'stripe' | …
+  received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  status_code INTEGER,                   -- HTTP we returned to the caller
+  event_type TEXT,                       -- parsed event type if available
+  machine_id TEXT,                       -- parsed coreid / machine_id if available
+  body_size INTEGER,                     -- bytes
+  user_agent TEXT,
+  remote_ip TEXT,
+  duplicate BOOLEAN DEFAULT false,
+  error_message TEXT,
+  raw_body JSONB                         -- truncated, optional for debugging
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_receipts_received
+  ON webhook_receipts (received_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_receipts_source_received
+  ON webhook_receipts (source, received_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_receipts_machine
+  ON webhook_receipts (machine_id, received_at DESC) WHERE machine_id IS NOT NULL;
+
+ALTER TABLE webhook_receipts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access on webhook_receipts"
+  ON webhook_receipts FOR ALL
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Authenticated can read webhook_receipts"
+  ON webhook_receipts FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- Convenience: how many webhooks have arrived per source per day, last 14 days
+CREATE OR REPLACE VIEW webhook_receipts_daily AS
+SELECT
+  DATE(received_at) AS day,
+  source,
+  COUNT(*) AS receipts,
+  COUNT(*) FILTER (WHERE status_code BETWEEN 200 AND 299) AS ok,
+  COUNT(*) FILTER (WHERE status_code >= 400) AS errors,
+  COUNT(*) FILTER (WHERE duplicate) AS duplicates,
+  COUNT(DISTINCT machine_id) FILTER (WHERE machine_id IS NOT NULL) AS distinct_machines
+FROM webhook_receipts
+WHERE received_at >= now() - INTERVAL '14 days'
+GROUP BY DATE(received_at), source
+ORDER BY day DESC, source;
+
+GRANT SELECT ON webhook_receipts_daily TO anon, authenticated, service_role;

--- a/v2/supabase/migrations/20260505000005_machine_monthly_activity.sql
+++ b/v2/supabase/migrations/20260505000005_machine_monthly_activity.sql
@@ -1,0 +1,24 @@
+-- Per-machine monthly activity histogram, used by the investigation cards on
+-- /admin/fleet to show whether each machine's death was sudden or gradual.
+
+CREATE OR REPLACE FUNCTION get_machine_monthly_activity()
+RETURNS TABLE (
+  machine_id TEXT,
+  month_start DATE,
+  events BIGINT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    u.machine_id,
+    DATE_TRUNC('month', u.created_at)::DATE AS month_start,
+    COUNT(*)::BIGINT AS events
+  FROM usage_logs u
+  WHERE u.machine_id IS NOT NULL
+    AND u.created_at >= now() - INTERVAL '12 months'
+    AND u.event_type IN ('cycle_complete', 'heartbeat')
+  GROUP BY u.machine_id, DATE_TRUNC('month', u.created_at);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION get_machine_monthly_activity() TO anon, authenticated, service_role;


### PR DESCRIPTION
## Summary

Surfaces the full diagnostic story on /admin/fleet so per-machine investigation can happen on the dashboard without reading docs.

- **Pipeline Health Diagram** — 5-stage horizontal flow with health per stage. Detects staggered device-side failure (one device alive, others dead) and explains it.
- **Silence Timeline** — bar chart of every machine that has ever reported, sorted most-recent-first.
- **Webhook Receipts Banner** — last-24h receipts per source, with stale flag if >6h since last hit.
- **Per-Machine Investigation Cards** — inferred cause heuristic, 12-month sparkline, 4-step investigation checklist.
- **Particle Cloud diagnostic endpoint** + CLI tool for token-based device verdicts.

Migrations `20260505000003` (deployments+diagnostics), `20260505000004` (webhook_receipts), `20260505000005` (monthly_activity) already applied to v2 Supabase.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] /admin/fleet renders 200 locally with all new sections
- [x] Investigation cards collapsible, sparklines render with real data
- [ ] Verify on prod after deploy