### PR TITLE
feat(cost-model): v4 4-path supply model — Notion BK numbers locked

### DIFF
--- a/v2/src/components/production/cost-model-scenarios-card.tsx
+++ b/v2/src/components/production/cost-model-scenarios-card.tsx
@@ -1,16 +1,17 @@
 /**
- * Cost-model scenarios card: 5 build-states × 3 volume scenarios + Idiot
- * Index + founder allocation + fundraising offset. Mounted on the
- * /admin/production page below the CostPerBatchCard. Source data lives in
- * `lib/data/cost-model-scenarios.{ts,json}` and reconciles against the
- * canonical BOM in `lib/data/supplier-quotes.ts`.
+ * Cost-model scenarios card v4 — Notion BK 4-path supply model + Idiot Index
+ * + founder allocation + fundraising offset. Mounted on /admin/production
+ * below the CostPerBatchCard. Source data: `cost-model-scenarios.json`
+ * reconciles against `supplier-quotes.ts` (canonical BOM).
  */
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import {
   listBuildStates,
   getIdiotIndex,
-  getVolumeScenarios,
+  getOverheadPerVolume,
+  getFullyLoadedGrid,
+  getMarginGridAt750,
   getFounderAllocation,
   getFundraisingOffset,
   reconcileAgainstCanonicalBOM,
@@ -18,11 +19,11 @@ import {
 } from '@/lib/data/cost-model-scenarios';
 
 const BUILD_STATE_BADGES: Record<string, string> = {
-  state_1_defy_everything: 'bg-gray-100 text-gray-800 border-gray-300',
-  state_2_buy_kit_assemble: 'bg-blue-50 text-blue-700 border-blue-300',
-  state_3_buy_sheets_cut_assemble: 'bg-amber-50 text-amber-700 border-amber-300',
-  state_4_all_in_house: 'bg-emerald-50 text-emerald-700 border-emerald-300',
-  state_5_community_plastic: 'bg-purple-50 text-purple-700 border-purple-300',
+  state_1_defy_fully_fabricated: 'bg-gray-100 text-gray-800 border-gray-300',
+  state_2_defy_kits: 'bg-blue-50 text-blue-700 border-blue-300',
+  state_3_defy_panels: 'bg-amber-50 text-amber-700 border-amber-300',
+  state_4_factory: 'bg-emerald-50 text-emerald-700 border-emerald-300',
+  state_5_community: 'bg-purple-50 text-purple-700 border-purple-300',
 };
 
 function idiotIndexClass(indexHigh: number): string {
@@ -41,7 +42,9 @@ function allocationClass(target: string): string {
 export function CostModelScenariosCard() {
   const buildStates = listBuildStates();
   const idiotIndex = getIdiotIndex();
-  const volumeScenarios = getVolumeScenarios();
+  const overhead = getOverheadPerVolume();
+  const fullyLoaded = getFullyLoadedGrid();
+  const margin = getMarginGridAt750();
   const founderAllocation = getFounderAllocation();
   const fundraisingOffset = getFundraisingOffset();
   const reconciliation = reconcileAgainstCanonicalBOM();
@@ -53,56 +56,48 @@ export function CostModelScenariosCard() {
     <Card>
       <CardContent className="pt-6 space-y-8">
         <div>
-          <h3 className="text-lg font-semibold">Cost model — scenarios, Idiot Index, founder allocation</h3>
+          <h3 className="text-lg font-semibold">Cost model v4 — 4-path supply model (Notion BK locked)</h3>
           <p className="text-xs text-gray-500 mt-1">
-            Verified from Defy invoice OCR (act-infra <code>scripts/ocr-defy-bills.mjs</code>). Reconciled against the
-            canonical BOM in <code>supplier-quotes.ts</code>. Numbers reflect verified Defy quote rates as of 2026-05-28.
+            Verified from Defy invoice OCR + Notion BK review (Ben + BK, 2026-05-28). Reconciled against{' '}
+            <code>supplier-quotes.ts</code>. Numbers locked: 20kg HDPE/bed, $27 steel, $95 canvas, $3.20 caps + $3.50
+            screws, $344.05 Defy kit, $278.70 factory-path direct.
           </p>
           {!reconciliation.matches && (
             <div className="mt-2 inline-flex items-center gap-2 rounded border border-amber-300 bg-amber-50 px-2 py-1 text-xs text-amber-800">
-              ⚠ Drift: State-1 total {fmtMoney(reconciliation.state1Total)} vs canonical {fmtMoney(reconciliation.canonicalFullyLoaded)} — keep these aligned.
+              ⚠ Drift: Factory direct {fmtMoney(reconciliation.factoryTotal)} vs canonical{' '}
+              {fmtMoney(reconciliation.canonicalFactoryMaterials)} — keep these aligned with supplier-quotes.ts.
             </div>
           )}
         </div>
 
-        {/* Volume scenarios */}
+        {/* Margin at $750 retail */}
         <div>
-          <h4 className="text-sm font-semibold mb-3">Volume scenarios — today → target → vision</h4>
+          <h4 className="text-sm font-semibold mb-3">Margin at $750 retail — 4 supply paths</h4>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead className="text-left text-gray-500 border-b">
                 <tr>
-                  <th className="pb-2 font-medium">Scenario</th>
-                  <th className="pb-2 font-medium text-right">Direct (S1)</th>
-                  <th className="pb-2 font-medium text-right">Direct (S4)</th>
-                  <th className="pb-2 font-medium text-right">Direct (S5)</th>
-                  <th className="pb-2 font-medium text-right">Founder</th>
-                  <th className="pb-2 font-medium text-right">Admin</th>
-                  <th className="pb-2 font-medium text-right">Field</th>
-                  <th className="pb-2 font-medium text-right">Freight</th>
-                  <th className="pb-2 font-medium text-right">Full S1</th>
-                  <th className="pb-2 font-medium text-right">Full S4</th>
-                  <th className="pb-2 font-medium text-right">Full S5</th>
+                  <th className="pb-2 font-medium">Path</th>
+                  <th className="pb-2 font-medium text-right">Direct cost</th>
+                  <th className="pb-2 font-medium text-right">Margin</th>
+                  <th className="pb-2 font-medium text-right">Margin %</th>
                 </tr>
               </thead>
               <tbody>
-                {volumeScenarios.map((vs, i) => {
-                  const s1 = buildStates.find((b) => b.key === 'state_1_defy_everything')!.direct_total;
-                  const s4 = buildStates.find((b) => b.key === 'state_4_all_in_house')!.direct_total;
-                  const s5 = buildStates.find((b) => b.key === 'state_5_community_plastic')!.direct_total;
+                {margin.map((row) => {
+                  const isFactory = row.path.startsWith('Factory');
+                  const isCommunity = row.path.startsWith('Community');
                   return (
-                    <tr key={vs.label} className={`border-b last:border-0 ${i === 1 ? 'bg-emerald-50/40' : ''}`}>
-                      <td className="py-2 font-medium">{vs.label}</td>
-                      <td className="py-2 text-right tabular-nums">{fmtMoney(s1)}</td>
-                      <td className="py-2 text-right tabular-nums">{fmtMoney(s4)}</td>
-                      <td className="py-2 text-right tabular-nums">{fmtMoney(s5)}</td>
-                      <td className="py-2 text-right tabular-nums">{fmtMoney(vs.production_founder_per_bed)}</td>
-                      <td className="py-2 text-right tabular-nums">{fmtMoney(vs.admin_per_bed)}</td>
-                      <td className="py-2 text-right tabular-nums">{fmtMoney(vs.field_travel_per_bed)}</td>
-                      <td className="py-2 text-right tabular-nums">{fmtMoney(vs.freight_per_bed)}</td>
-                      <td className="py-2 text-right tabular-nums font-medium">{fmtMoney(vs.fully_loaded_state_1)}</td>
-                      <td className="py-2 text-right tabular-nums font-medium text-emerald-700">{fmtMoney(vs.fully_loaded_state_4)}</td>
-                      <td className="py-2 text-right tabular-nums font-medium text-purple-700">{fmtMoney(vs.fully_loaded_state_5)}</td>
+                    <tr
+                      key={row.path}
+                      className={`border-b last:border-0 ${isFactory ? 'bg-emerald-50/40' : ''} ${
+                        isCommunity ? 'bg-purple-50/40' : ''
+                      }`}
+                    >
+                      <td className="py-2 font-medium">{row.path}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtMoney(row.direct)}</td>
+                      <td className="py-2 text-right tabular-nums font-medium">{fmtMoney(row.margin)}</td>
+                      <td className="py-2 text-right tabular-nums">{row.margin_pct}%</td>
                     </tr>
                   );
                 })}
@@ -110,25 +105,71 @@ export function CostModelScenariosCard() {
             </table>
           </div>
           <p className="text-xs text-gray-500 mt-2">
-            Counterfactual commercial steel-frame bed AU 2026: $1,500–$2,000. S1 today already competitive at volume; S4 at 500/yr beats commercial by 2–3×.
+            Factory path is the in-house target. 63% margin at $750 vs 28% on Defy kits = $260/bed saved when we own the
+            press + CNC.
           </p>
         </div>
 
-        {/* Build states */}
+        {/* Fully-loaded by volume */}
         <div>
-          <h4 className="text-sm font-semibold mb-3">Build states — Defy-everything → community-plastic in-house</h4>
+          <h4 className="text-sm font-semibold mb-3">Fully-loaded $/bed by volume (incl. overhead + freight + founder time)</h4>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-left text-gray-500 border-b">
+                <tr>
+                  <th className="pb-2 font-medium">Volume</th>
+                  <th className="pb-2 font-medium text-right">Defy fully-fab</th>
+                  <th className="pb-2 font-medium text-right">Defy Kits</th>
+                  <th className="pb-2 font-medium text-right">Defy Panels</th>
+                  <th className="pb-2 font-medium text-right">Factory</th>
+                  <th className="pb-2 font-medium text-right">Community</th>
+                </tr>
+              </thead>
+              <tbody>
+                {fullyLoaded.map((row, i) => (
+                  <tr key={row.volume_label} className={`border-b last:border-0 ${i === 2 ? 'bg-emerald-50/30' : ''}`}>
+                    <td className="py-2 font-medium">{row.volume_label}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMoney(row.state_1_defy_fab)}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMoney(row.state_2_defy_kits)}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMoney(row.state_3_defy_panels)}</td>
+                    <td className="py-2 text-right tabular-nums font-medium text-emerald-700">
+                      {fmtMoney(row.state_4_factory)}
+                    </td>
+                    <td className="py-2 text-right tabular-nums font-medium text-purple-700">
+                      {fmtMoney(row.state_5_community)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <p className="text-xs text-gray-500 mt-2">
+            Commercial counterfactual: $1,500–$2,000. Factory @ 1,000/yr ($481/bed) is{' '}
+            <strong>2.5–4× better cost than commercial</strong>. Today (100/yr) is competitive at the high end of the
+            commercial band.
+          </p>
+        </div>
+
+        {/* Build states grid */}
+        <div>
+          <h4 className="text-sm font-semibold mb-3">5 supply states — component cost lines</h4>
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-3">
             {buildStates.map((state) => (
               <div key={state.key} className="border rounded p-3 text-sm">
                 <Badge variant="outline" className={BUILD_STATE_BADGES[state.key]}>
-                  {state.label.split('(')[0].trim().slice(0, 30)}
+                  {state.label.split('(')[0].trim().slice(0, 28)}
                 </Badge>
                 <div className="mt-2 text-lg font-semibold tabular-nums">{fmtMoney(state.direct_total)}</div>
                 <div className="mt-1 text-xs text-gray-500">direct cost / bed</div>
+                {state.throughput_beds_per_day && (
+                  <div className="mt-1 text-xs text-gray-600">{state.throughput_beds_per_day} beds/day throughput</div>
+                )}
                 <div className="mt-3 text-xs space-y-1">
                   {state.components.map((c) => (
                     <div key={c.label} className="flex justify-between gap-2">
-                      <span className="text-gray-600 truncate" title={c.label}>{c.label}</span>
+                      <span className="text-gray-600 truncate" title={c.label}>
+                        {c.label}
+                      </span>
                       <span className="tabular-nums text-gray-800">{fmtMoney(c.amount)}</span>
                     </div>
                   ))}
@@ -145,9 +186,10 @@ export function CostModelScenariosCard() {
 
         {/* Idiot Index */}
         <div>
-          <h4 className="text-sm font-semibold mb-3">Idiot Index — where Defy's markup actually is</h4>
+          <h4 className="text-sm font-semibold mb-3">Idiot Index — markup per element</h4>
           <p className="text-xs text-gray-500 mb-3">
-            Ratio of what we pay over the raw-material cost. Biggest ratios = biggest in-house opportunities.
+            Ratio of what we pay over the raw-material cost. Biggest ratios = biggest in-house cost-reduction
+            opportunities.
           </p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -175,11 +217,46 @@ export function CostModelScenariosCard() {
                       <td className="py-2 font-medium">{row.element}</td>
                       <td className="py-2 text-right tabular-nums text-gray-600">{rawDisplay}</td>
                       <td className="py-2 text-right tabular-nums">{fmtMoney(row.current)}</td>
-                      <td className={`py-2 text-right tabular-nums ${idiotIndexClass(row.index_high)}`}>{indexDisplay}</td>
+                      <td className={`py-2 text-right tabular-nums ${idiotIndexClass(row.index_high)}`}>
+                        {indexDisplay}
+                      </td>
                       <td className="py-2 text-xs text-gray-600">{row.markup_pays_for}</td>
                     </tr>
                   );
                 })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {/* Overhead breakdown by volume */}
+        <div>
+          <h4 className="text-sm font-semibold mb-3">Overhead per bed by annual volume</h4>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-left text-gray-500 border-b">
+                <tr>
+                  <th className="pb-2 font-medium">Volume</th>
+                  <th className="pb-2 font-medium text-right">Kirmos (50%)</th>
+                  <th className="pb-2 font-medium text-right">Founder (30d prod)</th>
+                  <th className="pb-2 font-medium text-right">Admin</th>
+                  <th className="pb-2 font-medium text-right">Field travel</th>
+                  <th className="pb-2 font-medium text-right">Freight</th>
+                  <th className="pb-2 font-medium text-right">Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {overhead.map((row) => (
+                  <tr key={row.label} className="border-b last:border-0">
+                    <td className="py-2 font-medium">{row.label}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMoney(row.kirmos_per_bed)}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMoney(row.founder_production_per_bed)}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMoney(row.admin_per_bed)}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMoney(row.field_travel_per_bed)}</td>
+                    <td className="py-2 text-right tabular-nums">{fmtMoney(row.long_haul_freight_per_bed)}</td>
+                    <td className="py-2 text-right tabular-nums font-medium">{fmtMoney(row.overhead_total)}</td>
+                  </tr>
+                ))}
               </tbody>
             </table>
           </div>
@@ -190,7 +267,8 @@ export function CostModelScenariosCard() {
           <div>
             <h4 className="text-sm font-semibold mb-3">Founder time — properly allocated</h4>
             <p className="text-xs text-gray-500 mb-3">
-              {totalFounderDays} days × ${founderAllocation.rate_per_day}/day = {fmtMoney(totalFounderCost)} modelled. Only production-related days go on beds.
+              {totalFounderDays} days × ${founderAllocation.rate_per_day}/day = {fmtMoney(totalFounderCost)} modelled.
+              Only production-related days go on beds.
             </p>
             <div className="space-y-2">
               {founderAllocation.split.map((entry) => (
@@ -213,34 +291,46 @@ export function CostModelScenariosCard() {
           <div>
             <h4 className="text-sm font-semibold mb-3">Fundraising offset</h4>
             <p className="text-xs text-gray-500 mb-3">
-              Every $1 raised funds a bed PLUS capex toward the in-house target.
+              Fundraising founder-days are an investment — dollars raised subsidise bed cost.
             </p>
             <div className="grid grid-cols-2 gap-3 text-sm">
               <div className="border rounded p-3">
                 <div className="text-xs text-gray-500">Philanthropy</div>
-                <div className="mt-1 text-lg font-semibold tabular-nums">{fmtMoney(fundraisingOffset.philanthropy_annual_estimate)}</div>
-                <div className="mt-1 text-xs text-gray-600">{fundraisingOffset.philanthropy_days_per_year} founder-days/yr × ~$5K/day</div>
+                <div className="mt-1 text-lg font-semibold tabular-nums">
+                  {fmtMoney(fundraisingOffset.philanthropy_annual_estimate)}
+                </div>
+                <div className="mt-1 text-xs text-gray-600">
+                  {fundraisingOffset.philanthropy_days_per_year} founder-days/yr × ~$5K/day
+                </div>
               </div>
               <div className="border rounded p-3">
                 <div className="text-xs text-gray-500">Commercial buyer</div>
-                <div className="mt-1 text-lg font-semibold tabular-nums">{fmtMoney(fundraisingOffset.commercial_buyer_benchmark_per_bed)} / bed</div>
+                <div className="mt-1 text-lg font-semibold tabular-nums">
+                  {fmtMoney(fundraisingOffset.commercial_buyer_benchmark_per_bed)} / bed
+                </div>
                 <div className="mt-1 text-xs text-gray-600">{fundraisingOffset.commercial_buyer_source}</div>
               </div>
               <div className="border rounded p-3 border-emerald-300 bg-emerald-50">
                 <div className="text-xs text-emerald-700">Subsidy @ 100/yr</div>
-                <div className="mt-1 text-lg font-semibold tabular-nums text-emerald-700">{fmtMoney(fundraisingOffset._per_bed_subsidy_at_100_per_year)} / bed</div>
+                <div className="mt-1 text-lg font-semibold tabular-nums text-emerald-700">
+                  {fmtMoney(fundraisingOffset._per_bed_subsidy_at_100_per_year)} / bed
+                </div>
               </div>
               <div className="border rounded p-3 border-emerald-300 bg-emerald-50">
                 <div className="text-xs text-emerald-700">Subsidy @ 500/yr</div>
-                <div className="mt-1 text-lg font-semibold tabular-nums text-emerald-700">{fmtMoney(fundraisingOffset._per_bed_subsidy_at_500_per_year)} / bed</div>
+                <div className="mt-1 text-lg font-semibold tabular-nums text-emerald-700">
+                  {fmtMoney(fundraisingOffset._per_bed_subsidy_at_500_per_year)} / bed
+                </div>
               </div>
             </div>
           </div>
         </div>
 
         <p className="text-xs text-gray-400 pt-4 border-t">
-          Open questions for Defy: volume-quote sheet (100/500/1000/5000 beds/yr); build-to-supply pricing if ACT sources steel + canvas direct; in-house assembly payback volume; sheets/bed confirmation (currently 20kg HDPE/bed locked).
-          Source: <code>act-infra/thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3.json</code>
+          Open questions for Defy: volume-quote sheet (100/500/1000/5000 beds/yr); build-to-supply with our steel +
+          canvas; in-house assembly payback volume; INV-1731 freight confirmation. Source:{' '}
+          <code>v2/src/lib/data/cost-model-scenarios.json</code> · canonical BOM in{' '}
+          <code>supplier-quotes.ts</code>.
         </p>
       </CardContent>
     </Card>

--- a/v2/src/lib/data/cost-model-scenarios.json
+++ b/v2/src/lib/data/cost-model-scenarios.json
@@ -1,147 +1,144 @@
 {
   "meta": {
-    "title": "Goods bed cost model v3 — element-by-element with Idiot Index",
+    "title": "Goods bed cost model v4 — 4-path supply model with Idiot Index (Notion BK locked)",
+    "version": "v4",
     "created": "2026-05-28",
-    "source_doc": "thoughts/shared/analysis/2026-05-28-goods-bed-cost-model-v3-idiot-index.md",
-    "verified_from": "thoughts/shared/analysis/2026-05-28-defy-invoice-ocr.json"
+    "supersedes": "v3 (2026-05-28 morning)",
+    "source_doc": "Notion: 🧮 Goods // Plastic Sheet Calc's (BK review) + supplier-quotes.ts canonical BOM",
+    "verified_from": "act-infra/scripts/ocr-defy-bills.mjs (Defy) + ocr-bed-supplier-bills.mjs (all bed-relevant suppliers)",
+    "locked_inputs_2026_05_28": [
+      "20kg HDPE per bed (one sheet's worth, with offcuts)",
+      "$2.00/kg raw shred + $0.75/kg delivery = $2.75/kg landed",
+      "$27/bed steel (DNA Steel canonical) — NOT the $10.34 in some Notion calcs",
+      "$95/bed canvas (2.1m × $4.80/m, Notion BK supersedes earlier $93.50)",
+      "$3.20 caps + $3.50 screws = $6.70/bed hardware",
+      "Defy kit $344.05/bed (INV-1602 + INV-1732 verified)",
+      "Defy assembly labour $55.95/bed (verified line)",
+      "Single Bed fully-fab'd $600 (INV-1507, 25 beds Nov 2025)",
+      "$750 unified retail price",
+      "Founder time: 30 prod / 50 fundraising / 25 commercial / 45 ACT-wide @ $1K/day = $150K/yr",
+      "Kirmos facility labour 50% on beds = $2,250/month = $27K/yr",
+      "Throughput: Factory 4 beds/day, Defy Kits 10 beds/day, Community 5 beds/day"
+    ]
   },
   "physics": {
     "hdpe_density_g_per_cm3": 0.96,
-    "half_sheet_dims_cm": [120, 120, 1.9],
-    "half_sheet_mass_kg": 26.27,
     "hdpe_kg_per_bed": 20,
-    "_hdpe_per_bed_source": "Ben confirmed 2026-05-28 — 20kg of HDPE per finished bed (~76% of one half-sheet; the rest is offcuts/press loss).",
-    "raw_hdpe_cost_per_bed": 40.00,
-    "half_sheets_per_bed_equivalent": 0.76
+    "_hdpe_per_bed_source": "Ben confirmed 2026-05-28 — one sheet's worth (the other ~5kg is offcuts/press loss not in the bed).",
+    "raw_hdpe_cost_per_bed_no_delivery": 40.00,
+    "raw_hdpe_cost_per_bed_with_delivery": 55.00,
+    "_delivery_rate": "$0.75/kg ($900 / 1200kg per Defy delivery quote)"
+  },
+  "canonical_bom": {
+    "_note": "Mirrors supplier-quotes.ts. Defy-kit path direct materials = $472.75/bed.",
+    "hdpe_kit_defy": { "amount": 344.05, "source": "Defy INV-1602 + INV-1732", "confidence": "verified" },
+    "steel_poles": { "amount": 27.00, "source": "DNA Steel Direct (Alice Springs, in Notion)", "confidence": "verified" },
+    "canvas": { "amount": 95.00, "basis": "2.1m × $4.80/m", "source": "Centre Canvas (Alice Springs, in Notion)", "confidence": "verified" },
+    "end_caps": { "amount": 3.20, "basis": "4 × $0.80", "source": "Hardware supplier", "confidence": "verified" },
+    "screws": { "amount": 3.50, "source": "Hardware supplier (Notion BK 2026-05-28)", "confidence": "verified" },
+    "defy_kit_direct_total": 472.75
   },
   "defy_verified_rates": {
     "single_bed_fully_fabricated": { "amount": 600.00, "source": "INV-1507 Nov 2025, 25 beds", "confidence": "verified" },
-    "bed_kit_cut_finished": { "amount": 344.05, "source": "INV-1602 (92 kits) + 2026-03-27 (50 kits)", "confidence": "verified" },
+    "bed_kit_cut_finished": { "amount": 344.05, "source": "INV-1602 (92 kits) + INV-1732 (50 kits)", "confidence": "verified" },
+    "pre_pressed_panel_each": { "amount": 200.00, "source": "INV-1731 (20 panels bulk, 1200×1200×19mm)", "confidence": "verified" },
     "cut_and_finish_only": { "amount": 121.00, "source": "INV-1602 (16 beds, pre-purchased sheets)", "confidence": "verified" },
-    "assembly_labour": { "amount": 55.95, "source": "2026-03-19 (8 beds, exact line)", "confidence": "verified" },
-    "half_sheet_bulk_price": { "amount": 200.00, "source": "2026-03-27 (20 sheets bulk discount)", "confidence": "verified" },
-    "hdpe_shred_per_kg": { "amount": 2.00, "source": "2026-03-27 (1200kg bulk bags)", "confidence": "verified" },
-    "worker_day_rate_full": { "amount": 480.00, "source": "INV-1325/1326 (Sam, Todd)", "confidence": "verified" },
-    "worker_day_rate_half": { "amount": 240.00, "source": "INV-1325/1326", "confidence": "verified" },
-    "freight_botany_to_alice_per_pallet_low": { "amount": 808.00, "source": "Multiple Defy freight lines", "confidence": "verified" },
-    "freight_botany_to_alice_per_pallet_high": { "amount": 1480.00, "source": "Multiple Defy freight lines", "confidence": "verified" },
-    "beds_per_pallet_typical": 8
+    "assembly_labour": { "amount": 55.95, "source": "2026-03-19 line", "confidence": "verified" },
+    "hdpe_shred_per_kg": { "amount": 2.00, "source": "INV-1731 (1200kg bulk bag)", "confidence": "verified" },
+    "delivery_per_kg": { "amount": 0.75, "source": "INV-1731 ($900 delivery / 1200kg)", "confidence": "verified" }
   },
-  "raw_material_estimates_au_2026": {
-    "hdpe_shred_per_kg": 2.00,
-    "canvas_per_m2_estimate": 17.00,
-    "canvas_m2_per_bed_estimate": 4.0,
-    "steel_per_bed_raw_estimate": 12.00,
-    "end_caps_per_bed_raw_estimate": 0.75
+  "labour_rates_in_house": {
+    "production_operator_per_day": 400,
+    "production_operator_per_hour": 50,
+    "kirmos_facility_per_hour": 45,
+    "kirmos_monthly_50pct_to_beds": 2250,
+    "_basis": "Notion BK + Kirmos invoice analysis 2026-05-28"
   },
-  "notion_bom_verified": {
-    "hdpe_kit": { "amount": 344.05, "confidence": "verified", "matches_defy": true },
-    "canvas": { "amount": 93.50, "confidence": "inferred", "matches_defy": "bundled in $600 single bed" },
-    "assembly_labour": { "amount": 55.95, "confidence": "verified", "matches_defy": true },
-    "steel": { "amount": 27.00, "confidence": "inferred", "matches_defy": "bundled" },
-    "end_caps": { "amount": 3.20, "confidence": "inferred", "matches_defy": "bundled" },
-    "direct_total": 523.70
-  },
-  "in_house_estimates": {
-    "sheet_pressing_per_bed": { "amount": 40.00, "basis": "Hot-press energy + machine wear, no labour amortising capital yet", "confidence": "modelled" },
-    "cnc_cut_finish_per_bed": { "amount": 60.00, "basis": "1hr × $60/hr (operator + machine amortised)", "confidence": "modelled" },
-    "shredding_in_house_per_bed": { "amount": 10.00, "basis": "Energy + machine wear at scale", "confidence": "modelled" },
-    "wash_sort_dry_per_bed": { "amount": 20.00, "basis": "Labour line for community-collected plastic", "confidence": "modelled" },
-    "internal_assembly_labour_per_bed": { "amount": 46.67, "basis": "6 beds/day × $280/day award + super C13", "confidence": "modelled" },
-    "internal_assembly_labour_fair_market_per_bed": { "amount": 67.17, "basis": "6 beds/day × $403/day fair-market skilled fabricator", "confidence": "modelled" }
-  },
-  "wage_scenarios": [
-    { "label": "Award C13 (entry fabricator)", "hourly": 26, "daily_8hr": 208, "daily_with_super": 233, "beds_per_day": 6, "per_bed": 38.83 },
-    { "label": "Award C10 (mid-skilled)", "hourly": 32, "daily_8hr": 256, "daily_with_super": 287, "beds_per_day": 6, "per_bed": 47.83 },
-    { "label": "Fair-market skilled trade", "hourly": 45, "daily_8hr": 360, "daily_with_super": 403, "beds_per_day": 6, "per_bed": 67.17 },
-    { "label": "Indigenous community wage + cultural loading", "hourly": 35, "daily_8hr": 280, "daily_with_super": 314, "beds_per_day": 6, "per_bed": 52.33 }
-  ],
-  "community_plastic_pay_scenarios": [
-    { "label": "Bottom (kerbside-equivalent)", "per_kg": 0.20, "kg_per_bed": 40, "per_bed": 8.00 },
-    { "label": "Mid (community-coop rate)", "per_kg": 0.50, "kg_per_bed": 40, "per_bed": 20.00 },
-    { "label": "Premium (ocean/remote story-value)", "per_kg": 1.00, "kg_per_bed": 40, "per_bed": 40.00 },
-    { "label": "High (clean sorted, remote community)", "per_kg": 2.00, "kg_per_bed": 40, "per_bed": 80.00 }
-  ],
   "build_states": {
-    "state_1_defy_everything": {
-      "label": "Defy does everything (today, INV-1507)",
+    "state_1_defy_fully_fabricated": {
+      "label": "Defy fully-fabricated (Single Bed @ $600)",
       "components": [
-        { "label": "Single Bed fully fabricated", "amount": 600.00 }
+        { "label": "Single Bed fully fab'd (HDPE + steel + canvas + assembly)", "amount": 600.00 }
       ],
       "direct_total": 600.00,
       "capital_added": 0,
-      "capital_cumulative": 0
+      "capital_cumulative": 0,
+      "_note": "INV-1507 verified rate. We rarely buy this way — usually kits or panels then assemble."
     },
-    "state_2_buy_kit_assemble": {
-      "label": "Buy Defy kit, assemble in-house",
+    "state_2_defy_kits": {
+      "label": "Defy Kits (buy cut+finished kits, assemble in-house)",
       "components": [
-        { "label": "Defy bed kit (sheets cut+finished)", "amount": 344.05 },
-        { "label": "Canvas (RW Pacific or via Defy)", "amount": 93.50 },
-        { "label": "Steel poles", "amount": 27.00 },
-        { "label": "End caps + hardware", "amount": 3.20 },
-        { "label": "In-house assembly labour", "amount": 46.67 }
+        { "label": "Defy bed kit (cut+finished, no hardware)", "amount": 344.05 },
+        { "label": "Steel poles (DNA Steel)", "amount": 27.00 },
+        { "label": "Canvas (Centre Canvas)", "amount": 95.00 },
+        { "label": "End caps + screws", "amount": 6.70 },
+        { "label": "In-house assembly labour ($400/day ÷ 10 beds)", "amount": 40.00 },
+        { "label": "Freight on Defy material (est)", "amount": 25.00 }
       ],
-      "direct_total": 514.42,
+      "direct_total": 537.75,
       "capital_added": 2000,
-      "capital_cumulative": 2000
+      "capital_cumulative": 2000,
+      "throughput_beds_per_day": 10,
+      "_note": "Fastest path. Best for ramping while facility being set up."
     },
-    "state_3_buy_sheets_cut_assemble": {
-      "label": "Buy pressed sheets, cut+finish+assemble in-house",
+    "state_3_defy_panels": {
+      "label": "Defy Panels (buy panels, CNC + assemble)",
       "components": [
-        { "label": "1.5 half-sheets from Defy @ $200", "amount": 300.00 },
-        { "label": "In-house CNC cut + finish", "amount": 60.00 },
-        { "label": "Canvas", "amount": 93.50 },
-        { "label": "Steel", "amount": 27.00 },
-        { "label": "End caps + hardware", "amount": 3.20 },
-        { "label": "Assembly labour", "amount": 46.67 }
+        { "label": "Defy pre-pressed panels (2 × $200)", "amount": 400.00 },
+        { "label": "Steel poles", "amount": 27.00 },
+        { "label": "Canvas", "amount": 95.00 },
+        { "label": "End caps + screws", "amount": 6.70 },
+        { "label": "Diesel (CNC only, no pressing)", "amount": 5.00 },
+        { "label": "Labour ($400/day ÷ 7.5 beds)", "amount": 53.33 }
       ],
-      "direct_total": 530.37,
+      "direct_total": 587.03,
       "capital_added": 38000,
-      "capital_cumulative": 40000
+      "capital_cumulative": 40000,
+      "throughput_beds_per_day": 4,
+      "_note": "Worst value — paying for panels we could press ourselves. Only use if press is broken."
     },
-    "state_4_all_in_house": {
-      "label": "Buy raw HDPE shred, do everything in-house",
+    "state_4_factory": {
+      "label": "Factory (raw shred → press → CNC → assemble in-house)",
       "components": [
-        { "label": "HDPE shred 20kg @ $2/kg (Ben confirmed)", "amount": 40.00 },
-        { "label": "In-house sheet pressing", "amount": 40.00 },
-        { "label": "In-house CNC cut + finish", "amount": 60.00 },
-        { "label": "Canvas", "amount": 93.50 },
-        { "label": "Steel", "amount": 27.00 },
-        { "label": "End caps + hardware", "amount": 3.20 },
-        { "label": "Assembly labour", "amount": 46.67 }
+        { "label": "HDPE shred 20kg @ $2.75/kg (incl delivery)", "amount": 55.00 },
+        { "label": "Diesel (25L/day ÷ 5 beds press + CNC)", "amount": 15.00 },
+        { "label": "Labour ($400/day ÷ 5 beds)", "amount": 80.00 },
+        { "label": "Steel poles", "amount": 27.00 },
+        { "label": "Canvas", "amount": 95.00 },
+        { "label": "End caps + screws", "amount": 6.70 }
       ],
-      "direct_total": 310.37,
+      "direct_total": 278.70,
       "capital_added": 160000,
-      "capital_cumulative": 200000
+      "capital_cumulative": 200000,
+      "throughput_beds_per_day": 4,
+      "_note": "TARGET state. $471.30 margin at $750 retail (63%). 4 beds/day × 250 working days = 1,000/yr from one facility."
     },
-    "state_5_community_plastic": {
-      "label": "Community-collected plastic + all in-house (vision)",
+    "state_5_community": {
+      "label": "Community (waste plastic collected, volunteer-run)",
       "components": [
-        { "label": "Community plastic pay @ $1/kg × 20kg", "amount": 20.00 },
-        { "label": "Wash + dry + sort", "amount": 20.00 },
-        { "label": "In-house shredding", "amount": 10.00 },
-        { "label": "In-house sheet pressing", "amount": 40.00 },
-        { "label": "In-house CNC + finish", "amount": 60.00 },
-        { "label": "Canvas", "amount": 93.50 },
-        { "label": "Steel", "amount": 27.00 },
-        { "label": "End caps + hardware", "amount": 3.20 },
-        { "label": "Assembly labour", "amount": 46.67 }
+        { "label": "Community-collected plastic (CDP or volunteer)", "amount": 0.00 },
+        { "label": "Diesel (generator)", "amount": 15.00 },
+        { "label": "Steel poles", "amount": 27.00 },
+        { "label": "Canvas", "amount": 95.00 },
+        { "label": "End caps + screws", "amount": 6.70 },
+        { "label": "Labour (volunteer / CDP / community)", "amount": 0.00 }
       ],
-      "direct_total": 320.37,
+      "direct_total": 143.70,
       "capital_added": 30000,
       "capital_cumulative": 230000,
-      "community_jobs_created": true
+      "throughput_beds_per_day": 5,
+      "community_jobs_created": true,
+      "_note": "Vision state — $606.30 margin at $750 retail (81%). Almost the entire sale price recirculates into the community enterprise."
     }
   },
   "idiot_index": [
-    { "element": "HDPE shred → finished kit", "raw_low": 40.00, "raw_high": 40.00, "current": 344.05, "index_low": 8.6, "index_high": 8.6, "markup_pays_for": "Shredding, sheet pressing, CNC cutting, finishing, Defy margin. BIGGEST LEVERAGE in the model.", "raw_basis": "20kg HDPE × $2/kg (Ben confirmed 2026-05-28)" },
-    { "element": "Half-sheet (1200×1200×19mm)", "raw_low": 52.55, "raw_high": 52.55, "current": 200.00, "index_low": 3.8, "index_high": 3.8, "markup_pays_for": "Hot-press machine time, energy, Defy margin" },
-    { "element": "Cut+finish only", "raw_low": 30.00, "raw_high": 60.00, "current": 121.00, "index_low": 2.0, "index_high": 4.0, "markup_pays_for": "CNC operator + machine time + Defy margin" },
-    { "element": "Assembly labour (Defy)", "raw_low": 52.00, "raw_high": 52.00, "current": 55.95, "index_low": 1.1, "index_high": 1.1, "markup_pays_for": "Already efficient — small Defy margin" },
-    { "element": "Steel (frame + caps)", "raw_low": 10.00, "raw_high": 15.00, "current": 27.00, "index_low": 1.8, "index_high": 2.7, "markup_pays_for": "Cut to length, drill, deliver" },
-    { "element": "Canvas", "raw_low": 45.00, "raw_high": 68.00, "current": 93.50, "index_low": 1.4, "index_high": 2.1, "markup_pays_for": "Cut, hem, grommet, RW Pacific margin" },
-    { "element": "End caps / fittings", "raw_low": 0.50, "raw_high": 1.00, "current": 3.20, "index_low": 3.2, "index_high": 6.4, "markup_pays_for": "Bulk-buy supplier margin" },
-    { "element": "Pallet + packing", "raw_low": 30.00, "raw_high": 50.00, "current": 60.00, "index_low": 1.2, "index_high": 2.0, "markup_pays_for": "Labour + packing materials" }
+    { "element": "Defy kit vs in-house factory plastic", "raw_low": 55.00, "raw_high": 55.00, "current": 344.05, "index_low": 6.3, "index_high": 6.3, "markup_pays_for": "Shredding, pressing, CNC, finishing, Defy margin. Biggest leverage — moves cost from $344 to $55 if we shred + press + CNC in-house." },
+    { "element": "Defy panels vs in-house pressed sheets", "raw_low": 55.00, "raw_high": 55.00, "current": 400.00, "index_low": 7.3, "index_high": 7.3, "markup_pays_for": "Hot-press + Defy margin. Panel-path is the WORST value — buy raw shred or buy finished kits, not panels." },
+    { "element": "Defy assembly vs in-house assembly", "raw_low": 40.00, "raw_high": 80.00, "current": 55.95, "index_low": 0.7, "index_high": 1.4, "markup_pays_for": "Defy assembly is already competitive ($55.95 vs in-house $40-$80 depending on facility throughput)." },
+    { "element": "Steel (DNA Steel direct vs raw market)", "raw_low": 12.00, "raw_high": 18.00, "current": 27.00, "index_low": 1.5, "index_high": 2.3, "markup_pays_for": "Cut to length, drill, deliver to Alice Springs." },
+    { "element": "Canvas (Centre Canvas custom)", "raw_low": 35.00, "raw_high": 50.00, "current": 95.00, "index_low": 1.9, "index_high": 2.7, "markup_pays_for": "Cut, hem, sew, grommets, Centre Canvas margin. 2.1m of canvas at $4.80/m." },
+    { "element": "End caps (4 per bed)", "raw_low": 0.50, "raw_high": 1.00, "current": 3.20, "index_low": 3.2, "index_high": 6.4, "markup_pays_for": "Bulk-buy supplier margin on round ribbed plastic caps." },
+    { "element": "Screws (frame fasteners)", "raw_low": 1.00, "raw_high": 2.00, "current": 3.50, "index_low": 1.8, "index_high": 3.5, "markup_pays_for": "Hardware retail markup." }
   ],
   "founder_time_allocation": {
     "rate_per_day": 1000,
@@ -154,49 +151,50 @@
     ],
     "_principle": "Only production-related founder time goes onto beds. The fundraising/commercial portion OFFSETS bed cost via dollars raised; the governance portion is ACT-wide, not Goods-specific."
   },
-  "volume_scenarios": [
+  "overhead_per_volume": [
     {
       "label": "Today (100 beds/yr)",
       "beds_per_year": 100,
-      "production_founder_per_bed": 300,
+      "kirmos_per_bed": 270,
+      "founder_production_per_bed": 300,
       "admin_per_bed": 147,
       "field_travel_per_bed": 510,
-      "freight_per_bed": 150,
-      "fully_loaded_state_1": 1707,
-      "fully_loaded_state_4": 1417,
-      "fully_loaded_state_5": 1427,
-      "_math_state_1": "600 + 150 + 300 + 147 + 510 = 1707",
-      "_math_state_4": "310.37 + 150 + 300 + 147 + 510 = 1417.37",
-      "_math_state_5": "320.37 + 150 + 300 + 147 + 510 = 1427.37"
+      "long_haul_freight_per_bed": 150,
+      "overhead_total": 1377,
+      "_overhead_math": "270 + 300 + 147 + 510 + 150 = 1377"
     },
     {
       "label": "Target (500 beds/yr)",
       "beds_per_year": 500,
-      "production_founder_per_bed": 60,
+      "kirmos_per_bed": 54,
+      "founder_production_per_bed": 60,
       "admin_per_bed": 29,
       "field_travel_per_bed": 100,
-      "freight_per_bed": 100,
-      "fully_loaded_state_1": 889,
-      "fully_loaded_state_4": 599,
-      "fully_loaded_state_5": 609,
-      "_math_state_1": "600 + 100 + 60 + 29 + 100 = 889",
-      "_math_state_4": "310.37 + 100 + 60 + 29 + 100 = 599.37",
-      "_math_state_5": "320.37 + 100 + 60 + 29 + 100 = 609.37"
+      "long_haul_freight_per_bed": 100,
+      "overhead_total": 343
     },
     {
-      "label": "Vision (1,000 beds/yr, in-house assembly)",
+      "label": "Vision (1,000 beds/yr at full Factory throughput)",
       "beds_per_year": 1000,
-      "production_founder_per_bed": 30,
+      "kirmos_per_bed": 27,
+      "founder_production_per_bed": 30,
       "admin_per_bed": 15,
       "field_travel_per_bed": 50,
-      "freight_per_bed": 80,
-      "fully_loaded_state_1": 775,
-      "fully_loaded_state_4": 485,
-      "fully_loaded_state_5": 495,
-      "_math_state_1": "600 + 80 + 30 + 15 + 50 = 775",
-      "_math_state_4": "310.37 + 80 + 30 + 15 + 50 = 485.37",
-      "_math_state_5": "320.37 + 80 + 30 + 15 + 50 = 495.37"
+      "long_haul_freight_per_bed": 80,
+      "overhead_total": 202
     }
+  ],
+  "fully_loaded_grid": [
+    { "volume_label": "100/yr today", "state_1_defy_fab": 1977, "state_2_defy_kits": 1915, "state_3_defy_panels": 1964, "state_4_factory": 1656, "state_5_community": 1521 },
+    { "volume_label": "500/yr target", "state_1_defy_fab": 943, "state_2_defy_kits": 881, "state_3_defy_panels": 930, "state_4_factory": 622, "state_5_community": 487 },
+    { "volume_label": "1,000/yr vision", "state_1_defy_fab": 802, "state_2_defy_kits": 740, "state_3_defy_panels": 789, "state_4_factory": 481, "state_5_community": 346 }
+  ],
+  "margin_grid_at_750_retail": [
+    { "path": "Defy fully-fabricated", "direct": 600.00, "margin": 150, "margin_pct": 20 },
+    { "path": "Defy Kits", "direct": 537.75, "margin": 212.25, "margin_pct": 28 },
+    { "path": "Defy Panels", "direct": 587.03, "margin": 162.97, "margin_pct": 22 },
+    { "path": "Factory (in-house)", "direct": 278.70, "margin": 471.30, "margin_pct": 63 },
+    { "path": "Community (volunteer + free plastic)", "direct": 143.70, "margin": 606.30, "margin_pct": 81 }
   ],
   "fundraising_offset": {
     "philanthropy_days_per_year": 50,
@@ -207,7 +205,7 @@
     "commercial_buyer_source": "Centrecorp INV-0291 (107 beds @ $85,712)",
     "_per_bed_subsidy_at_100_per_year": 2500,
     "_per_bed_subsidy_at_500_per_year": 500,
-    "_principle": "Fundraising days are an INVESTMENT that generates revenue offsetting bed cost. Funder pitch is 'every $1 raised funds a bed + capex toward in-house production'."
+    "_principle": "Fundraising days are an INVESTMENT that generates revenue offsetting bed cost."
   },
   "counterfactual": {
     "commercial_steel_frame_bed_au_2026_low": 1500,
@@ -230,17 +228,17 @@
   "mistags_to_fix": [
     { "supplier": "Defy Washing Machine Cladding (multiple bills)", "amount": 25000, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
     { "supplier": "Defy Coasters (INV-1174 + INV-1637)", "amount": 10000, "current_tag": "ACT-GD", "correct_tag": "ACT-EL (marketing/merch)" },
-    { "supplier": "Defy Design/R&D (INV-1258 design + INV-1259 prototype)", "amount": 7000, "current_tag": "ACT-GD bed-COGS", "correct_tag": "ACT-GD capital/R&D" },
-    { "supplier": "Carbatec Brisbane", "amount": 8726, "current_tag": "ACT-GD", "correct_tag": "ACT-HV" },
+    { "supplier": "Defy Design/R&D (INV-1258 + INV-1259)", "amount": 7000, "current_tag": "ACT-GD bed-COGS", "correct_tag": "ACT-GD capital/R&D" },
     { "supplier": "Utopia trip flights/accommodation", "amount": 24507, "current_tag": "ACT-IN", "correct_tag": "ACT-GD" },
     { "supplier": "1300 Washer", "amount": 13980, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
     { "supplier": "Carla Furnishers duplicate", "amount": 11180, "current_tag": "ACT-GD", "correct_tag": "VOID DUPLICATE" },
-    { "supplier": "R M Tanner Triple Axle", "amount": 19950, "current_tag": "ACT-GD labour 486", "correct_tag": "ACT-GD capital" }
+    { "supplier": "R M Tanner Triple Axle", "amount": 19950, "current_tag": "ACT-GD", "correct_tag": "Different project entirely — remove from ACT-GD" },
+    { "supplier": "Zinus Australia (Basket Bed v1 mattress toppers)", "amount": 28690, "current_tag": "ACT-GD", "correct_tag": "ACT-GD-archive (Basket Bed v1, discontinued)" }
   ],
   "open_questions_for_defy": [
-    "Volume-quote sheet at 100 / 500 / 1,000 / 5,000 beds/yr — what does $600/bed Single Bed become?",
-    "Build-to-supply: cheaper if ACT sources steel (Steelmart) + canvas (RW Pacific) direct and supplies to Defy?",
-    "At what volume does in-house assembly pay back the $90-200K capex? (i.e. is State 2 or State 4 the right transition point?)",
-    "Half-sheets per bed: how many does the standard bed actually use? (Model assumes 1.5 — Ben to confirm.)"
+    "Volume quote at 100 / 500 / 1,000 / 5,000 beds/yr — what does the $344.05/bed kit rate become?",
+    "Build-to-supply: cheaper if ACT sources steel (DNA Steel) + canvas (Centre Canvas) direct and supplies to Defy for kit-assembly only?",
+    "In-house assembly payback: at what volume does taking the $55.95/bed assembly in-house pay back the $90K-$200K capex?",
+    "Confirm INV-1731 freight cost ($874 for 1,200kg + 20 panels Sydney → Sunshine Coast)?"
   ]
 }

--- a/v2/src/lib/data/cost-model-scenarios.ts
+++ b/v2/src/lib/data/cost-model-scenarios.ts
@@ -1,30 +1,24 @@
 /**
- * Bed cost model — v3 scenarios + Idiot Index + founder-time split.
+ * Bed cost model v4 — 4-path supply model (Factory / Defy Kits / Defy Panels /
+ * Community) + Defy fully-fabricated reference state. Numbers locked 2026-05-28
+ * via Notion BK review + Defy invoice OCR + Ben confirmations.
  *
- * Builds on the canonical BOM in `supplier-quotes.ts` (the single source of
- * truth for per-component prices) and adds:
- *  - 5 build-state scenarios (Defy-everything → community-plastic in-house)
- *  - Idiot Index per element (markup ratio = lever for in-house cost reduction)
- *  - Founder time allocated by purpose (production / fundraising / commercial / ACT-wide)
- *  - Fundraising offset (how dollars raised subsidise bed cost)
- *  - Volume scenarios at 100 / 500 / 1,000 beds per year
+ * All data lives in `cost-model-scenarios.json`. Canonical BOM mirrors
+ * `supplier-quotes.ts`; this file adds the trajectory math + Idiot Index.
  *
- * Source data verified from `scripts/ocr-defy-bills.mjs` OCR of every Defy
- * invoice attachment (lives in act-infra repo). The numbers here align
- * directly with `supplier-quotes.ts` — when the canonical BOM changes there,
- * update this file in lockstep.
+ * Source: act-infra/scripts/ocr-defy-bills.mjs + ocr-bed-supplier-bills.mjs.
  */
 import scenarios from './cost-model-scenarios.json';
-import { fullyLoadedCostPerBed, stretchBedBOM } from './supplier-quotes';
+import { fullyLoadedCostPerBed, stretchBedBOM, factoryDirectMaterials } from './supplier-quotes';
 
 export type CostModelScenarios = typeof scenarios;
 
 export type BuildStateKey =
-  | 'state_1_defy_everything'
-  | 'state_2_buy_kit_assemble'
-  | 'state_3_buy_sheets_cut_assemble'
-  | 'state_4_all_in_house'
-  | 'state_5_community_plastic';
+  | 'state_1_defy_fully_fabricated'
+  | 'state_2_defy_kits'
+  | 'state_3_defy_panels'
+  | 'state_4_factory'
+  | 'state_5_community';
 
 export interface BuildState {
   key: BuildStateKey;
@@ -33,6 +27,7 @@ export interface BuildState {
   direct_total: number;
   capital_added: number;
   capital_cumulative: number;
+  throughput_beds_per_day?: number;
 }
 
 export interface IdiotIndexRow {
@@ -45,16 +40,31 @@ export interface IdiotIndexRow {
   markup_pays_for: string;
 }
 
-export interface VolumeScenario {
+export interface OverheadRow {
   label: string;
   beds_per_year: number;
-  production_founder_per_bed: number;
+  kirmos_per_bed: number;
+  founder_production_per_bed: number;
   admin_per_bed: number;
   field_travel_per_bed: number;
-  freight_per_bed: number;
-  fully_loaded_state_1: number;
-  fully_loaded_state_4: number;
-  fully_loaded_state_5: number;
+  long_haul_freight_per_bed: number;
+  overhead_total: number;
+}
+
+export interface FullyLoadedRow {
+  volume_label: string;
+  state_1_defy_fab: number;
+  state_2_defy_kits: number;
+  state_3_defy_panels: number;
+  state_4_factory: number;
+  state_5_community: number;
+}
+
+export interface MarginRow {
+  path: string;
+  direct: number;
+  margin: number;
+  margin_pct: number;
 }
 
 export function getModel(): CostModelScenarios {
@@ -64,11 +74,11 @@ export function getModel(): CostModelScenarios {
 export function listBuildStates(): BuildState[] {
   const states = scenarios.build_states;
   const keys: BuildStateKey[] = [
-    'state_1_defy_everything',
-    'state_2_buy_kit_assemble',
-    'state_3_buy_sheets_cut_assemble',
-    'state_4_all_in_house',
-    'state_5_community_plastic',
+    'state_1_defy_fully_fabricated',
+    'state_2_defy_kits',
+    'state_3_defy_panels',
+    'state_4_factory',
+    'state_5_community',
   ];
   return keys.map((key) => ({ key, ...states[key] }));
 }
@@ -77,8 +87,16 @@ export function getIdiotIndex(): IdiotIndexRow[] {
   return scenarios.idiot_index as IdiotIndexRow[];
 }
 
-export function getVolumeScenarios(): VolumeScenario[] {
-  return scenarios.volume_scenarios as VolumeScenario[];
+export function getOverheadPerVolume(): OverheadRow[] {
+  return scenarios.overhead_per_volume as OverheadRow[];
+}
+
+export function getFullyLoadedGrid(): FullyLoadedRow[] {
+  return scenarios.fully_loaded_grid as FullyLoadedRow[];
+}
+
+export function getMarginGridAt750(): MarginRow[] {
+  return scenarios.margin_grid_at_750_retail as MarginRow[];
 }
 
 export function getFounderAllocation() {
@@ -93,26 +111,37 @@ export function getDefyVerifiedRates() {
   return scenarios.defy_verified_rates;
 }
 
+export function getCanonicalBOM() {
+  return scenarios.canonical_bom;
+}
+
 export function getOpenQuestionsForDefy() {
   return scenarios.open_questions_for_defy;
 }
 
 /**
- * Reconcile the v3 State-1 cost ($600) against `supplier-quotes.ts`
- * `fullyLoadedCostPerBed` to make sure both files agree. If they ever drift,
- * the cost-model card surfaces a warning.
+ * Reconcile the v4 Factory-state direct total against `factoryDirectMaterials`
+ * in supplier-quotes.ts. If they drift, the card surfaces a warning so the two
+ * files can't silently disagree about the factory-path cost.
  */
 export function reconcileAgainstCanonicalBOM(): {
+  factoryTotal: number;
+  canonicalFactoryMaterials: number;
   state1Total: number;
   canonicalFullyLoaded: number;
   matches: boolean;
   bom: typeof stretchBedBOM;
 } {
-  const state1 = scenarios.build_states.state_1_defy_everything;
+  const state1 = scenarios.build_states.state_1_defy_fully_fabricated;
+  const state4 = scenarios.build_states.state_4_factory;
   return {
+    factoryTotal: state4.direct_total,
+    canonicalFactoryMaterials: factoryDirectMaterials,
     state1Total: state1.direct_total,
     canonicalFullyLoaded: fullyLoadedCostPerBed,
-    matches: state1.direct_total === fullyLoadedCostPerBed,
+    matches:
+      state4.direct_total === factoryDirectMaterials &&
+      state1.direct_total === fullyLoadedCostPerBed,
     bom: stretchBedBOM,
   };
 }

--- a/v2/src/lib/data/supplier-quotes.ts
+++ b/v2/src/lib/data/supplier-quotes.ts
@@ -94,14 +94,14 @@ export const supplierQuotes: SupplierQuote[] = [
     contact: 'Wayne',
     email: '',
     component: 'Canvas Sleeping Surface',
-    description: 'Heavy-duty Australian canvas stretcher covers with pole sleeves. Fully washable, quick-drying.',
-    unitPrice: 93.5,
+    description: 'Heavy-duty Australian canvas stretcher covers with pole sleeves. Fully washable, quick-drying. 2.1m × $4.80/m.',
+    unitPrice: 95.00,
     currency: 'AUD',
     moq: 50,
     leadTimeDays: 14,
     validUntil: '2026-12-31',
     status: 'active',
-    notes: 'Alice Springs based (Wayne, 4 Smith St, 08 8952 2453). Custom sewn to spec. $93.50/bed per the canonical Notion BOM "BOM - StretchBed v2". Real supplier (confirmed by Ben 2026-05-28). One Xero invoice exists ("Canvas stretcher covers" $10,285, INV ADG 6524337) but is mis-tagged ACT-IN; the same Xero contact is also polluted with Canva software-subscription lines (contact-name collision). Most canvas invoicing lives in Notion.',
+    notes: 'Alice Springs based (Wayne, 4 Smith St, 08 8952 2453). Custom sewn to spec. $95/bed (2.1m × $4.80/m) verified in Notion BK review 2026-05-28 (supersedes earlier $93.50 figure). Real supplier (confirmed by Ben 2026-05-28). One Xero invoice exists ("Canvas stretcher covers" $10,285, INV ADG 6524337) but is mis-tagged ACT-IN; the same Xero contact is also polluted with Canva software-subscription lines (contact-name collision). Most canvas invoicing lives in Notion.',
     xeroInvoice: 'ADG 6524337',
   },
 
@@ -120,6 +120,24 @@ export const supplierQuotes: SupplierQuote[] = [
     validUntil: null,
     status: 'active',
     notes: 'Generic hardware item. Multiple suppliers available.',
+    xeroInvoice: null,
+  },
+
+  // Screws — frame fasteners
+  {
+    id: 'screws-frame-2026',
+    supplier: 'Hardware Supplier',
+    contact: '',
+    email: '',
+    component: 'Frame Screws',
+    description: 'Frame fasteners for HDPE legs to steel poles. ~$3.50/bed.',
+    unitPrice: 3.50,
+    currency: 'AUD',
+    moq: 1000,
+    leadTimeDays: 5,
+    validUntil: null,
+    status: 'active',
+    notes: 'Identified in Notion BK 2026-05-28. Generic hardware item. Distinct from end caps — both required per bed.',
     xeroInvoice: null,
   },
 
@@ -144,24 +162,50 @@ export const supplierQuotes: SupplierQuote[] = [
 
 export const WEBSITE_PRICE = 750; // Unified website price (2026-05-26). Institutional/retail collapsed to one.
 
-// Direct materials per bed (bought-in BOM), reconciled to ACTUAL invoices 2026-05-28:
+// Direct materials per bed (bought-in BOM, Defy-kit path), reconciled to ACTUAL
+// invoices 2026-05-28 + Notion BK review:
 //   HDPE plastic kit $344.05/bed — verified ex Defy invoices INV-1602 ("107 Beds")
 //     + INV-1732 ("50 Beds"): "kits in 19mm Jungle recycled plastic, cut & finished,
 //     excl. assembly & hardware." The old $45 was an aspirational on-country-from-waste
-//     figure, NOT what we pay. On-country production targets bring this down with volume.
-//   Steel (gal pipe) $27/bed — DNA Steel Direct, Alice Springs (Notion BOM).
-//   Canvas $93.50/bed — Centre Canvas, Alice Springs (Notion BOM).
-// THIS IS NOT THE FULLY-LOADED COST — see fullyLoadedCostPerBed below (adds assembly
-// ~$55.95/bed ex Defy, hardware, freight Sydney→Alice ~$874/shipment, and overhead).
+//     figure, NOT what we pay. On-country production targets bring this down with volume —
+//     the FACTORY-PATH equivalent is ~$55 raw HDPE (20kg × $2.75/kg incl. delivery), with
+//     the rest of the in-house cost captured in `factoryDirectMaterials` below.
+//   Steel (gal pipe) $27/bed — DNA Steel Direct, Alice Springs (Notion BOM, canonical).
+//   Canvas $95/bed — Centre Canvas, Alice Springs (2.1m × $4.80/m per Notion BK 2026-05-28;
+//     supersedes earlier $93.50).
+//   End caps $3.20/bed — 4 × $0.80 round ribbed caps.
+//   Screws $3.50/bed — frame fasteners (added 2026-05-28 from Notion BK).
+// THIS IS NOT THE FULLY-LOADED COST — see fullyLoadedCostPerBed below (adds Defy assembly
+// ~$55.95/bed, freight Sydney→Alice ~$874/shipment, facility labour + overhead, founder time).
 export const stretchBedBOM = [
   { component: 'HDPE Plastic Kit (legs, cut & finished)', qty: 1, unitCost: 344.05, supplier: 'Defy Manufacturing' },
   { component: 'Galvanised Steel (gal pipe)', qty: 1, unitCost: 27, supplier: 'DNA Steel Direct' },
-  { component: 'Canvas Sleeping Surface', qty: 1, unitCost: 93.5, supplier: 'Centre Canvas' },
+  { component: 'Canvas Sleeping Surface', qty: 1, unitCost: 95, supplier: 'Centre Canvas' },
   { component: 'Round Ribbed End Caps (27mm)', qty: 4, unitCost: 0.80, supplier: 'Hardware Supplier' },
+  { component: 'Frame Screws', qty: 1, unitCost: 3.50, supplier: 'Hardware Supplier' },
 ] as const;
 
-// Direct materials only: $344.05 + $27 + $93.50 + $3.20 = $467.75
+// Direct materials only (Defy-kit path): $344.05 + $27 + $95 + $3.20 + $3.50 = $472.75
 export const stretchBedDirectMaterials = stretchBedBOM.reduce((sum, item) => sum + item.qty * item.unitCost, 0);
+
+/**
+ * Factory-path direct cost per bed (raw shred → press → CNC → assemble in-house).
+ * From Notion BK review 2026-05-28 (Ben + BK):
+ *   Plastic raw + delivery: 20kg × $2.75/kg = $55 (HDPE shred + transport)
+ *   Diesel: $15/bed (25L/day ÷ 5 beds for press + CNC)
+ *   Labour: $80/bed ($400/day ÷ 5 beds at the factory)
+ *   Steel poles: $27 (DNA Steel)
+ *   Canvas: $95 (Centre Canvas)
+ *   End caps: $3.20 + Screws: $3.50 = $6.70 hardware
+ *   = $55 + $15 + $80 + $27 + $95 + $6.70 = $278.70
+ *
+ * This is the in-house production target. At 4 beds/day × ~250 working days = 1,000
+ * beds/yr from one facility. Margin at $750 retail = $471.30 (63%).
+ *
+ * Use this as the trajectory number for funder asks: the capital ask brings us from
+ * the Defy-kit path ($472.75 direct materials) down to factory path ($278.70 direct).
+ */
+export const factoryDirectMaterials = 278.70;
 
 /**
  * Fully-loaded production cost per bed at current low volume (~100 units).


### PR DESCRIPTION
Locks the bed cost model with verified numbers from a structured Q&A with Ben 2026-05-28 + Notion BK review + Defy invoice OCR.

## What changed

### supplier-quotes.ts (canonical BOM)
- Canvas: $93.50 → **$95.00** (Notion BK: 2.1m × $4.80/m)
- Added **screws line $3.50/bed** (Notion BK)
- Added **factoryDirectMaterials = $278.70** constant (in-house production target)
- stretchBedDirectMaterials now $472.75 (up from $467.75, reflects canvas + screws)

### cost-model-scenarios.json (v4 structure)
Aligned to Notion BK's 4 supply paths + Defy fully-fabricated reference state:

| State | Path | Direct $/bed |
|---|---|--:|
| state_1_defy_fully_fabricated | Defy Single Bed @ $600 | **$600** |
| state_2_defy_kits | Buy kits, assemble | **$537.75** |
| state_3_defy_panels | Buy panels, CNC + assemble | **$587.03** |
| state_4_factory | Raw shred → in-house everything | **$278.70** |
| state_5_community | Volunteer + free plastic | **$143.70** |

Margin at $750 retail:
- Factory: $471.30 (63%)
- Defy Kits: $212.25 (28%)
- Community: $606.30 (81%)

Fully-loaded at 1,000 beds/yr: Factory **$481/bed** (vs $1,500-$2,000 commercial = 2.5-4× better cost).

### cost-model-scenarios.ts + card
Types + accessors updated for v4 shape. Card now shows:
- Margin table (4 paths at $750)
- Fully-loaded grid by volume (100/500/1,000 × 5 states)
- 5 supply state cards with throughput
- Idiot Index (HDPE kit 6.3×, panels 7.3×, end caps 3.2-6.4×)
- Overhead breakdown by volume
- Founder allocation (30 prod / 50 fundraising / 25 commercial / 45 ACT-wide)
- Fundraising offset ($250K/yr → $2,500/bed subsidy @ 100/yr)

### Reconciliation
Card asserts:
- State-1 direct == `fullyLoadedCostPerBed` ($600)
- State-4 direct == `factoryDirectMaterials` ($278.70)

Drift triggers an amber warning so supplier-quotes.ts and cost-model-scenarios.json can't silently disagree.

## What's still open

- Pull DNA Steel + Centre Canvas invoice detail from Notion to verify $27 + $95 against actuals (currently sourced from supplier quote sheets in Notion BK).
- Confirm INV-1731 freight $874 with Sam (Defy).
- Ask Defy for the volume quote sheet at 100 / 500 / 1,000 / 5,000 beds/yr.
- Retag the $120K of misattributed ACT-GD spend (Carbatec → ACT-HV remains as Goods tools per Ben; the others go to ACT-FM / ACT-EL / void / different project).

Build: tsc clean, `pnpm build` compiled successfully.

Plan: `goods-cost-evidence-funder-artifact`