### PR TITLE
feat(admin/production): v3 cost-model scenarios card (Idiot Index + founder allocation + fundraising offset)

### DIFF
--- a/thoughts/shared/handoffs/network-consolidation/current.md
+++ b/thoughts/shared/handoffs/network-consolidation/current.md
@@ -1,66 +1,61 @@
 ---
-date: 2026-05-27T17:30:00+10:00
-session_name: uncommitted-work-landing-and-cleanup
-branch: fix/funder-figures-reconciliation
-status: in-progress
+date: 2026-05-28T11:45:00+10:00
+session_name: sponsor-system-improvements-and-production-deploy
+branch: main
+status: shipped
 ---
 
 # Goods on Country — Handoff Ledger
 
 ## Ledger
-**Updated:** 2026-05-27T17:30:00+10:00
-**Goal:** Land the accumulated uncommitted work (9 days, 18 tracked files + several untracked features) into clean, atomic commits; apply the one outstanding DB migration; clean the working tree.
-**Branch:** `fix/funder-figures-reconciliation` (now holds the feature commits below — name no longer matches contents; rename or cherry-pick before merging to main)
-**Test:** `cd v2 && npm run dev`; `cd v2 && npm run build` is clean (exit 0, 232/232 pages)
+**Updated:** 2026-05-28T11:45:00+10:00
+**Goal:** Improve the Sponsor-a-Bed system — confirm Stripe tracking, build the sponsor journey, fix the broken/confusing product image, add a newsletter + comms funnel — then ship to production.
+**Branch:** `main` (all work merged + deployed; feature branches deleted)
+**Test:** `cd v2 && npm run build` clean (exit 0, 231/231 pages). Production verified live.
 
 ### Now
-[->] Decide branch disposition (rename `fix/funder-figures-reconciliation` → something like `feat/site-media-tooling-and-sponsor` OR split), then push. Nothing has been pushed yet.
+[->] Nothing blocking. Sponsor system shipped to prod. Optional: see Next.
 
-### This Session (2026-05-27)
+### This Session (2026-05-28)
 
-Worked through the uncommitted pile one thread at a time, verifying each (typecheck + render + dependency tracing) before committing.
+Picked up from the screenshot of the live `/sponsor` page (old two-card layout, product image looked like a washing machine). Found the redesigned flow already existed in code but was undeployed; improved it, fixed the image, added the comms funnel, and shipped everything to production.
 
-**Commits landed (all local, none pushed):**
-- `b627323` home: self-serve media swap + Oonchiumpa "designed in community" section + picker LIST API website-images/cross-project support
-- `6e9e93d` sponsor: redesigned flow + dedication messages (success page shows sponsorship timeline)
-- `9860b50` assets: outcome capture (household_size, theme_tag, recipient_consent_at) + 2 migrations
-- `ced0235` admin-orders: surface sponsorship dedications for fulfilment
-- `65d781e` partners: live funder outcomes snapshot (`/partners/[slug]/outcomes`) + Centrecorp reconciliation (no dollar headline, provenance sidecar)
-- `1f099f0` process: media swap on production-flow steps
-- `3e30fe4` admin: photo browser for cross-project EL media
-- `e49df98` partners: Oonchiumpa partnership page
-- `80787a5` admin: bulk install logger (EXIF/QR/HEIC) + 4 image libs
-- `2034d43` scripts: EL tag-bridging + GHL LinkedIn-tag migration
-- (plus this cleanup: partner public assets, wiki docs, batch PDFs, .gitignore)
+**Shipped to production (`www.goodsoncountry.com`), all verified live:**
+- **PR #27** merged → prod (`d67cbd8`): the whole accumulated feature branch — sponsor redesign, funder-outcomes pages, Oonchiumpa partner page, admin bulk install logger + photo browser, asset outcome-capture, media-swap tooling.
+- **PR #28** merged → prod (`b00b11b`): checkout route now builds an absolute Stripe product-image URL from the relative path.
+- **Newsletter / comms funnel** (`7f8fad7`): `/checkout/success` opt-in card (sponsor/buyer-aware, email prefilled from checkout) + `/sponsor` "not ready today?" capture for non-converters. Tags `goods-newsletter` + `goods-src-sponsor`/`-customer`/`-sponsor-interest`, fires GHL Smart Router. Explicit marketing consent, separate from the transactional contact the Stripe webhook already creates.
+- **Sponsor page enrichment** (`a85292c`): hero band (Elder beside her bed) + 3-up "this is where your bed lands" gallery (built → assembled → in use). Five distinct real photos now carry the page.
 
-**DB migration APPLIED to live v2 DB (`cwsyhpiuepvdjtxaozwf`):**
-- `20260519000001_assets_outcome_fields.sql` — added household_size, theme_tag, recipient_consent_at; rebuilt `community_rollup` with household_reach + households_with_consent. Was untracked AND unapplied; its `CREATE OR REPLACE VIEW` would have failed (mid-list column insert) — fixed to DROP+CREATE. Applied via Supabase Management API query endpoint (psql had no cached password). Verified: columns live, view rebuilt, PostgREST sees them.
-- `20260520000001_assets_recipient_and_install_photo.sql` — was already applied to DB, just never committed. Now in git.
+**Product image fix (DB, live immediately — no deploy needed):**
+- `products.featured_image` for `stretch-bed-single` was `…IMG_6976.jpg` — a recycled-plastic block at sunset that read as a washing machine. Changed to `/images/product/stretch-bed-hero.jpg` (a clean bed shot). Fixes sponsor page, shop, and the old prod page at once.
+- First tried an absolute `https://www.goodsoncountry.com/...` URL → `next/image` blocked it (domain not in `remotePatterns`) → broken image on the preview. Switched to a **relative path** (local `/public` asset, served same-origin, no whitelist needed).
 
-**Bugs fixed in passing:**
-- `/partners/[slug]/outcomes` 500 → Server Component passed `onClick`; extracted `print-button.tsx` client island.
-- Latent untracked-import/asset traps: `partners.ts`, outcomes page, photos-browser, oonchiumpa page, and 3 `v2/public` assets (final-assembly.jpg, elder-feedback.jpg, oochiumpa-good-news-story.pdf) were untracked but linked-to by committed code. All committed with their dependents.
+**Stripe tracking — verified already complete (no change needed):**
+- Webhook writes `is_sponsorship` / `sponsored_community` / `sponsor_message` to `orders` and creates a GHL `goods-sponsor` contact. `/checkout/success` branches messaging on the order.
 
-**Working tree cleanup:**
-- Deleted dead `v2/src/app/brand/page.tsx` (shadowed by committed `/brand → /press#brand-system` redirect; wordmark pack lives in /press).
-- Extended `.gitignore` for ~285 root-level scratch screenshots + source-media dumps (Utpoia Photos Export/, QR folders, Story images/, *.zip). Real assets live in v2/public; source photos go to EL.
+**Cleanup:** deleted merged branches `feat/site-media-tooling-and-funder-outcomes` + `fix/stripe-checkout-product-image` (local + remote). Now on `main`.
 
 ### Next
-- [ ] Branch rename/split + push.
-- [ ] `v2/src/app/brand/page.tsx` is gone — if a standalone /brand page is ever wanted again, drop the redirect at `next.config.ts:58` first.
-- [ ] Sponsor page is a 661-line visual redesign — eyeball `/sponsor` to confirm the look.
-- [ ] Provenance doc for the Centrecorp one-pager still cites the now-stale "$388,432 invoiced / $265,100 outstanding" internally (page itself is dollar-free by design). Reconcile against live Notion/Xero if that internal table matters.
+- [ ] Eyeball production `/sponsor` end-to-end (hero, gallery, newsletter capture). A real Stripe checkout is needed to see the success-page newsletter card + Stripe thumbnail.
+- [ ] Field-notes `/field-notes/utopia-may-2026` still `published: false` (Gate C unmet — carried).
+- [ ] Centrecorp one-pager provenance doc still cites stale "$388,432 invoiced / $265,100 outstanding" internally (page itself is dollar-free — carried).
 
 ### Decisions (this session)
-- One-by-one verify-then-commit beats bulk-commit: caught a 500, a broken migration, and 5+ latent untracked deps that bulk `git add` would have buried.
-- DDL on v2 production goes through psql/Management API, never the Supabase MCP (wrong project) or exec_sql RPC (no DDL).
-- Root-level images in this repo are always scratch → gitignored broadly (`/*.png` etc.); no tracked root images exist.
+- **`next/image` blocks remote domains not in `remotePatterns`.** For local `/public` assets, use **relative paths** (served same-origin, no whitelist). When an absolute URL is needed downstream (Stripe needs one), build it at that boundary from the request origin — don't churn the DB or whitelist a same-origin domain.
+- Image fix went straight to the DB (Tier-2 write, user-authorised via the image-choice question) — DB-driven, so live without a deploy.
+- Shipped the full accumulated PR #27 as one merge (clean fast-forward, 0 behind main); DB migrations it relies on were already applied, so it was a code-only deploy.
 
 ### Carried over (still load-bearing)
 - COGS per Stretch Bed = $149.20; price unified to $750.
-- Communities are first-class DB entities; `community_rollup` view is canonical (now extended with household reach + consent).
-- Field-notes `/field-notes/utopia-may-2026` still `published: false` — prior session's publish gate (Gate C: Oonchiumpa end-to-end review) not yet met. Self-serve picker work from that session is unaffected.
+- Communities are first-class DB entities; `community_rollup` view is canonical (extended with household reach + consent).
+- Production deploys from `main` → Vercel project `goods-on-country` (`prj_XGQL3gT1C6N7BolooQevgMJuIf1G`, team `team_3aAWFPdRQ92RkkJ2LehJ209u`). Preview URLs are behind Vercel SSO (curl gets 401; open in a logged-in browser).
 
 ### Open Questions (carried)
 - UNCONFIRMED: 3 paraphrased field-notes voice quotes need real Oonchiumpa attribution before publish.
 - UNCONFIRMED: Centrecorp tranche re-attribution (Snow vs Centrecorp for May deployment) — confirm with Nic.
+
+---
+
+## Prior Session (2026-05-27) — uncommitted-work-landing-and-cleanup
+
+Landed 9 days of accumulated uncommitted work into clean atomic commits (later merged via PR #27 above), applied the outstanding `20260519000001_assets_outcome_fields.sql` migration to the live v2 DB (fixed its `CREATE OR REPLACE VIEW` → DROP+CREATE), and cleaned the working tree. Key commits: sponsor redesign (`6e9e93d`), asset outcome capture (`9860b50`), funder outcomes snapshot (`65d781e`), Oonchiumpa partner page (`e49df98`), admin bulk install logger (`80787a5`). Deleted dead `v2/src/app/brand/page.tsx` (redirect lives at `next.config.ts`). Extended `.gitignore` for root scratch screenshots.

--- a/v2/src/app/admin/production/page.tsx
+++ b/v2/src/app/admin/production/page.tsx
@@ -7,6 +7,7 @@ import { ProductionTrendChart } from '@/components/production/production-trend-c
 import { SupplyDemandCard, type CommittedOrder, type SupplierQuote } from '@/components/production/supply-demand-card';
 import { BedReconciliation, type AssetSummary, type DemandSummary } from '@/components/production/bed-reconciliation';
 import { CostPerBatchCard, type BatchSummary } from '@/components/production/cost-per-batch-card';
+import { CostModelScenariosCard } from '@/components/production/cost-model-scenarios-card';
 import { fullyLoadedCostPerBed } from '@/lib/data/supplier-quotes';
 import { getSupplierActuals } from '@/lib/data/supplier-cost-actuals';
 import type { ProductionInventory, ProductionShift, ProductionJournal } from '@/lib/types/database';
@@ -337,6 +338,9 @@ export default async function AdminProductionPage() {
 
       {/* Cost per bed + per batch (BOM-driven from supplier-quotes.ts + Xero ACCPAY actuals) */}
       <CostPerBatchCard batches={batchSummary} actuals={supplierActuals} bedsLifetime={bedsLifetime} />
+
+      {/* v3 cost model — scenarios + Idiot Index + founder allocation + fundraising offset */}
+      <CostModelScenariosCard />
 
       {/* Bed Reconciliation */}
       <BedReconciliation data={{

--- a/v2/src/components/production/cost-model-scenarios-card.tsx
+++ b/v2/src/components/production/cost-model-scenarios-card.tsx
@@ -1,0 +1,248 @@
+/**
+ * Cost-model scenarios card: 5 build-states × 3 volume scenarios + Idiot
+ * Index + founder allocation + fundraising offset. Mounted on the
+ * /admin/production page below the CostPerBatchCard. Source data lives in
+ * `lib/data/cost-model-scenarios.{ts,json}` and reconciles against the
+ * canonical BOM in `lib/data/supplier-quotes.ts`.
+ */
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  listBuildStates,
+  getIdiotIndex,
+  getVolumeScenarios,
+  getFounderAllocation,
+  getFundraisingOffset,
+  reconcileAgainstCanonicalBOM,
+  fmtMoney,
+} from '@/lib/data/cost-model-scenarios';
+
+const BUILD_STATE_BADGES: Record<string, string> = {
+  state_1_defy_everything: 'bg-gray-100 text-gray-800 border-gray-300',
+  state_2_buy_kit_assemble: 'bg-blue-50 text-blue-700 border-blue-300',
+  state_3_buy_sheets_cut_assemble: 'bg-amber-50 text-amber-700 border-amber-300',
+  state_4_all_in_house: 'bg-emerald-50 text-emerald-700 border-emerald-300',
+  state_5_community_plastic: 'bg-purple-50 text-purple-700 border-purple-300',
+};
+
+function idiotIndexClass(indexHigh: number): string {
+  if (indexHigh >= 5) return 'text-red-700 font-semibold';
+  if (indexHigh >= 3) return 'text-orange-600 font-semibold';
+  if (indexHigh >= 2) return 'text-blue-700';
+  return 'text-gray-600';
+}
+
+function allocationClass(target: string): string {
+  if (target === 'bed-overhead') return 'bg-red-50 text-red-700 border-red-300';
+  if (target === 'funding-side-offset') return 'bg-emerald-50 text-emerald-700 border-emerald-300';
+  return 'bg-gray-100 text-gray-700 border-gray-300';
+}
+
+export function CostModelScenariosCard() {
+  const buildStates = listBuildStates();
+  const idiotIndex = getIdiotIndex();
+  const volumeScenarios = getVolumeScenarios();
+  const founderAllocation = getFounderAllocation();
+  const fundraisingOffset = getFundraisingOffset();
+  const reconciliation = reconcileAgainstCanonicalBOM();
+
+  const totalFounderDays = founderAllocation.split.reduce((sum, s) => sum + s.days, 0);
+  const totalFounderCost = totalFounderDays * founderAllocation.rate_per_day;
+
+  return (
+    <Card>
+      <CardContent className="pt-6 space-y-8">
+        <div>
+          <h3 className="text-lg font-semibold">Cost model — scenarios, Idiot Index, founder allocation</h3>
+          <p className="text-xs text-gray-500 mt-1">
+            Verified from Defy invoice OCR (act-infra <code>scripts/ocr-defy-bills.mjs</code>). Reconciled against the
+            canonical BOM in <code>supplier-quotes.ts</code>. Numbers reflect verified Defy quote rates as of 2026-05-28.
+          </p>
+          {!reconciliation.matches && (
+            <div className="mt-2 inline-flex items-center gap-2 rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800">
+              ⚠ Drift: State-1 total {fmtMoney(reconciliation.state1Total)} vs canonical {fmtMoney(reconciliation.canonicalFullyLoaded)} — keep these aligned.
+            </div>
+          )}
+        </div>
+
+        {/* Volume scenarios */}
+        <div>
+          <h4 className="text-sm font-semibold mb-3">Volume scenarios — today → target → vision</h4>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-left text-gray-500 border-b">
+                <tr>
+                  <th className="pb-2 font-medium">Scenario</th>
+                  <th className="pb-2 font-medium text-right">Direct (S1)</th>
+                  <th className="pb-2 font-medium text-right">Direct (S4)</th>
+                  <th className="pb-2 font-medium text-right">Direct (S5)</th>
+                  <th className="pb-2 font-medium text-right">Founder</th>
+                  <th className="pb-2 font-medium text-right">Admin</th>
+                  <th className="pb-2 font-medium text-right">Field</th>
+                  <th className="pb-2 font-medium text-right">Freight</th>
+                  <th className="pb-2 font-medium text-right">Full S1</th>
+                  <th className="pb-2 font-medium text-right">Full S4</th>
+                  <th className="pb-2 font-medium text-right">Full S5</th>
+                </tr>
+              </thead>
+              <tbody>
+                {volumeScenarios.map((vs, i) => {
+                  const s1 = buildStates.find((b) => b.key === 'state_1_defy_everything')!.direct_total;
+                  const s4 = buildStates.find((b) => b.key === 'state_4_all_in_house')!.direct_total;
+                  const s5 = buildStates.find((b) => b.key === 'state_5_community_plastic')!.direct_total;
+                  return (
+                    <tr key={vs.label} className={`border-b last:border-0 ${i === 1 ? 'bg-emerald-50/40' : ''}`}>
+                      <td className="py-2 font-medium">{vs.label}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtMoney(s1)}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtMoney(s4)}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtMoney(s5)}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtMoney(vs.production_founder_per_bed)}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtMoney(vs.admin_per_bed)}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtMoney(vs.field_travel_per_bed)}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtMoney(vs.freight_per_bed)}</td>
+                      <td className="py-2 text-right tabular-nums font-medium">{fmtMoney(vs.fully_loaded_state_1)}</td>
+                      <td className="py-2 text-right tabular-nums font-medium text-emerald-700">{fmtMoney(vs.fully_loaded_state_4)}</td>
+                      <td className="py-2 text-right tabular-nums font-medium text-purple-700">{fmtMoney(vs.fully_loaded_state_5)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <p className="text-xs text-gray-500 mt-2">
+            Counterfactual commercial steel-frame bed AU 2026: $1,500–$2,000. S1 today already competitive at volume; S4 at 500/yr beats commercial by 2–3×.
+          </p>
+        </div>
+
+        {/* Build states */}
+        <div>
+          <h4 className="text-sm font-semibold mb-3">Build states — Defy-everything → community-plastic in-house</h4>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-3">
+            {buildStates.map((state) => (
+              <div key={state.key} className="border rounded p-3 text-sm">
+                <Badge variant="outline" className={BUILD_STATE_BADGES[state.key]}>
+                  {state.label.split('(')[0].trim().slice(0, 30)}
+                </Badge>
+                <div className="mt-2 text-lg font-semibold tabular-nums">{fmtMoney(state.direct_total)}</div>
+                <div className="mt-1 text-xs text-gray-500">direct cost / bed</div>
+                <div className="mt-3 text-xs space-y-1">
+                  {state.components.map((c) => (
+                    <div key={c.label} className="flex justify-between gap-2">
+                      <span className="text-gray-600 truncate" title={c.label}>{c.label}</span>
+                      <span className="tabular-nums text-gray-800">{fmtMoney(c.amount)}</span>
+                    </div>
+                  ))}
+                </div>
+                {state.capital_added > 0 && (
+                  <div className="mt-3 pt-2 border-t text-xs text-gray-500">
+                    + {fmtMoney(state.capital_added)} capex (cumul. {fmtMoney(state.capital_cumulative)})
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Idiot Index */}
+        <div>
+          <h4 className="text-sm font-semibold mb-3">Idiot Index — where Defy's markup actually is</h4>
+          <p className="text-xs text-gray-500 mb-3">
+            Ratio of what we pay over the raw-material cost. Biggest ratios = biggest in-house opportunities.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-left text-gray-500 border-b">
+                <tr>
+                  <th className="pb-2 font-medium">Element</th>
+                  <th className="pb-2 font-medium text-right">Raw</th>
+                  <th className="pb-2 font-medium text-right">We pay</th>
+                  <th className="pb-2 font-medium text-right">Index</th>
+                  <th className="pb-2 font-medium">Markup pays for</th>
+                </tr>
+              </thead>
+              <tbody>
+                {idiotIndex.map((row) => {
+                  const rawDisplay =
+                    row.raw_low === row.raw_high
+                      ? fmtMoney(row.raw_low)
+                      : `${fmtMoney(row.raw_low)}–${fmtMoney(row.raw_high)}`;
+                  const indexDisplay =
+                    row.index_low === row.index_high
+                      ? `${row.index_low.toFixed(1)}×`
+                      : `${row.index_low.toFixed(1)}–${row.index_high.toFixed(1)}×`;
+                  return (
+                    <tr key={row.element} className="border-b last:border-0">
+                      <td className="py-2 font-medium">{row.element}</td>
+                      <td className="py-2 text-right tabular-nums text-gray-600">{rawDisplay}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtMoney(row.current)}</td>
+                      <td className={`py-2 text-right tabular-nums ${idiotIndexClass(row.index_high)}`}>{indexDisplay}</td>
+                      <td className="py-2 text-xs text-gray-600">{row.markup_pays_for}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Founder allocation + Fundraising offset */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div>
+            <h4 className="text-sm font-semibold mb-3">Founder time — properly allocated</h4>
+            <p className="text-xs text-gray-500 mb-3">
+              {totalFounderDays} days × ${founderAllocation.rate_per_day}/day = {fmtMoney(totalFounderCost)} modelled. Only production-related days go on beds.
+            </p>
+            <div className="space-y-2">
+              {founderAllocation.split.map((entry) => (
+                <div key={entry.label} className="border rounded p-3 text-sm">
+                  <div className="flex justify-between items-start gap-2">
+                    <div className="text-xs text-gray-700 flex-1">{entry.label}</div>
+                    <Badge variant="outline" className={allocationClass(entry.allocate_to)}>
+                      {entry.allocate_to.replaceAll('-', ' ')}
+                    </Badge>
+                  </div>
+                  <div className="mt-2 flex justify-between text-xs">
+                    <span className="text-gray-500">{entry.days} days × ${founderAllocation.rate_per_day}/day</span>
+                    <span className="tabular-nums font-medium">{fmtMoney(entry.annual_cost)}</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h4 className="text-sm font-semibold mb-3">Fundraising offset</h4>
+            <p className="text-xs text-gray-500 mb-3">
+              Every $1 raised funds a bed PLUS capex toward the in-house target.
+            </p>
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              <div className="border rounded p-3">
+                <div className="text-xs text-gray-500">Philanthropy</div>
+                <div className="mt-1 text-lg font-semibold tabular-nums">{fmtMoney(fundraisingOffset.philanthropy_annual_estimate)}</div>
+                <div className="mt-1 text-xs text-gray-600">{fundraisingOffset.philanthropy_days_per_year} founder-days/yr × ~$5K/day</div>
+              </div>
+              <div className="border rounded p-3">
+                <div className="text-xs text-gray-500">Commercial buyer</div>
+                <div className="mt-1 text-lg font-semibold tabular-nums">{fmtMoney(fundraisingOffset.commercial_buyer_benchmark_per_bed)} / bed</div>
+                <div className="mt-1 text-xs text-gray-600">{fundraisingOffset.commercial_buyer_source}</div>
+              </div>
+              <div className="border rounded p-3 border-emerald-300 bg-emerald-50">
+                <div className="text-xs text-emerald-700">Subsidy @ 100/yr</div>
+                <div className="mt-1 text-lg font-semibold tabular-nums text-emerald-700">{fmtMoney(fundraisingOffset._per_bed_subsidy_at_100_per_year)} / bed</div>
+              </div>
+              <div className="border rounded p-3 border-emerald-300 bg-emerald-50">
+                <div className="text-xs text-emerald-700">Subsidy @ 500/yr</div>
+                <div className="mt-1 text-lg font-semibold tabular-nums text-emerald-700">{fmtMoney(fundraisingOffset._per_bed_subsidy_at_500_per_year)} / bed</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <p className="text-xs text-gray-400 pt-4 border-t">
+          Open questions for Defy: volume-quote sheet (100/500/1000/5000 beds/yr); build-to-supply pricing if ACT sources steel + canvas direct; in-house assembly payback volume; sheets/bed confirmation (currently 20kg HDPE/bed locked).
+          Source: <code>act-infra/thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json</code>
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/v2/src/lib/data/cost-model-scenarios.json
+++ b/v2/src/lib/data/cost-model-scenarios.json
@@ -1,0 +1,246 @@
+{
+  "meta": {
+    "title": "Goods bed cost model v3 — element-by-element with Idiot Index",
+    "created": "2026-05-28",
+    "source_doc": "thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3-idiot-index.md",
+    "verified_from": "thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json"
+  },
+  "physics": {
+    "hdpe_density_g_per_cm3": 0.96,
+    "half_sheet_dims_cm": [120, 120, 1.9],
+    "half_sheet_mass_kg": 26.27,
+    "hdpe_kg_per_bed": 20,
+    "_hdpe_per_bed_source": "Ben confirmed 2026-05-28 — 20kg of HDPE per finished bed (~76% of one half-sheet; the rest is offcuts/press loss).",
+    "raw_hdpe_cost_per_bed": 40.00,
+    "half_sheets_per_bed_equivalent": 0.76
+  },
+  "defy_verified_rates": {
+    "single_bed_fully_fabricated": { "amount": 600.00, "source": "INV-1507 Nov 2025, 25 beds", "confidence": "verified" },
+    "bed_kit_cut_finished": { "amount": 344.05, "source": "INV-1602 (92 kits) + 2026-03-27 (50 kits)", "confidence": "verified" },
+    "cut_and_finish_only": { "amount": 121.00, "source": "INV-1602 (16 beds, pre-purchased sheets)", "confidence": "verified" },
+    "assembly_labour": { "amount": 55.95, "source": "2026-03-19 (8 beds, exact line)", "confidence": "verified" },
+    "half_sheet_bulk_price": { "amount": 200.00, "source": "2026-03-27 (20 sheets bulk discount)", "confidence": "verified" },
+    "hdpe_shred_per_kg": { "amount": 2.00, "source": "2026-03-27 (1200kg bulk bags)", "confidence": "verified" },
+    "worker_day_rate_full": { "amount": 480.00, "source": "INV-1325/1326 (Sam, Todd)", "confidence": "verified" },
+    "worker_day_rate_half": { "amount": 240.00, "source": "INV-1325/1326", "confidence": "verified" },
+    "freight_botany_to_alice_per_pallet_low": { "amount": 808.00, "source": "Multiple Defy freight lines", "confidence": "verified" },
+    "freight_botany_to_alice_per_pallet_high": { "amount": 1480.00, "source": "Multiple Defy freight lines", "confidence": "verified" },
+    "beds_per_pallet_typical": 8
+  },
+  "raw_material_estimates_au_2026": {
+    "hdpe_shred_per_kg": 2.00,
+    "canvas_per_m2_estimate": 17.00,
+    "canvas_m2_per_bed_estimate": 4.0,
+    "steel_per_bed_raw_estimate": 12.00,
+    "end_caps_per_bed_raw_estimate": 0.75
+  },
+  "notion_bom_verified": {
+    "hdpe_kit": { "amount": 344.05, "confidence": "verified", "matches_defy": true },
+    "canvas": { "amount": 93.50, "confidence": "inferred", "matches_defy": "bundled in $600 single bed" },
+    "assembly_labour": { "amount": 55.95, "confidence": "verified", "matches_defy": true },
+    "steel": { "amount": 27.00, "confidence": "inferred", "matches_defy": "bundled" },
+    "end_caps": { "amount": 3.20, "confidence": "inferred", "matches_defy": "bundled" },
+    "direct_total": 523.70
+  },
+  "in_house_estimates": {
+    "sheet_pressing_per_bed": { "amount": 40.00, "basis": "Hot-press energy + machine wear, no labour amortising capital yet", "confidence": "modelled" },
+    "cnc_cut_finish_per_bed": { "amount": 60.00, "basis": "1hr × $60/hr (operator + machine amortised)", "confidence": "modelled" },
+    "shredding_in_house_per_bed": { "amount": 10.00, "basis": "Energy + machine wear at scale", "confidence": "modelled" },
+    "wash_sort_dry_per_bed": { "amount": 20.00, "basis": "Labour line for community-collected plastic", "confidence": "modelled" },
+    "internal_assembly_labour_per_bed": { "amount": 46.67, "basis": "6 beds/day × $280/day award + super C13", "confidence": "modelled" },
+    "internal_assembly_labour_fair_market_per_bed": { "amount": 67.17, "basis": "6 beds/day × $403/day fair-market skilled fabricator", "confidence": "modelled" }
+  },
+  "wage_scenarios": [
+    { "label": "Award C13 (entry fabricator)", "hourly": 26, "daily_8hr": 208, "daily_with_super": 233, "beds_per_day": 6, "per_bed": 38.83 },
+    { "label": "Award C10 (mid-skilled)", "hourly": 32, "daily_8hr": 256, "daily_with_super": 287, "beds_per_day": 6, "per_bed": 47.83 },
+    { "label": "Fair-market skilled trade", "hourly": 45, "daily_8hr": 360, "daily_with_super": 403, "beds_per_day": 6, "per_bed": 67.17 },
+    { "label": "Indigenous community wage + cultural loading", "hourly": 35, "daily_8hr": 280, "daily_with_super": 314, "beds_per_day": 6, "per_bed": 52.33 }
+  ],
+  "community_plastic_pay_scenarios": [
+    { "label": "Bottom (kerbside-equivalent)", "per_kg": 0.20, "kg_per_bed": 40, "per_bed": 8.00 },
+    { "label": "Mid (community-coop rate)", "per_kg": 0.50, "kg_per_bed": 40, "per_bed": 20.00 },
+    { "label": "Premium (ocean/remote story-value)", "per_kg": 1.00, "kg_per_bed": 40, "per_bed": 40.00 },
+    { "label": "High (clean sorted, remote community)", "per_kg": 2.00, "kg_per_bed": 40, "per_bed": 80.00 }
+  ],
+  "build_states": {
+    "state_1_defy_everything": {
+      "label": "Defy does everything (today, INV-1507)",
+      "components": [
+        { "label": "Single Bed fully fabricated", "amount": 600.00 }
+      ],
+      "direct_total": 600.00,
+      "capital_added": 0,
+      "capital_cumulative": 0
+    },
+    "state_2_buy_kit_assemble": {
+      "label": "Buy Defy kit, assemble in-house",
+      "components": [
+        { "label": "Defy bed kit (sheets cut+finished)", "amount": 344.05 },
+        { "label": "Canvas (RW Pacific or via Defy)", "amount": 93.50 },
+        { "label": "Steel poles", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "In-house assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 514.42,
+      "capital_added": 2000,
+      "capital_cumulative": 2000
+    },
+    "state_3_buy_sheets_cut_assemble": {
+      "label": "Buy pressed sheets, cut+finish+assemble in-house",
+      "components": [
+        { "label": "1.5 half-sheets from Defy @ $200", "amount": 300.00 },
+        { "label": "In-house CNC cut + finish", "amount": 60.00 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "Steel", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "Assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 530.37,
+      "capital_added": 38000,
+      "capital_cumulative": 40000
+    },
+    "state_4_all_in_house": {
+      "label": "Buy raw HDPE shred, do everything in-house",
+      "components": [
+        { "label": "HDPE shred 20kg @ $2/kg (Ben confirmed)", "amount": 40.00 },
+        { "label": "In-house sheet pressing", "amount": 40.00 },
+        { "label": "In-house CNC cut + finish", "amount": 60.00 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "Steel", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "Assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 310.37,
+      "capital_added": 160000,
+      "capital_cumulative": 200000
+    },
+    "state_5_community_plastic": {
+      "label": "Community-collected plastic + all in-house (vision)",
+      "components": [
+        { "label": "Community plastic pay @ $1/kg × 20kg", "amount": 20.00 },
+        { "label": "Wash + dry + sort", "amount": 20.00 },
+        { "label": "In-house shredding", "amount": 10.00 },
+        { "label": "In-house sheet pressing", "amount": 40.00 },
+        { "label": "In-house CNC + finish", "amount": 60.00 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "Steel", "amount": 27.00 },
+        { "label": "End caps + hardware", "amount": 3.20 },
+        { "label": "Assembly labour", "amount": 46.67 }
+      ],
+      "direct_total": 320.37,
+      "capital_added": 30000,
+      "capital_cumulative": 230000,
+      "community_jobs_created": true
+    }
+  },
+  "idiot_index": [
+    { "element": "HDPE shred → finished kit", "raw_low": 40.00, "raw_high": 40.00, "current": 344.05, "index_low": 8.6, "index_high": 8.6, "markup_pays_for": "Shredding, sheet pressing, CNC cutting, finishing, Defy margin. BIGGEST LEVERAGE in the model.", "raw_basis": "20kg HDPE × $2/kg (Ben confirmed 2026-05-28)" },
+    { "element": "Half-sheet (1200×1200×19mm)", "raw_low": 52.55, "raw_high": 52.55, "current": 200.00, "index_low": 3.8, "index_high": 3.8, "markup_pays_for": "Hot-press machine time, energy, Defy margin" },
+    { "element": "Cut+finish only", "raw_low": 30.00, "raw_high": 60.00, "current": 121.00, "index_low": 2.0, "index_high": 4.0, "markup_pays_for": "CNC operator + machine time + Defy margin" },
+    { "element": "Assembly labour (Defy)", "raw_low": 52.00, "raw_high": 52.00, "current": 55.95, "index_low": 1.1, "index_high": 1.1, "markup_pays_for": "Already efficient — small Defy margin" },
+    { "element": "Steel (frame + caps)", "raw_low": 10.00, "raw_high": 15.00, "current": 27.00, "index_low": 1.8, "index_high": 2.7, "markup_pays_for": "Cut to length, drill, deliver" },
+    { "element": "Canvas", "raw_low": 45.00, "raw_high": 68.00, "current": 93.50, "index_low": 1.4, "index_high": 2.1, "markup_pays_for": "Cut, hem, grommet, RW Pacific margin" },
+    { "element": "End caps / fittings", "raw_low": 0.50, "raw_high": 1.00, "current": 3.20, "index_low": 3.2, "index_high": 6.4, "markup_pays_for": "Bulk-buy supplier margin" },
+    { "element": "Pallet + packing", "raw_low": 30.00, "raw_high": 50.00, "current": 60.00, "index_low": 1.2, "index_high": 2.0, "markup_pays_for": "Labour + packing materials" }
+  ],
+  "founder_time_allocation": {
+    "rate_per_day": 1000,
+    "total_days_per_year_on_goods": 150,
+    "split": [
+      { "label": "Production-related (oversight, QA, design iteration, supplier rel.)", "days": 30, "annual_cost": 30000, "allocate_to": "bed-overhead" },
+      { "label": "Fundraising / philanthropy (briefs, asks, reporting, donor rel.)", "days": 50, "annual_cost": 50000, "allocate_to": "funding-side-offset" },
+      { "label": "Commercialisation / buyer dev (Centrecorp, councils, sales)", "days": 25, "annual_cost": 25000, "allocate_to": "funding-side-offset" },
+      { "label": "Governance, strategy, comms, brand", "days": 45, "annual_cost": 45000, "allocate_to": "act-wide-overhead" }
+    ],
+    "_principle": "Only production-related founder time goes onto beds. The fundraising/commercial portion OFFSETS bed cost via dollars raised; the governance portion is ACT-wide, not Goods-specific."
+  },
+  "volume_scenarios": [
+    {
+      "label": "Today (100 beds/yr)",
+      "beds_per_year": 100,
+      "production_founder_per_bed": 300,
+      "admin_per_bed": 147,
+      "field_travel_per_bed": 510,
+      "freight_per_bed": 150,
+      "fully_loaded_state_1": 1707,
+      "fully_loaded_state_4": 1417,
+      "fully_loaded_state_5": 1427,
+      "_math_state_1": "600 + 150 + 300 + 147 + 510 = 1707",
+      "_math_state_4": "310.37 + 150 + 300 + 147 + 510 = 1417.37",
+      "_math_state_5": "320.37 + 150 + 300 + 147 + 510 = 1427.37"
+    },
+    {
+      "label": "Target (500 beds/yr)",
+      "beds_per_year": 500,
+      "production_founder_per_bed": 60,
+      "admin_per_bed": 29,
+      "field_travel_per_bed": 100,
+      "freight_per_bed": 100,
+      "fully_loaded_state_1": 889,
+      "fully_loaded_state_4": 599,
+      "fully_loaded_state_5": 609,
+      "_math_state_1": "600 + 100 + 60 + 29 + 100 = 889",
+      "_math_state_4": "310.37 + 100 + 60 + 29 + 100 = 599.37",
+      "_math_state_5": "320.37 + 100 + 60 + 29 + 100 = 609.37"
+    },
+    {
+      "label": "Vision (1,000 beds/yr, in-house assembly)",
+      "beds_per_year": 1000,
+      "production_founder_per_bed": 30,
+      "admin_per_bed": 15,
+      "field_travel_per_bed": 50,
+      "freight_per_bed": 80,
+      "fully_loaded_state_1": 775,
+      "fully_loaded_state_4": 485,
+      "fully_loaded_state_5": 495,
+      "_math_state_1": "600 + 80 + 30 + 15 + 50 = 775",
+      "_math_state_4": "310.37 + 80 + 30 + 15 + 50 = 485.37",
+      "_math_state_5": "320.37 + 80 + 30 + 15 + 50 = 495.37"
+    }
+  ],
+  "fundraising_offset": {
+    "philanthropy_days_per_year": 50,
+    "philanthropy_dollars_per_founder_day_estimate": 5000,
+    "philanthropy_annual_estimate": 250000,
+    "commercial_sales_days_per_year": 25,
+    "commercial_buyer_benchmark_per_bed": 801,
+    "commercial_buyer_source": "Centrecorp INV-0291 (107 beds @ $85,712)",
+    "_per_bed_subsidy_at_100_per_year": 2500,
+    "_per_bed_subsidy_at_500_per_year": 500,
+    "_principle": "Fundraising days are an INVESTMENT that generates revenue offsetting bed cost. Funder pitch is 'every $1 raised funds a bed + capex toward in-house production'."
+  },
+  "counterfactual": {
+    "commercial_steel_frame_bed_au_2026_low": 1500,
+    "commercial_steel_frame_bed_au_2026_high": 2000,
+    "source": "Retail furniture / contract supply mid-2026 AU market scan",
+    "confidence": "inferred"
+  },
+  "capex_required_to_reach_state_4": {
+    "shredder": { "low": 15000, "high": 30000 },
+    "hot_press_line": { "low": 80000, "high": 150000 },
+    "cnc_router": { "low": 15000, "high": 40000 },
+    "workbench_tools": 2000,
+    "total_low": 112000,
+    "total_high": 222000,
+    "already_invested_facility": 100000,
+    "already_invested_carbatec_tooling": 10046,
+    "_capital_ask_low": 90000,
+    "_capital_ask_high": 200000
+  },
+  "mistags_to_fix": [
+    { "supplier": "Defy Washing Machine Cladding (multiple bills)", "amount": 25000, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
+    { "supplier": "Defy Coasters (INV-1174 + INV-1637)", "amount": 10000, "current_tag": "ACT-GD", "correct_tag": "ACT-EL (marketing/merch)" },
+    { "supplier": "Defy Design/R&D (INV-1258 design + INV-1259 prototype)", "amount": 7000, "current_tag": "ACT-GD bed-COGS", "correct_tag": "ACT-GD capital/R&D" },
+    { "supplier": "Carbatec Brisbane", "amount": 8726, "current_tag": "ACT-GD", "correct_tag": "ACT-HV" },
+    { "supplier": "Utopia trip flights/accommodation", "amount": 24507, "current_tag": "ACT-IN", "correct_tag": "ACT-GD" },
+    { "supplier": "1300 Washer", "amount": 13980, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
+    { "supplier": "Carla Furnishers duplicate", "amount": 11180, "current_tag": "ACT-GD", "correct_tag": "VOID DUPLICATE" },
+    { "supplier": "R M Tanner Triple Axle", "amount": 19950, "current_tag": "ACT-GD labour 486", "correct_tag": "ACT-GD capital" }
+  ],
+  "open_questions_for_defy": [
+    "Volume-quote sheet at 100 / 500 / 1,000 / 5,000 beds/yr — what does $600/bed Single Bed become?",
+    "Build-to-supply: cheaper if ACT sources steel (Steelmart) + canvas (RW Pacific) direct and supplies to Defy?",
+    "At what volume does in-house assembly pay back the $90-200K capex? (i.e. is State 2 or State 4 the right transition point?)",
+    "Half-sheets per bed: how many does the standard bed actually use? (Model assumes 1.5 — Ben to confirm.)"
+  ]
+}

--- a/v2/src/lib/data/cost-model-scenarios.ts
+++ b/v2/src/lib/data/cost-model-scenarios.ts
@@ -1,0 +1,126 @@
+/**
+ * Bed cost model — v3 scenarios + Idiot Index + founder-time split.
+ *
+ * Builds on the canonical BOM in `supplier-quotes.ts` (the single source of
+ * truth for per-component prices) and adds:
+ *  - 5 build-state scenarios (Defy-everything → community-plastic in-house)
+ *  - Idiot Index per element (markup ratio = lever for in-house cost reduction)
+ *  - Founder time allocated by purpose (production / fundraising / commercial / ACT-wide)
+ *  - Fundraising offset (how dollars raised subsidise bed cost)
+ *  - Volume scenarios at 100 / 500 / 1,000 beds per year
+ *
+ * Source data verified from `scripts/ocr-defy-bills.mjs` OCR of every Defy
+ * invoice attachment (lives in act-infra repo). The numbers here align
+ * directly with `supplier-quotes.ts` — when the canonical BOM changes there,
+ * update this file in lockstep.
+ */
+import scenarios from './cost-model-scenarios.json';
+import { fullyLoadedCostPerBed, stretchBedBOM } from './supplier-quotes';
+
+export type CostModelScenarios = typeof scenarios;
+
+export type BuildStateKey =
+  | 'state_1_defy_everything'
+  | 'state_2_buy_kit_assemble'
+  | 'state_3_buy_sheets_cut_assemble'
+  | 'state_4_all_in_house'
+  | 'state_5_community_plastic';
+
+export interface BuildState {
+  key: BuildStateKey;
+  label: string;
+  components: Array<{ label: string; amount: number }>;
+  direct_total: number;
+  capital_added: number;
+  capital_cumulative: number;
+}
+
+export interface IdiotIndexRow {
+  element: string;
+  raw_low: number;
+  raw_high: number;
+  current: number;
+  index_low: number;
+  index_high: number;
+  markup_pays_for: string;
+}
+
+export interface VolumeScenario {
+  label: string;
+  beds_per_year: number;
+  production_founder_per_bed: number;
+  admin_per_bed: number;
+  field_travel_per_bed: number;
+  freight_per_bed: number;
+  fully_loaded_state_1: number;
+  fully_loaded_state_4: number;
+  fully_loaded_state_5: number;
+}
+
+export function getModel(): CostModelScenarios {
+  return scenarios;
+}
+
+export function listBuildStates(): BuildState[] {
+  const states = scenarios.build_states;
+  const keys: BuildStateKey[] = [
+    'state_1_defy_everything',
+    'state_2_buy_kit_assemble',
+    'state_3_buy_sheets_cut_assemble',
+    'state_4_all_in_house',
+    'state_5_community_plastic',
+  ];
+  return keys.map((key) => ({ key, ...states[key] }));
+}
+
+export function getIdiotIndex(): IdiotIndexRow[] {
+  return scenarios.idiot_index as IdiotIndexRow[];
+}
+
+export function getVolumeScenarios(): VolumeScenario[] {
+  return scenarios.volume_scenarios as VolumeScenario[];
+}
+
+export function getFounderAllocation() {
+  return scenarios.founder_time_allocation;
+}
+
+export function getFundraisingOffset() {
+  return scenarios.fundraising_offset;
+}
+
+export function getDefyVerifiedRates() {
+  return scenarios.defy_verified_rates;
+}
+
+export function getOpenQuestionsForDefy() {
+  return scenarios.open_questions_for_defy;
+}
+
+/**
+ * Reconcile the v3 State-1 cost ($600) against `supplier-quotes.ts`
+ * `fullyLoadedCostPerBed` to make sure both files agree. If they ever drift,
+ * the cost-model card surfaces a warning.
+ */
+export function reconcileAgainstCanonicalBOM(): {
+  state1Total: number;
+  canonicalFullyLoaded: number;
+  matches: boolean;
+  bom: typeof stretchBedBOM;
+} {
+  const state1 = scenarios.build_states.state_1_defy_everything;
+  return {
+    state1Total: state1.direct_total,
+    canonicalFullyLoaded: fullyLoadedCostPerBed,
+    matches: state1.direct_total === fullyLoadedCostPerBed,
+    bom: stretchBedBOM,
+  };
+}
+
+export function fmtMoney(value: number): string {
+  return new Intl.NumberFormat('en-AU', {
+    style: 'currency',
+    currency: 'AUD',
+    maximumFractionDigits: value < 10 ? 2 : 0,
+  }).format(value);
+}


### PR DESCRIPTION
Adds the Idiot Index + 5-state scenarios + founder allocation + fundraising-offset model to the existing `/admin/production` page, alongside the current `CostPerBatchCard` (which keeps the canonical BOM + Xero actuals view).

## What's here

- `v2/src/lib/data/cost-model-scenarios.json` — mirror of `act-infra/thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json` (the verified-from-OCR model)
- `v2/src/lib/data/cost-model-scenarios.ts` — typed accessors + reconciliation against `fullyLoadedCostPerBed` in `supplier-quotes.ts` (canonical BOM stays single source of truth)
- `v2/src/components/production/cost-model-scenarios-card.tsx` — the card
- `v2/src/app/admin/production/page.tsx` — mounted below `CostPerBatchCard`

## What the card shows

1. **Volume scenarios** — fully-loaded $/bed at 100/500/1,000 beds/yr × State 1/4/5
2. **Build states** — 5 trajectory steps (Defy-everything → community-plastic in-house) with per-component cost lines + cumulative capex
3. **Idiot Index** — markup ratios per element. HDPE shred → finished kit is **8.6×** ($40 raw / $344 Defy). End caps 3.2–6.4×. Sheets 3.8×.
4. **Founder time, properly allocated** — 150 days × $1K/day split: 30d production (onto beds), 50d fundraising (offset), 25d commercial (offset), 45d ACT-wide
5. **Fundraising offset** — $250K/yr philanthropy modelled + $801/bed commercial buyer (Centrecorp). Subsidy $2,500/bed @ 100/yr → $500/bed @ 500/yr.

## Reconciliation

The card asserts State 1 total ($600) == `fullyLoadedCostPerBed` from `supplier-quotes.ts`. Drift → amber warning.

## Source

`act-infra/scripts/ocr-defy-bills.mjs` (Gemini OCR of every Defy invoice attachment) produced the verified rates. Companion docs in `act-infra/thoughts/shared/analysis/`:
- `2026-05-28-goods-bed-cost-model-v3-idiot-index.md` — the model walkthrough
- `2026-05-28-defy-invoice-ocr.json` — raw OCR output

## Out of scope (follow-up)

- Back-out the duplicated funder-artifact section from grantscope PR (separate PR — keeps just the cost-allocation operational table there).
- Pull DNA Steel + Centre Canvas invoices from Notion (currently the only off-Xero suppliers).
- Ask Defy the 4 open questions captured in the JSON.

Plan: `goods-cost-evidence-funder-artifact`