### PR TITLE
feat(cost-model): v5 interactive explorer at /admin/cost-model + invoice-verified corrections

### DIFF
--- a/v2/src/app/admin/cost-model/cost-model-explorer.tsx
+++ b/v2/src/app/admin/cost-model/cost-model-explorer.tsx
@@ -1,0 +1,501 @@
+'use client';
+/**
+ * Cost-model explorer — sliders drive the matrix. First-principles inputs
+ * (HDPE kg/bed, $/kg, steel/canvas/hardware, labour rates, throughput,
+ * volume, founder time) → derived outputs (direct cost per state, fully-
+ * loaded by volume, margin matrix, capital ask, Idiot Index, payback).
+ *
+ * The defaults are seeded from cost-model-scenarios.json + supplier-quotes.ts.
+ * Every slider has the verified-default labelled so you can see when you're
+ * playing with assumptions vs. invoice-verified numbers.
+ */
+import { useState, useMemo } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+function fmt(n: number): string {
+  return new Intl.NumberFormat('en-AU', { style: 'currency', currency: 'AUD', maximumFractionDigits: n < 10 ? 2 : 0 }).format(n);
+}
+function fmtPct(n: number): string {
+  return `${Math.round(n * 100)}%`;
+}
+
+interface Inputs {
+  // Material per bed
+  hdpe_kg_per_bed: number;
+  hdpe_per_kg_landed: number; // raw + delivery
+  defy_kit_per_bed: number; // Defy kit rate
+  defy_panel_each: number; // Defy pre-pressed panel
+  steel_per_bed: number;
+  canvas_per_bed: number;
+  hardware_per_bed: number; // end caps + screws + bolts
+  // Labour
+  labour_per_day: number;
+  factory_beds_per_day: number;
+  defy_kits_beds_per_day: number;
+  defy_panels_beds_per_day: number;
+  community_beds_per_day: number;
+  defy_assembly_per_bed: number; // when Defy assembles
+  // Energy
+  diesel_per_bed_factory: number;
+  diesel_per_bed_panels: number;
+  // Volume + overhead
+  beds_per_year: number;
+  kirmos_monthly_50pct: number;
+  founder_days_production: number;
+  founder_rate_per_day: number;
+  admin_per_year: number;
+  field_travel_per_year: number;
+  freight_per_bed: number;
+  // Retail
+  retail_price: number;
+  commercial_low: number;
+  commercial_high: number;
+  // Capital
+  capital_to_factory_low: number;
+  capital_to_factory_high: number;
+}
+
+const DEFAULTS: Inputs = {
+  hdpe_kg_per_bed: 20,
+  hdpe_per_kg_landed: 2.75,
+  defy_kit_per_bed: 344.05,
+  defy_panel_each: 200,
+  steel_per_bed: 27,
+  canvas_per_bed: 93.50,
+  hardware_per_bed: 5.24, // 3.20 caps + 1.04 screws + 1.00 bolts
+  labour_per_day: 400,
+  factory_beds_per_day: 5, // Notion BK
+  defy_kits_beds_per_day: 10,
+  defy_panels_beds_per_day: 7.5,
+  community_beds_per_day: 5,
+  defy_assembly_per_bed: 55.95,
+  diesel_per_bed_factory: 15,
+  diesel_per_bed_panels: 5,
+  beds_per_year: 500,
+  kirmos_monthly_50pct: 2250,
+  founder_days_production: 30,
+  founder_rate_per_day: 1000,
+  admin_per_year: 14700,
+  field_travel_per_year: 51000,
+  freight_per_bed: 100,
+  retail_price: 750,
+  commercial_low: 1500,
+  commercial_high: 2000,
+  capital_to_factory_low: 90000,
+  capital_to_factory_high: 200000,
+};
+
+const VERIFIED_HINTS: Partial<Record<keyof Inputs, string>> = {
+  hdpe_kg_per_bed: 'Ben confirmed (one sheet)',
+  hdpe_per_kg_landed: '$2/kg shred + $0.75/kg delivery (Defy INV-1731)',
+  defy_kit_per_bed: 'INV-1602 + INV-1732 verified',
+  defy_panel_each: 'INV-1731 (20 panels @ $200 bulk)',
+  steel_per_bed: 'DNA Steel canonical (Notion)',
+  canvas_per_bed: 'Centre Canvas verified (3 invoices 2026)',
+  hardware_per_bed: 'Coastal Fasteners verified ($3.20 caps + $1.04 16-screws + $1.00 2-bolts)',
+  defy_assembly_per_bed: 'Defy 2026-03-19 invoice verified',
+  retail_price: 'supplier-quotes.ts canonical',
+  commercial_low: 'AU retail/contract scan',
+  commercial_high: 'AU retail/contract scan',
+};
+
+interface Slider {
+  key: keyof Inputs;
+  label: string;
+  group: 'Materials' | 'Labour & throughput' | 'Volume & overhead' | 'Market';
+  min: number;
+  max: number;
+  step: number;
+  prefix?: string;
+  suffix?: string;
+}
+
+const SLIDERS: Slider[] = [
+  // Materials
+  { key: 'hdpe_kg_per_bed', label: 'HDPE per bed', group: 'Materials', min: 10, max: 50, step: 1, suffix: 'kg' },
+  { key: 'hdpe_per_kg_landed', label: 'HDPE $/kg landed', group: 'Materials', min: 1, max: 6, step: 0.25, prefix: '$' },
+  { key: 'defy_kit_per_bed', label: 'Defy kit $/bed', group: 'Materials', min: 200, max: 500, step: 5, prefix: '$' },
+  { key: 'defy_panel_each', label: 'Defy panel $/each', group: 'Materials', min: 100, max: 300, step: 10, prefix: '$' },
+  { key: 'steel_per_bed', label: 'Steel $/bed', group: 'Materials', min: 10, max: 80, step: 1, prefix: '$' },
+  { key: 'canvas_per_bed', label: 'Canvas $/bed', group: 'Materials', min: 50, max: 150, step: 1, prefix: '$' },
+  { key: 'hardware_per_bed', label: 'Hardware $/bed', group: 'Materials', min: 2, max: 15, step: 0.25, prefix: '$' },
+  // Labour
+  { key: 'labour_per_day', label: 'Labour $/day', group: 'Labour & throughput', min: 200, max: 800, step: 25, prefix: '$' },
+  { key: 'factory_beds_per_day', label: 'Factory beds/day', group: 'Labour & throughput', min: 1, max: 15, step: 0.5 },
+  { key: 'defy_kits_beds_per_day', label: 'Defy Kits beds/day', group: 'Labour & throughput', min: 2, max: 20, step: 0.5 },
+  { key: 'defy_panels_beds_per_day', label: 'Defy Panels beds/day', group: 'Labour & throughput', min: 2, max: 15, step: 0.5 },
+  { key: 'community_beds_per_day', label: 'Community beds/day', group: 'Labour & throughput', min: 1, max: 15, step: 0.5 },
+  { key: 'defy_assembly_per_bed', label: 'Defy assembly $/bed', group: 'Labour & throughput', min: 30, max: 100, step: 1, prefix: '$' },
+  { key: 'diesel_per_bed_factory', label: 'Diesel/bed (Factory)', group: 'Labour & throughput', min: 5, max: 50, step: 1, prefix: '$' },
+  { key: 'diesel_per_bed_panels', label: 'Diesel/bed (Panels)', group: 'Labour & throughput', min: 0, max: 20, step: 1, prefix: '$' },
+  // Volume & overhead
+  { key: 'beds_per_year', label: 'Beds per year', group: 'Volume & overhead', min: 50, max: 2000, step: 50 },
+  { key: 'kirmos_monthly_50pct', label: 'Kirmos monthly (50% on beds)', group: 'Volume & overhead', min: 0, max: 5000, step: 100, prefix: '$' },
+  { key: 'founder_days_production', label: 'Founder days/yr on production', group: 'Volume & overhead', min: 0, max: 100, step: 5, suffix: 'd' },
+  { key: 'founder_rate_per_day', label: 'Founder rate $/day', group: 'Volume & overhead', min: 500, max: 2500, step: 100, prefix: '$' },
+  { key: 'admin_per_year', label: 'Admin $/yr', group: 'Volume & overhead', min: 0, max: 50000, step: 1000, prefix: '$' },
+  { key: 'field_travel_per_year', label: 'Field travel $/yr', group: 'Volume & overhead', min: 0, max: 150000, step: 5000, prefix: '$' },
+  { key: 'freight_per_bed', label: 'Long-haul freight $/bed', group: 'Volume & overhead', min: 0, max: 500, step: 10, prefix: '$' },
+  // Market
+  { key: 'retail_price', label: 'Retail / institutional price', group: 'Market', min: 400, max: 1500, step: 25, prefix: '$' },
+  { key: 'commercial_low', label: 'Commercial counterfactual low', group: 'Market', min: 1000, max: 2500, step: 50, prefix: '$' },
+  { key: 'commercial_high', label: 'Commercial counterfactual high', group: 'Market', min: 1000, max: 3000, step: 50, prefix: '$' },
+  { key: 'capital_to_factory_low', label: 'Capital ask (low)', group: 'Market', min: 50000, max: 500000, step: 5000, prefix: '$' },
+  { key: 'capital_to_factory_high', label: 'Capital ask (high)', group: 'Market', min: 50000, max: 500000, step: 5000, prefix: '$' },
+];
+
+// Derive everything from inputs — this is the model.
+function computeModel(i: Inputs) {
+  const hdpeRawCost = i.hdpe_kg_per_bed * i.hdpe_per_kg_landed;
+  // Direct cost per state
+  const stateKits = i.defy_kit_per_bed + i.steel_per_bed + i.canvas_per_bed + i.hardware_per_bed + (i.labour_per_day / i.defy_kits_beds_per_day) + 25; // +25 freight on Defy material
+  const statePanels = i.defy_panel_each * 2 + i.steel_per_bed + i.canvas_per_bed + i.hardware_per_bed + i.diesel_per_bed_panels + (i.labour_per_day / i.defy_panels_beds_per_day);
+  const stateFactory = hdpeRawCost + i.diesel_per_bed_factory + (i.labour_per_day / i.factory_beds_per_day) + i.steel_per_bed + i.canvas_per_bed + i.hardware_per_bed;
+  const stateCommunity = 0 + i.diesel_per_bed_factory + i.steel_per_bed + i.canvas_per_bed + i.hardware_per_bed; // free plastic, volunteer labour
+  // Overhead per bed at current volume
+  const kirmosPerBed = (i.kirmos_monthly_50pct * 12) / i.beds_per_year;
+  const founderProductionPerBed = (i.founder_days_production * i.founder_rate_per_day) / i.beds_per_year;
+  const adminPerBed = i.admin_per_year / i.beds_per_year;
+  const fieldPerBed = i.field_travel_per_year / i.beds_per_year;
+  const overheadPerBed = kirmosPerBed + founderProductionPerBed + adminPerBed + fieldPerBed + i.freight_per_bed;
+  // Fully-loaded
+  const fullKits = stateKits + overheadPerBed;
+  const fullPanels = statePanels + overheadPerBed;
+  const fullFactory = stateFactory + overheadPerBed;
+  const fullCommunity = stateCommunity + overheadPerBed;
+  // Margin matrix
+  const marginKits = i.retail_price - stateKits;
+  const marginFactory = i.retail_price - stateFactory;
+  const marginCommunity = i.retail_price - stateCommunity;
+  // First-principles floor
+  const firstPrinciplesFloor = hdpeRawCost + 10.34 /* steel raw */ + 35 /* canvas raw */ + 2 /* caps raw */ + 1.65 /* screws+bolts raw */ + (i.labour_per_day / i.defy_kits_beds_per_day);
+  const supplyChainMarkup = stateKits - firstPrinciplesFloor;
+  // Idiot Index
+  const idiotKit = i.defy_kit_per_bed / hdpeRawCost;
+  const idiotPanel = (i.defy_panel_each * 2) / hdpeRawCost;
+  const idiotSteel = i.steel_per_bed / 10.34;
+  const idiotCanvas = i.canvas_per_bed / 35;
+  // Counterfactual ratios
+  const counterfactualMid = (i.commercial_low + i.commercial_high) / 2;
+  const valueVsCommercial = counterfactualMid / fullFactory;
+  // Capital payback (years)
+  const capitalLow = i.capital_to_factory_low;
+  const capitalHigh = i.capital_to_factory_high;
+  const savingsPerBed = stateKits - stateFactory; // Going from buying kits to factory in-house
+  const paybackBedsLow = capitalLow / savingsPerBed;
+  const paybackBedsHigh = capitalHigh / savingsPerBed;
+  const paybackYearsLow = paybackBedsLow / i.beds_per_year;
+  const paybackYearsHigh = paybackBedsHigh / i.beds_per_year;
+
+  return {
+    hdpeRawCost,
+    stateKits, statePanels, stateFactory, stateCommunity,
+    overheadPerBed, kirmosPerBed, founderProductionPerBed, adminPerBed, fieldPerBed,
+    fullKits, fullPanels, fullFactory, fullCommunity,
+    marginKits, marginFactory, marginCommunity,
+    firstPrinciplesFloor, supplyChainMarkup,
+    idiotKit, idiotPanel, idiotSteel, idiotCanvas,
+    counterfactualMid, valueVsCommercial,
+    capitalLow, capitalHigh, savingsPerBed, paybackBedsLow, paybackBedsHigh, paybackYearsLow, paybackYearsHigh,
+  };
+}
+
+export function CostModelExplorer() {
+  const [inputs, setInputs] = useState<Inputs>(DEFAULTS);
+  const model = useMemo(() => computeModel(inputs), [inputs]);
+
+  function setInput<K extends keyof Inputs>(key: K, val: number) {
+    setInputs((prev) => ({ ...prev, [key]: val }));
+  }
+  function resetAll() {
+    setInputs(DEFAULTS);
+  }
+
+  const grouped = SLIDERS.reduce((acc, s) => {
+    if (!acc[s.group]) acc[s.group] = [];
+    acc[s.group].push(s);
+    return acc;
+  }, {} as Record<string, Slider[]>);
+
+  return (
+    <div className="space-y-6">
+      {/* Headline cards — QBE-style at-a-glance */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-xs text-gray-500 uppercase tracking-wide">Fully-loaded today</p>
+            <p className="text-3xl font-bold tabular-nums">{fmt(model.fullKits)}</p>
+            <p className="text-xs text-gray-600 mt-1">Defy Kits @ {inputs.beds_per_year}/yr</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-xs text-gray-500 uppercase tracking-wide">Fully-loaded target</p>
+            <p className="text-3xl font-bold tabular-nums text-emerald-700">{fmt(model.fullFactory)}</p>
+            <p className="text-xs text-gray-600 mt-1">Factory in-house</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-xs text-gray-500 uppercase tracking-wide">Value vs commercial</p>
+            <p className="text-3xl font-bold tabular-nums text-purple-700">{model.valueVsCommercial.toFixed(2)}×</p>
+            <p className="text-xs text-gray-600 mt-1">{fmt(model.counterfactualMid)} commercial</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-xs text-gray-500 uppercase tracking-wide">Capital payback</p>
+            <p className="text-3xl font-bold tabular-nums">
+              {model.paybackYearsLow.toFixed(1)}-{model.paybackYearsHigh.toFixed(1)}y
+            </p>
+            <p className="text-xs text-gray-600 mt-1">{fmt(model.capitalLow)}-{fmt(model.capitalHigh)}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[420px_1fr] gap-6">
+        {/* Sliders panel */}
+        <Card>
+          <CardContent className="pt-6 space-y-6">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold">Inputs</h2>
+              <button onClick={resetAll} className="text-xs underline text-gray-600 hover:text-gray-900">
+                Reset to verified defaults
+              </button>
+            </div>
+            {Object.entries(grouped).map(([group, sliders]) => (
+              <div key={group}>
+                <h3 className="text-xs uppercase tracking-wide text-gray-500 font-semibold mb-3">{group}</h3>
+                <div className="space-y-3">
+                  {sliders.map((s) => {
+                    const val = inputs[s.key];
+                    const isDefault = val === DEFAULTS[s.key];
+                    const hint = VERIFIED_HINTS[s.key];
+                    return (
+                      <div key={s.key} className="text-sm">
+                        <div className="flex justify-between items-baseline mb-1">
+                          <label className="text-gray-700">{s.label}</label>
+                          <span className="tabular-nums font-medium">
+                            {s.prefix || ''}{val}{s.suffix || ''}
+                          </span>
+                        </div>
+                        <input
+                          type="range"
+                          min={s.min}
+                          max={s.max}
+                          step={s.step}
+                          value={val}
+                          onChange={(e) => setInput(s.key, parseFloat(e.target.value))}
+                          className="w-full"
+                        />
+                        {hint && (
+                          <p className="text-[10px] text-gray-500 mt-0.5">
+                            {isDefault ? `✓ ${hint}` : `(default: ${s.prefix || ''}${DEFAULTS[s.key]}${s.suffix || ''} — ${hint})`}
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        {/* Output panels */}
+        <div className="space-y-6">
+          {/* Direct cost matrix */}
+          <Card>
+            <CardContent className="pt-6">
+              <h3 className="text-lg font-semibold mb-3">Direct cost per bed (4 supply paths)</h3>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="text-left text-gray-500 border-b">
+                    <tr>
+                      <th className="pb-2">Path</th>
+                      <th className="pb-2 text-right">Direct $/bed</th>
+                      <th className="pb-2 text-right">Margin @ {fmt(inputs.retail_price)}</th>
+                      <th className="pb-2 text-right">Margin %</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr className="border-b">
+                      <td className="py-2 font-medium">Defy Kits (today)</td>
+                      <td className="py-2 text-right tabular-nums">{fmt(model.stateKits)}</td>
+                      <td className="py-2 text-right tabular-nums">{fmt(model.marginKits)}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtPct(model.marginKits / inputs.retail_price)}</td>
+                    </tr>
+                    <tr className="border-b">
+                      <td className="py-2 font-medium">Defy Panels</td>
+                      <td className="py-2 text-right tabular-nums">{fmt(model.statePanels)}</td>
+                      <td className="py-2 text-right tabular-nums">{fmt(inputs.retail_price - model.statePanels)}</td>
+                      <td className="py-2 text-right tabular-nums">{fmtPct((inputs.retail_price - model.statePanels) / inputs.retail_price)}</td>
+                    </tr>
+                    <tr className="border-b bg-emerald-50/50">
+                      <td className="py-2 font-medium">Factory (in-house target)</td>
+                      <td className="py-2 text-right tabular-nums">{fmt(model.stateFactory)}</td>
+                      <td className="py-2 text-right tabular-nums font-medium text-emerald-700">{fmt(model.marginFactory)}</td>
+                      <td className="py-2 text-right tabular-nums font-medium text-emerald-700">{fmtPct(model.marginFactory / inputs.retail_price)}</td>
+                    </tr>
+                    <tr className="bg-purple-50/50">
+                      <td className="py-2 font-medium">Community (vision)</td>
+                      <td className="py-2 text-right tabular-nums">{fmt(model.stateCommunity)}</td>
+                      <td className="py-2 text-right tabular-nums font-medium text-purple-700">{fmt(model.marginCommunity)}</td>
+                      <td className="py-2 text-right tabular-nums font-medium text-purple-700">{fmtPct(model.marginCommunity / inputs.retail_price)}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Fully-loaded + overhead breakdown */}
+          <Card>
+            <CardContent className="pt-6">
+              <h3 className="text-lg font-semibold mb-3">Fully-loaded at {inputs.beds_per_year} beds/yr</h3>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <div>
+                  <h4 className="text-sm font-medium mb-2">Overhead per bed</h4>
+                  <table className="w-full text-sm">
+                    <tbody>
+                      <tr className="border-b">
+                        <td className="py-1.5 text-gray-600">Kirmos (50% on beds)</td>
+                        <td className="py-1.5 text-right tabular-nums">{fmt(model.kirmosPerBed)}</td>
+                      </tr>
+                      <tr className="border-b">
+                        <td className="py-1.5 text-gray-600">Founder time (production)</td>
+                        <td className="py-1.5 text-right tabular-nums">{fmt(model.founderProductionPerBed)}</td>
+                      </tr>
+                      <tr className="border-b">
+                        <td className="py-1.5 text-gray-600">Admin</td>
+                        <td className="py-1.5 text-right tabular-nums">{fmt(model.adminPerBed)}</td>
+                      </tr>
+                      <tr className="border-b">
+                        <td className="py-1.5 text-gray-600">Field travel + ops</td>
+                        <td className="py-1.5 text-right tabular-nums">{fmt(model.fieldPerBed)}</td>
+                      </tr>
+                      <tr className="border-b">
+                        <td className="py-1.5 text-gray-600">Long-haul freight</td>
+                        <td className="py-1.5 text-right tabular-nums">{fmt(inputs.freight_per_bed)}</td>
+                      </tr>
+                      <tr>
+                        <td className="py-1.5 font-semibold">Overhead total</td>
+                        <td className="py-1.5 text-right tabular-nums font-semibold">{fmt(model.overheadPerBed)}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div>
+                  <h4 className="text-sm font-medium mb-2">Fully-loaded (direct + overhead)</h4>
+                  <table className="w-full text-sm">
+                    <tbody>
+                      <tr className="border-b">
+                        <td className="py-1.5 text-gray-600">Defy Kits</td>
+                        <td className="py-1.5 text-right tabular-nums">{fmt(model.fullKits)}</td>
+                      </tr>
+                      <tr className="border-b">
+                        <td className="py-1.5 text-gray-600">Defy Panels</td>
+                        <td className="py-1.5 text-right tabular-nums">{fmt(model.fullPanels)}</td>
+                      </tr>
+                      <tr className="border-b bg-emerald-50/50">
+                        <td className="py-1.5 font-medium">Factory (target)</td>
+                        <td className="py-1.5 text-right tabular-nums font-semibold text-emerald-700">{fmt(model.fullFactory)}</td>
+                      </tr>
+                      <tr className="bg-purple-50/50">
+                        <td className="py-1.5 font-medium">Community (vision)</td>
+                        <td className="py-1.5 text-right tabular-nums font-semibold text-purple-700">{fmt(model.fullCommunity)}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <p className="text-xs text-gray-500 mt-3">
+                    Commercial counterfactual: {fmt(inputs.commercial_low)}–{fmt(inputs.commercial_high)}.{' '}
+                    Factory @ this volume is {model.valueVsCommercial.toFixed(1)}× cheaper than commercial.
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Idiot Index */}
+          <Card>
+            <CardContent className="pt-6">
+              <h3 className="text-lg font-semibold mb-2">Idiot Index — first-principles markup</h3>
+              <p className="text-xs text-gray-600 mb-4">
+                Musk's metric: <code>finished cost ÷ raw material cost</code>. Ratios &gt; 3× are candidates for in-housing.
+                First-principles floor for a bed: <strong>{fmt(model.firstPrinciplesFloor)}</strong>.
+                We currently pay <strong>{fmt(model.stateKits)}</strong> via Defy Kits. The gap is{' '}
+                <strong className="text-amber-700">{fmt(model.supplyChainMarkup)}/bed</strong> of supply-chain markup we
+                can capture in-house at scale.
+              </p>
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                <IdiotCard label="HDPE kit (Defy)" ratio={model.idiotKit} raw={model.hdpeRawCost} current={inputs.defy_kit_per_bed} />
+                <IdiotCard label="Defy panels (x2)" ratio={model.idiotPanel} raw={model.hdpeRawCost} current={inputs.defy_panel_each * 2} />
+                <IdiotCard label="Steel poles" ratio={model.idiotSteel} raw={10.34} current={inputs.steel_per_bed} />
+                <IdiotCard label="Canvas" ratio={model.idiotCanvas} raw={35} current={inputs.canvas_per_bed} />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* QBE-style capital ask + payback */}
+          <Card>
+            <CardContent className="pt-6">
+              <h3 className="text-lg font-semibold mb-3">Capital ask + payback (QBE-ready)</h3>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
+                <div className="border rounded p-4">
+                  <p className="text-xs text-gray-500 uppercase tracking-wide">Capital ask</p>
+                  <p className="text-2xl font-bold tabular-nums mt-1">
+                    {fmt(model.capitalLow)}–{fmt(model.capitalHigh)}
+                  </p>
+                  <p className="text-xs text-gray-600 mt-2">Shredder + hot-press + CNC + workbench</p>
+                </div>
+                <div className="border rounded p-4 bg-emerald-50/50">
+                  <p className="text-xs text-emerald-700 uppercase tracking-wide">Savings per bed</p>
+                  <p className="text-2xl font-bold tabular-nums text-emerald-700 mt-1">{fmt(model.savingsPerBed)}</p>
+                  <p className="text-xs text-gray-600 mt-2">Defy Kits → Factory in-house</p>
+                </div>
+                <div className="border rounded p-4">
+                  <p className="text-xs text-gray-500 uppercase tracking-wide">Payback @ {inputs.beds_per_year}/yr</p>
+                  <p className="text-2xl font-bold tabular-nums mt-1">
+                    {model.paybackYearsLow.toFixed(1)}–{model.paybackYearsHigh.toFixed(1)}y
+                  </p>
+                  <p className="text-xs text-gray-600 mt-2">
+                    {Math.round(model.paybackBedsLow)}–{Math.round(model.paybackBedsHigh)} beds to recoup
+                  </p>
+                </div>
+              </div>
+              <p className="text-xs text-gray-600 mt-4">
+                <strong>The QBE pitch:</strong> Invest {fmt(model.capitalLow)}–{fmt(model.capitalHigh)} to unlock
+                in-house production. Per-bed cost drops from {fmt(model.stateKits)} (Defy Kits) to {fmt(model.stateFactory)}{' '}
+                (Factory) — saving {fmt(model.savingsPerBed)}/bed. At {inputs.beds_per_year} beds/yr capacity, the capital
+                pays back in {model.paybackYearsLow.toFixed(1)}–{model.paybackYearsHigh.toFixed(1)} years, then every
+                future bed delivers {fmt(model.savingsPerBed)} more to community.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      <p className="text-xs text-gray-400 text-center pt-4 border-t">
+        Source: <code>v2/src/lib/data/cost-model-scenarios.json</code> + <code>supplier-quotes.ts</code>. All defaults
+        verified from invoice OCR + Notion BK 2026-05-28. Change a slider to test an assumption — the page is
+        read-only of the underlying canonical numbers.
+      </p>
+    </div>
+  );
+}
+
+function IdiotCard({ label, ratio, raw, current }: { label: string; ratio: number; raw: number; current: number }) {
+  const color =
+    ratio >= 5 ? 'border-red-300 bg-red-50 text-red-700'
+    : ratio >= 3 ? 'border-orange-300 bg-orange-50 text-orange-700'
+    : ratio >= 2 ? 'border-blue-300 bg-blue-50 text-blue-700'
+    : 'border-gray-200 bg-gray-50 text-gray-700';
+  return (
+    <div className={`border rounded p-3 ${color}`}>
+      <p className="text-xs uppercase tracking-wide">{label}</p>
+      <p className="text-2xl font-bold tabular-nums mt-1">{ratio.toFixed(1)}×</p>
+      <p className="text-[10px] mt-1">{fmt(raw)} raw → {fmt(current)} paid</p>
+    </div>
+  );
+}

--- a/v2/src/app/admin/cost-model/page.tsx
+++ b/v2/src/app/admin/cost-model/page.tsx
@@ -1,0 +1,30 @@
+/**
+ * Interactive cost-model explorer — sliders + matrix + Musk Idiot Index.
+ * Designed for QBE-style funder pitches: capital ask + unit economics + scaling plan.
+ *
+ * All defaults come from `cost-model-scenarios.json`. Sliders let you override
+ * any input and watch the matrix recompute live. Source of truth stays the JSON;
+ * this page is the playground.
+ */
+import { CostModelExplorer } from './cost-model-explorer';
+
+export const metadata = {
+  title: 'Cost Model Explorer — Goods on Country',
+  description: 'Interactive bed cost model: sliders, scenarios, Idiot Index, QBE-ready capital ask.',
+};
+
+export default function CostModelPage() {
+  return (
+    <div className="container mx-auto py-8 max-w-7xl">
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold">Bed Cost Model Explorer</h1>
+        <p className="text-sm text-gray-600 mt-2">
+          Musk-style first-principles cost model. Sliders drive the matrix below — adjust assumptions and
+          see how the unit economics, capital ask, and scaling plan respond live. All defaults verified from
+          Defy/Centre Canvas/Coastal Fasteners invoices + Notion BK review 2026-05-28.
+        </p>
+      </div>
+      <CostModelExplorer />
+    </div>
+  );
+}

--- a/v2/src/components/production/cost-model-scenarios-card.tsx
+++ b/v2/src/components/production/cost-model-scenarios-card.tsx
@@ -118,7 +118,6 @@ export function CostModelScenariosCard() {
               <thead className="text-left text-gray-500 border-b">
                 <tr>
                   <th className="pb-2 font-medium">Volume</th>
-                  <th className="pb-2 font-medium text-right">Defy fully-fab</th>
                   <th className="pb-2 font-medium text-right">Defy Kits</th>
                   <th className="pb-2 font-medium text-right">Defy Panels</th>
                   <th className="pb-2 font-medium text-right">Factory</th>
@@ -129,7 +128,6 @@ export function CostModelScenariosCard() {
                 {fullyLoaded.map((row, i) => (
                   <tr key={row.volume_label} className={`border-b last:border-0 ${i === 2 ? 'bg-emerald-50/30' : ''}`}>
                     <td className="py-2 font-medium">{row.volume_label}</td>
-                    <td className="py-2 text-right tabular-nums">{fmtMoney(row.state_1_defy_fab)}</td>
                     <td className="py-2 text-right tabular-nums">{fmtMoney(row.state_2_defy_kits)}</td>
                     <td className="py-2 text-right tabular-nums">{fmtMoney(row.state_3_defy_panels)}</td>
                     <td className="py-2 text-right tabular-nums font-medium text-emerald-700">

--- a/v2/src/lib/data/cost-model-scenarios.json
+++ b/v2/src/lib/data/cost-model-scenarios.json
@@ -1,45 +1,38 @@
 {
   "meta": {
-    "title": "Goods bed cost model v4 — 4-path supply model with Idiot Index (Notion BK locked)",
-    "version": "v4",
+    "title": "Goods bed cost model v5 — verified-from-invoices, Musk first-principles",
+    "version": "v5",
     "created": "2026-05-28",
-    "supersedes": "v3 (2026-05-28 morning)",
-    "source_doc": "Notion: 🧮 Goods // Plastic Sheet Calc's (BK review) + supplier-quotes.ts canonical BOM",
-    "verified_from": "act-infra/scripts/ocr-defy-bills.mjs (Defy) + ocr-bed-supplier-bills.mjs (all bed-relevant suppliers)",
-    "locked_inputs_2026_05_28": [
-      "20kg HDPE per bed (one sheet's worth, with offcuts)",
-      "$2.00/kg raw shred + $0.75/kg delivery = $2.75/kg landed",
-      "$27/bed steel (DNA Steel canonical) — NOT the $10.34 in some Notion calcs",
-      "$95/bed canvas (2.1m × $4.80/m, Notion BK supersedes earlier $93.50)",
-      "$3.20 caps + $3.50 screws = $6.70/bed hardware",
-      "Defy kit $344.05/bed (INV-1602 + INV-1732 verified)",
-      "Defy assembly labour $55.95/bed (verified line)",
-      "Single Bed fully-fab'd $600 (INV-1507, 25 beds Nov 2025)",
-      "$750 unified retail price",
-      "Founder time: 30 prod / 50 fundraising / 25 commercial / 45 ACT-wide @ $1K/day = $150K/yr",
-      "Kirmos facility labour 50% on beds = $2,250/month = $27K/yr",
-      "Throughput: Factory 4 beds/day, Defy Kits 10 beds/day, Community 5 beds/day"
+    "supersedes": "v4 (state_1 was Weave Bed, canvas was $95 not $93.50)",
+    "source_doc": "Deep OCR of canvas + Bunnings + INV-1507 invoices + Coastal Fasteners + Notion BK",
+    "verified_from": "act-infra/scripts/ocr-defy-bills.mjs + ocr-bed-supplier-bills.mjs + ocr-bed-elements-deep.mjs",
+    "key_corrections_2026_05_28": [
+      "INV-1507 $600/bed was WEAVE BED (discontinued) — state_1 removed entirely",
+      "Canvas: $93.50/cover verified actual (Centre Canvas 50+110×2 covers in 2026), not $95",
+      "Screws: 16/bed × $0.065 (Coastal Fasteners verified) = $1.04/bed",
+      "Bolts: 2/bed × $0.50 (est) = $1.00/bed",
+      "Hardware total: $5.24/bed (caps $3.20 + screws $1.04 + bolts $1.00) — was $6.70 estimated",
+      "Centre Canvas $14,915 mistag retag pending (ACT-IN → ACT-GD)"
     ]
   },
   "physics": {
     "hdpe_density_g_per_cm3": 0.96,
     "hdpe_kg_per_bed": 20,
-    "_hdpe_per_bed_source": "Ben confirmed 2026-05-28 — one sheet's worth (the other ~5kg is offcuts/press loss not in the bed).",
     "raw_hdpe_cost_per_bed_no_delivery": 40.00,
     "raw_hdpe_cost_per_bed_with_delivery": 55.00,
     "_delivery_rate": "$0.75/kg ($900 / 1200kg per Defy delivery quote)"
   },
   "canonical_bom": {
-    "_note": "Mirrors supplier-quotes.ts. Defy-kit path direct materials = $472.75/bed.",
+    "_note": "Mirrors supplier-quotes.ts. Defy-kit path direct materials = $469.79/bed.",
     "hdpe_kit_defy": { "amount": 344.05, "source": "Defy INV-1602 + INV-1732", "confidence": "verified" },
     "steel_poles": { "amount": 27.00, "source": "DNA Steel Direct (Alice Springs, in Notion)", "confidence": "verified" },
-    "canvas": { "amount": 95.00, "basis": "2.1m × $4.80/m", "source": "Centre Canvas (Alice Springs, in Notion)", "confidence": "verified" },
+    "canvas": { "amount": 93.50, "source": "Centre Canvas (3 invoices 2026, 270 covers @ $93.50)", "confidence": "verified" },
     "end_caps": { "amount": 3.20, "basis": "4 × $0.80", "source": "Hardware supplier", "confidence": "verified" },
-    "screws": { "amount": 3.50, "source": "Hardware supplier (Notion BK 2026-05-28)", "confidence": "verified" },
-    "defy_kit_direct_total": 472.75
+    "screws": { "amount": 1.04, "basis": "16 × $0.065", "source": "Coastal Fasteners RB20247673190", "confidence": "verified" },
+    "bolts": { "amount": 1.00, "basis": "2 × $0.50 est", "source": "Coastal Fasteners (rate estimated)", "confidence": "inferred" },
+    "defy_kit_direct_total": 469.79
   },
   "defy_verified_rates": {
-    "single_bed_fully_fabricated": { "amount": 600.00, "source": "INV-1507 Nov 2025, 25 beds", "confidence": "verified" },
     "bed_kit_cut_finished": { "amount": 344.05, "source": "INV-1602 (92 kits) + INV-1732 (50 kits)", "confidence": "verified" },
     "pre_pressed_panel_each": { "amount": 200.00, "source": "INV-1731 (20 panels bulk, 1200×1200×19mm)", "confidence": "verified" },
     "cut_and_finish_only": { "amount": 121.00, "source": "INV-1602 (16 beds, pre-purchased sheets)", "confidence": "verified" },
@@ -51,31 +44,20 @@
     "production_operator_per_day": 400,
     "production_operator_per_hour": 50,
     "kirmos_facility_per_hour": 45,
-    "kirmos_monthly_50pct_to_beds": 2250,
-    "_basis": "Notion BK + Kirmos invoice analysis 2026-05-28"
+    "kirmos_monthly_50pct_to_beds": 2250
   },
   "build_states": {
-    "state_1_defy_fully_fabricated": {
-      "label": "Defy fully-fabricated (Single Bed @ $600)",
-      "components": [
-        { "label": "Single Bed fully fab'd (HDPE + steel + canvas + assembly)", "amount": 600.00 }
-      ],
-      "direct_total": 600.00,
-      "capital_added": 0,
-      "capital_cumulative": 0,
-      "_note": "INV-1507 verified rate. We rarely buy this way — usually kits or panels then assemble."
-    },
     "state_2_defy_kits": {
       "label": "Defy Kits (buy cut+finished kits, assemble in-house)",
       "components": [
         { "label": "Defy bed kit (cut+finished, no hardware)", "amount": 344.05 },
         { "label": "Steel poles (DNA Steel)", "amount": 27.00 },
-        { "label": "Canvas (Centre Canvas)", "amount": 95.00 },
-        { "label": "End caps + screws", "amount": 6.70 },
+        { "label": "Canvas (Centre Canvas)", "amount": 93.50 },
+        { "label": "End caps + screws + bolts", "amount": 5.24 },
         { "label": "In-house assembly labour ($400/day ÷ 10 beds)", "amount": 40.00 },
         { "label": "Freight on Defy material (est)", "amount": 25.00 }
       ],
-      "direct_total": 537.75,
+      "direct_total": 534.79,
       "capital_added": 2000,
       "capital_cumulative": 2000,
       "throughput_beds_per_day": 10,
@@ -86,12 +68,12 @@
       "components": [
         { "label": "Defy pre-pressed panels (2 × $200)", "amount": 400.00 },
         { "label": "Steel poles", "amount": 27.00 },
-        { "label": "Canvas", "amount": 95.00 },
-        { "label": "End caps + screws", "amount": 6.70 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "End caps + screws + bolts", "amount": 5.24 },
         { "label": "Diesel (CNC only, no pressing)", "amount": 5.00 },
         { "label": "Labour ($400/day ÷ 7.5 beds)", "amount": 53.33 }
       ],
-      "direct_total": 587.03,
+      "direct_total": 584.07,
       "capital_added": 38000,
       "capital_cumulative": 40000,
       "throughput_beds_per_day": 4,
@@ -104,14 +86,14 @@
         { "label": "Diesel (25L/day ÷ 5 beds press + CNC)", "amount": 15.00 },
         { "label": "Labour ($400/day ÷ 5 beds)", "amount": 80.00 },
         { "label": "Steel poles", "amount": 27.00 },
-        { "label": "Canvas", "amount": 95.00 },
-        { "label": "End caps + screws", "amount": 6.70 }
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "End caps + screws + bolts", "amount": 5.24 }
       ],
-      "direct_total": 278.70,
+      "direct_total": 275.74,
       "capital_added": 160000,
       "capital_cumulative": 200000,
       "throughput_beds_per_day": 4,
-      "_note": "TARGET state. $471.30 margin at $750 retail (63%). 4 beds/day × 250 working days = 1,000/yr from one facility."
+      "_note": "TARGET state. $474.26 margin at $750 retail (63%). 4 beds/day × 250 working days = 1,000/yr from one facility."
     },
     "state_5_community": {
       "label": "Community (waste plastic collected, volunteer-run)",
@@ -119,82 +101,67 @@
         { "label": "Community-collected plastic (CDP or volunteer)", "amount": 0.00 },
         { "label": "Diesel (generator)", "amount": 15.00 },
         { "label": "Steel poles", "amount": 27.00 },
-        { "label": "Canvas", "amount": 95.00 },
-        { "label": "End caps + screws", "amount": 6.70 },
+        { "label": "Canvas", "amount": 93.50 },
+        { "label": "End caps + screws + bolts", "amount": 5.24 },
         { "label": "Labour (volunteer / CDP / community)", "amount": 0.00 }
       ],
-      "direct_total": 143.70,
+      "direct_total": 140.74,
       "capital_added": 30000,
       "capital_cumulative": 230000,
       "throughput_beds_per_day": 5,
       "community_jobs_created": true,
-      "_note": "Vision state — $606.30 margin at $750 retail (81%). Almost the entire sale price recirculates into the community enterprise."
+      "_note": "Vision state — $609.26 margin at $750 retail (81%). Almost the entire sale price recirculates into the community enterprise."
     }
   },
+  "first_principles_floor": {
+    "_principle": "Musk Idiot Index: what's the absolute minimum a bed could cost if every input was bought at raw-market rate and assembled at industry-low labour rates?",
+    "components": [
+      { "element": "HDPE plastic raw shred", "qty": "20 kg", "raw_rate": "$2/kg", "cost": 40.00, "source": "Defy INV-1731 shred bulk rate" },
+      { "element": "Galvanised steel pipe raw", "qty": "1.88 m", "raw_rate": "$5.50/m", "cost": 10.34, "source": "Brisbane Steel Xero invoice rate" },
+      { "element": "Cotton 12oz canvas raw", "qty": "2.1 m", "raw_rate": "$15-20/m raw", "cost": 35.00, "source": "12oz cotton duck wholesale benchmark" },
+      { "element": "End caps bulk", "qty": "4", "raw_rate": "$0.50 ea bulk", "cost": 2.00, "source": "Bulk hardware estimate" },
+      { "element": "Screws + bolts", "qty": "16 + 2", "raw_rate": "$0.065 + $0.30 ea bulk", "cost": 1.65, "source": "Coastal Fasteners verified + bulk bolt estimate" },
+      { "element": "Operator labour @ 10 beds/day", "qty": "0.1 day", "raw_rate": "$400/day", "cost": 40.00, "source": "Industry-low fabrication rate" }
+    ],
+    "floor_total_per_bed": 128.99,
+    "current_defy_kit_direct": 469.79,
+    "gap_supply_chain_markup": 340.80,
+    "_implication": "$340.80/bed of supply-chain markup we could capture in-house at scale. That's the capital-investment case."
+  },
   "idiot_index": [
-    { "element": "Defy kit vs in-house factory plastic", "raw_low": 55.00, "raw_high": 55.00, "current": 344.05, "index_low": 6.3, "index_high": 6.3, "markup_pays_for": "Shredding, pressing, CNC, finishing, Defy margin. Biggest leverage — moves cost from $344 to $55 if we shred + press + CNC in-house." },
-    { "element": "Defy panels vs in-house pressed sheets", "raw_low": 55.00, "raw_high": 55.00, "current": 400.00, "index_low": 7.3, "index_high": 7.3, "markup_pays_for": "Hot-press + Defy margin. Panel-path is the WORST value — buy raw shred or buy finished kits, not panels." },
-    { "element": "Defy assembly vs in-house assembly", "raw_low": 40.00, "raw_high": 80.00, "current": 55.95, "index_low": 0.7, "index_high": 1.4, "markup_pays_for": "Defy assembly is already competitive ($55.95 vs in-house $40-$80 depending on facility throughput)." },
-    { "element": "Steel (DNA Steel direct vs raw market)", "raw_low": 12.00, "raw_high": 18.00, "current": 27.00, "index_low": 1.5, "index_high": 2.3, "markup_pays_for": "Cut to length, drill, deliver to Alice Springs." },
-    { "element": "Canvas (Centre Canvas custom)", "raw_low": 35.00, "raw_high": 50.00, "current": 95.00, "index_low": 1.9, "index_high": 2.7, "markup_pays_for": "Cut, hem, sew, grommets, Centre Canvas margin. 2.1m of canvas at $4.80/m." },
-    { "element": "End caps (4 per bed)", "raw_low": 0.50, "raw_high": 1.00, "current": 3.20, "index_low": 3.2, "index_high": 6.4, "markup_pays_for": "Bulk-buy supplier margin on round ribbed plastic caps." },
-    { "element": "Screws (frame fasteners)", "raw_low": 1.00, "raw_high": 2.00, "current": 3.50, "index_low": 1.8, "index_high": 3.5, "markup_pays_for": "Hardware retail markup." }
+    { "element": "HDPE plastic kit (Defy)", "raw_low": 40.00, "raw_high": 40.00, "current": 344.05, "index_low": 8.6, "index_high": 8.6, "markup_pays_for": "Shredding + pressing + CNC + finishing + Defy margin. BIGGEST LEVERAGE — moves $304/bed if we shred + press + CNC in-house." },
+    { "element": "Defy panels (alternative path)", "raw_low": 40.00, "raw_high": 40.00, "current": 400.00, "index_low": 10.0, "index_high": 10.0, "markup_pays_for": "Hot-press + Defy margin. Panel-path is the WORST value — buy raw shred or buy finished kits, not panels." },
+    { "element": "Steel poles (DNA Steel finished)", "raw_low": 10.34, "raw_high": 15.00, "current": 27.00, "index_low": 1.8, "index_high": 2.6, "markup_pays_for": "Cut to length + drill + Alice Springs delivery. Already reasonable." },
+    { "element": "Canvas (Centre Canvas finished)", "raw_low": 32.00, "raw_high": 45.00, "current": 93.50, "index_low": 2.1, "index_high": 2.9, "markup_pays_for": "Cut + hem + grommet + sew + sewist labour. Centre Canvas is competitive against raw 12oz cotton at $62/m self-cut ($130/bed)." },
+    { "element": "End caps", "raw_low": 0.50, "raw_high": 0.80, "current": 0.80, "index_low": 1.0, "index_high": 1.6, "markup_pays_for": "Almost no markup — bulk-supplier direct." },
+    { "element": "Screws", "raw_low": 0.05, "raw_high": 0.07, "current": 0.065, "index_low": 0.9, "index_high": 1.4, "markup_pays_for": "At-cost from Coastal Fasteners — already raw rate." },
+    { "element": "Defy assembly labour", "raw_low": 40.00, "raw_high": 80.00, "current": 55.95, "index_low": 0.7, "index_high": 1.4, "markup_pays_for": "Already competitive — Defy assembly is reasonable vs in-house $40-$80." }
   ],
   "founder_time_allocation": {
     "rate_per_day": 1000,
     "total_days_per_year_on_goods": 150,
     "split": [
-      { "label": "Production-related (oversight, QA, design iteration, supplier rel.)", "days": 30, "annual_cost": 30000, "allocate_to": "bed-overhead" },
-      { "label": "Fundraising / philanthropy (briefs, asks, reporting, donor rel.)", "days": 50, "annual_cost": 50000, "allocate_to": "funding-side-offset" },
-      { "label": "Commercialisation / buyer dev (Centrecorp, councils, sales)", "days": 25, "annual_cost": 25000, "allocate_to": "funding-side-offset" },
+      { "label": "Production-related", "days": 30, "annual_cost": 30000, "allocate_to": "bed-overhead" },
+      { "label": "Fundraising / philanthropy", "days": 50, "annual_cost": 50000, "allocate_to": "funding-side-offset" },
+      { "label": "Commercialisation / buyer dev", "days": 25, "annual_cost": 25000, "allocate_to": "funding-side-offset" },
       { "label": "Governance, strategy, comms, brand", "days": 45, "annual_cost": 45000, "allocate_to": "act-wide-overhead" }
-    ],
-    "_principle": "Only production-related founder time goes onto beds. The fundraising/commercial portion OFFSETS bed cost via dollars raised; the governance portion is ACT-wide, not Goods-specific."
+    ]
   },
   "overhead_per_volume": [
-    {
-      "label": "Today (100 beds/yr)",
-      "beds_per_year": 100,
-      "kirmos_per_bed": 270,
-      "founder_production_per_bed": 300,
-      "admin_per_bed": 147,
-      "field_travel_per_bed": 510,
-      "long_haul_freight_per_bed": 150,
-      "overhead_total": 1377,
-      "_overhead_math": "270 + 300 + 147 + 510 + 150 = 1377"
-    },
-    {
-      "label": "Target (500 beds/yr)",
-      "beds_per_year": 500,
-      "kirmos_per_bed": 54,
-      "founder_production_per_bed": 60,
-      "admin_per_bed": 29,
-      "field_travel_per_bed": 100,
-      "long_haul_freight_per_bed": 100,
-      "overhead_total": 343
-    },
-    {
-      "label": "Vision (1,000 beds/yr at full Factory throughput)",
-      "beds_per_year": 1000,
-      "kirmos_per_bed": 27,
-      "founder_production_per_bed": 30,
-      "admin_per_bed": 15,
-      "field_travel_per_bed": 50,
-      "long_haul_freight_per_bed": 80,
-      "overhead_total": 202
-    }
+    { "label": "Today (100 beds/yr)", "beds_per_year": 100, "kirmos_per_bed": 270, "founder_production_per_bed": 300, "admin_per_bed": 147, "field_travel_per_bed": 510, "long_haul_freight_per_bed": 150, "overhead_total": 1377 },
+    { "label": "Target (500 beds/yr)", "beds_per_year": 500, "kirmos_per_bed": 54, "founder_production_per_bed": 60, "admin_per_bed": 29, "field_travel_per_bed": 100, "long_haul_freight_per_bed": 100, "overhead_total": 343 },
+    { "label": "Vision (1,000 beds/yr)", "beds_per_year": 1000, "kirmos_per_bed": 27, "founder_production_per_bed": 30, "admin_per_bed": 15, "field_travel_per_bed": 50, "long_haul_freight_per_bed": 80, "overhead_total": 202 }
   ],
   "fully_loaded_grid": [
-    { "volume_label": "100/yr today", "state_1_defy_fab": 1977, "state_2_defy_kits": 1915, "state_3_defy_panels": 1964, "state_4_factory": 1656, "state_5_community": 1521 },
-    { "volume_label": "500/yr target", "state_1_defy_fab": 943, "state_2_defy_kits": 881, "state_3_defy_panels": 930, "state_4_factory": 622, "state_5_community": 487 },
-    { "volume_label": "1,000/yr vision", "state_1_defy_fab": 802, "state_2_defy_kits": 740, "state_3_defy_panels": 789, "state_4_factory": 481, "state_5_community": 346 }
+    { "volume_label": "100/yr today", "state_2_defy_kits": 1912, "state_3_defy_panels": 1961, "state_4_factory": 1653, "state_5_community": 1518 },
+    { "volume_label": "500/yr target", "state_2_defy_kits": 878, "state_3_defy_panels": 927, "state_4_factory": 619, "state_5_community": 484 },
+    { "volume_label": "1,000/yr vision", "state_2_defy_kits": 737, "state_3_defy_panels": 786, "state_4_factory": 478, "state_5_community": 343 }
   ],
   "margin_grid_at_750_retail": [
-    { "path": "Defy fully-fabricated", "direct": 600.00, "margin": 150, "margin_pct": 20 },
-    { "path": "Defy Kits", "direct": 537.75, "margin": 212.25, "margin_pct": 28 },
-    { "path": "Defy Panels", "direct": 587.03, "margin": 162.97, "margin_pct": 22 },
-    { "path": "Factory (in-house)", "direct": 278.70, "margin": 471.30, "margin_pct": 63 },
-    { "path": "Community (volunteer + free plastic)", "direct": 143.70, "margin": 606.30, "margin_pct": 81 }
+    { "path": "Defy Kits", "direct": 534.79, "margin": 215.21, "margin_pct": 29 },
+    { "path": "Defy Panels", "direct": 584.07, "margin": 165.93, "margin_pct": 22 },
+    { "path": "Factory (in-house)", "direct": 275.74, "margin": 474.26, "margin_pct": 63 },
+    { "path": "Community (volunteer + free plastic)", "direct": 140.74, "margin": 609.26, "margin_pct": 81 }
   ],
   "fundraising_offset": {
     "philanthropy_days_per_year": 50,
@@ -204,8 +171,7 @@
     "commercial_buyer_benchmark_per_bed": 801,
     "commercial_buyer_source": "Centrecorp INV-0291 (107 beds @ $85,712)",
     "_per_bed_subsidy_at_100_per_year": 2500,
-    "_per_bed_subsidy_at_500_per_year": 500,
-    "_principle": "Fundraising days are an INVESTMENT that generates revenue offsetting bed cost."
+    "_per_bed_subsidy_at_500_per_year": 500
   },
   "counterfactual": {
     "commercial_steel_frame_bed_au_2026_low": 1500,
@@ -225,20 +191,36 @@
     "_capital_ask_low": 90000,
     "_capital_ask_high": 200000
   },
+  "qbe_pitch_inputs": {
+    "_principle": "QBE standard funder pitch: Capital ask + unit economics + scaling plan. Sliders should expose these levers.",
+    "capital_ask_low": 90000,
+    "capital_ask_high": 200000,
+    "beds_per_year_today": 100,
+    "beds_per_year_target": 500,
+    "beds_per_year_vision": 1000,
+    "fully_loaded_today_per_bed": 1912,
+    "fully_loaded_target_per_bed": 619,
+    "fully_loaded_vision_per_bed": 478,
+    "commercial_low": 1500,
+    "commercial_high": 2000,
+    "headline_value_per_dollar_at_target": "Each $1,000 of capital invested unlocks ~$X/bed cost reduction, ~Y beds/yr capacity"
+  },
   "mistags_to_fix": [
-    { "supplier": "Defy Washing Machine Cladding (multiple bills)", "amount": 25000, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
-    { "supplier": "Defy Coasters (INV-1174 + INV-1637)", "amount": 10000, "current_tag": "ACT-GD", "correct_tag": "ACT-EL (marketing/merch)" },
-    { "supplier": "Defy Design/R&D (INV-1258 + INV-1259)", "amount": 7000, "current_tag": "ACT-GD bed-COGS", "correct_tag": "ACT-GD capital/R&D" },
-    { "supplier": "Utopia trip flights/accommodation", "amount": 24507, "current_tag": "ACT-IN", "correct_tag": "ACT-GD" },
+    { "supplier": "Centre Canvas (3 bills)", "amount": 14915, "current_tag": "ACT-IN", "correct_tag": "ACT-GD", "_note": "Verified ex deep OCR 2026-05-28 — 50 + 110 covers @ $93.50, plus duplicate $10,285 to reconcile" },
+    { "supplier": "Coastal Fasteners screws", "amount": 131, "current_tag": "ACT-FM", "correct_tag": "ACT-GD or split", "_note": "2000 screws @ $0.065 — shared with Goods facility" },
+    { "supplier": "Defy Washing Machine Cladding", "amount": 25000, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
+    { "supplier": "Defy Coasters", "amount": 10000, "current_tag": "ACT-GD", "correct_tag": "ACT-EL" },
+    { "supplier": "Defy Design/R&D", "amount": 7000, "current_tag": "ACT-GD bed-COGS", "correct_tag": "ACT-GD capital/R&D" },
+    { "supplier": "Utopia trip flights/accom", "amount": 24507, "current_tag": "ACT-IN", "correct_tag": "ACT-GD" },
     { "supplier": "1300 Washer", "amount": 13980, "current_tag": "ACT-GD", "correct_tag": "ACT-FM" },
     { "supplier": "Carla Furnishers duplicate", "amount": 11180, "current_tag": "ACT-GD", "correct_tag": "VOID DUPLICATE" },
-    { "supplier": "R M Tanner Triple Axle", "amount": 19950, "current_tag": "ACT-GD", "correct_tag": "Different project entirely — remove from ACT-GD" },
+    { "supplier": "R M Tanner Triple Axle (Weave Bed era, different project)", "amount": 19950, "current_tag": "ACT-GD", "correct_tag": "Different project — remove from ACT-GD" },
     { "supplier": "Zinus Australia (Basket Bed v1 mattress toppers)", "amount": 28690, "current_tag": "ACT-GD", "correct_tag": "ACT-GD-archive (Basket Bed v1, discontinued)" }
   ],
   "open_questions_for_defy": [
-    "Volume quote at 100 / 500 / 1,000 / 5,000 beds/yr — what does the $344.05/bed kit rate become?",
+    "Volume quote at 100 / 500 / 1,000 / 5,000 beds/yr — what does $344.05/bed kit become?",
     "Build-to-supply: cheaper if ACT sources steel (DNA Steel) + canvas (Centre Canvas) direct and supplies to Defy for kit-assembly only?",
     "In-house assembly payback: at what volume does taking the $55.95/bed assembly in-house pay back the $90K-$200K capex?",
-    "Confirm INV-1731 freight cost ($874 for 1,200kg + 20 panels Sydney → Sunshine Coast)?"
+    "Confirm INV-1731 freight (3 × $450 = $1,350) Sydney → Sunshine Coast for 1200kg shred + 20 panels?"
   ]
 }

--- a/v2/src/lib/data/cost-model-scenarios.ts
+++ b/v2/src/lib/data/cost-model-scenarios.ts
@@ -14,7 +14,6 @@ import { fullyLoadedCostPerBed, stretchBedBOM, factoryDirectMaterials } from './
 export type CostModelScenarios = typeof scenarios;
 
 export type BuildStateKey =
-  | 'state_1_defy_fully_fabricated'
   | 'state_2_defy_kits'
   | 'state_3_defy_panels'
   | 'state_4_factory'
@@ -53,7 +52,6 @@ export interface OverheadRow {
 
 export interface FullyLoadedRow {
   volume_label: string;
-  state_1_defy_fab: number;
   state_2_defy_kits: number;
   state_3_defy_panels: number;
   state_4_factory: number;
@@ -74,7 +72,6 @@ export function getModel(): CostModelScenarios {
 export function listBuildStates(): BuildState[] {
   const states = scenarios.build_states;
   const keys: BuildStateKey[] = [
-    'state_1_defy_fully_fabricated',
     'state_2_defy_kits',
     'state_3_defy_panels',
     'state_4_factory',
@@ -120,28 +117,28 @@ export function getOpenQuestionsForDefy() {
 }
 
 /**
- * Reconcile the v4 Factory-state direct total against `factoryDirectMaterials`
+ * Reconcile the v5 Factory-state direct total against `factoryDirectMaterials`
  * in supplier-quotes.ts. If they drift, the card surfaces a warning so the two
  * files can't silently disagree about the factory-path cost.
+ *
+ * Note: v5 dropped state_1_defy_fully_fabricated (was Weave Bed @ $600, discontinued).
+ * `fullyLoadedCostPerBed` from supplier-quotes.ts ($600) is kept as a legacy reference
+ * but no longer mapped to a build state — the canonical path is now Defy Kits ($534.79)
+ * or Factory ($275.74).
  */
 export function reconcileAgainstCanonicalBOM(): {
   factoryTotal: number;
   canonicalFactoryMaterials: number;
-  state1Total: number;
-  canonicalFullyLoaded: number;
+  legacyFullyLoaded: number;
   matches: boolean;
   bom: typeof stretchBedBOM;
 } {
-  const state1 = scenarios.build_states.state_1_defy_fully_fabricated;
   const state4 = scenarios.build_states.state_4_factory;
   return {
     factoryTotal: state4.direct_total,
     canonicalFactoryMaterials: factoryDirectMaterials,
-    state1Total: state1.direct_total,
-    canonicalFullyLoaded: fullyLoadedCostPerBed,
-    matches:
-      state4.direct_total === factoryDirectMaterials &&
-      state1.direct_total === fullyLoadedCostPerBed,
+    legacyFullyLoaded: fullyLoadedCostPerBed,
+    matches: state4.direct_total === factoryDirectMaterials,
     bom: stretchBedBOM,
   };
 }

--- a/v2/src/lib/data/supplier-quotes.ts
+++ b/v2/src/lib/data/supplier-quotes.ts
@@ -94,14 +94,14 @@ export const supplierQuotes: SupplierQuote[] = [
     contact: 'Wayne',
     email: '',
     component: 'Canvas Sleeping Surface',
-    description: 'Heavy-duty Australian canvas stretcher covers with pole sleeves. Fully washable, quick-drying. 2.1m × $4.80/m.',
-    unitPrice: 95.00,
+    description: 'Heavy-duty Australian canvas stretcher cover with pole sleeves. Fully washable, quick-drying. Cut + hemmed + sewn.',
+    unitPrice: 93.50,
     currency: 'AUD',
     moq: 50,
     leadTimeDays: 14,
     validUntil: '2026-12-31',
     status: 'active',
-    notes: 'Alice Springs based (Wayne, 4 Smith St, 08 8952 2453). Custom sewn to spec. $95/bed (2.1m × $4.80/m) verified in Notion BK review 2026-05-28 (supersedes earlier $93.50 figure). Real supplier (confirmed by Ben 2026-05-28). One Xero invoice exists ("Canvas stretcher covers" $10,285, INV ADG 6524337) but is mis-tagged ACT-IN; the same Xero contact is also polluted with Canva software-subscription lines (contact-name collision). Most canvas invoicing lives in Notion.',
+    notes: 'Alice Springs based (Wayne, 4 Smith St, 08 8952 2453). Custom sewn to spec. **$93.50/cover VERIFIED** ex 3 Centre Canvas invoices 2026: Jan 50 covers + Mar 110 covers × 2 batches. All tagged ACT-IN in Xero — retag ACT-IN→ACT-GD ($14,915 retag pending). The 2026-03-31 duplicate ($10,285 AUTHORISED + $10,285 PAID) needs reconciling. The earlier "$95/bed (2.1m × $4.80/m)" calc was Notion BK working figure — actual Centre Canvas invoice price is $93.50 flat for a finished cover.',
     xeroInvoice: 'ADG 6524337',
   },
 
@@ -126,18 +126,36 @@ export const supplierQuotes: SupplierQuote[] = [
   // Screws — frame fasteners
   {
     id: 'screws-frame-2026',
-    supplier: 'Hardware Supplier',
+    supplier: 'Coastal Fasteners',
     contact: '',
     email: '',
-    component: 'Frame Screws',
-    description: 'Frame fasteners for HDPE legs to steel poles. ~$3.50/bed.',
-    unitPrice: 3.50,
+    component: 'Frame Screws (16 per bed)',
+    description: '16 frame screws per bed. Coastal Fasteners "8-9x 41 C3 Trec" @ $0.065/screw verified ex Xero RB20247673190 (2000 screws @ $130.94, 2026-04-16, currently tagged ACT-FM but used for Goods facility).',
+    unitPrice: 1.04,
     currency: 'AUD',
     moq: 1000,
     leadTimeDays: 5,
     validUntil: null,
     status: 'active',
-    notes: 'Identified in Notion BK 2026-05-28. Generic hardware item. Distinct from end caps — both required per bed.',
+    notes: 'VERIFIED ex Coastal Fasteners Xero invoice 2026-04-16 ($130.94 / 2000 screws = $0.0645/screw). 16 screws/bed × $0.065 = $1.04/bed. Coastal Fasteners bill is tagged ACT-FM (Facilities Management) but the same screws are used for Goods bed assembly.',
+    xeroInvoice: 'RB20247673190',
+  },
+
+  // Bolts — frame fasteners
+  {
+    id: 'bolts-frame-2026',
+    supplier: 'Coastal Fasteners',
+    contact: '',
+    email: '',
+    component: 'Frame Bolts (2 per bed)',
+    description: '2 galvanised hex bolts per bed (M8 estimate). ~$0.50 each = $1.00/bed.',
+    unitPrice: 1.00,
+    currency: 'AUD',
+    moq: 200,
+    leadTimeDays: 5,
+    validUntil: null,
+    status: 'active',
+    notes: 'Ben confirmed 2026-05-28: 2 bolts + 16 screws per bed. Bolt rate estimated at $0.50/bolt (galvanised hex M8 bulk) pending Coastal Fasteners line-item OCR. Update with verified rate when next invoice arrives.',
     xeroInvoice: null,
   },
 
@@ -163,49 +181,55 @@ export const supplierQuotes: SupplierQuote[] = [
 export const WEBSITE_PRICE = 750; // Unified website price (2026-05-26). Institutional/retail collapsed to one.
 
 // Direct materials per bed (bought-in BOM, Defy-kit path), reconciled to ACTUAL
-// invoices 2026-05-28 + Notion BK review:
+// invoices 2026-05-28 (deep OCR of every Centre Canvas + Defy + Coastal Fasteners bill):
 //   HDPE plastic kit $344.05/bed — verified ex Defy invoices INV-1602 ("107 Beds")
 //     + INV-1732 ("50 Beds"): "kits in 19mm Jungle recycled plastic, cut & finished,
-//     excl. assembly & hardware." The old $45 was an aspirational on-country-from-waste
-//     figure, NOT what we pay. On-country production targets bring this down with volume —
-//     the FACTORY-PATH equivalent is ~$55 raw HDPE (20kg × $2.75/kg incl. delivery), with
-//     the rest of the in-house cost captured in `factoryDirectMaterials` below.
-//   Steel (gal pipe) $27/bed — DNA Steel Direct, Alice Springs (Notion BOM, canonical).
-//   Canvas $95/bed — Centre Canvas, Alice Springs (2.1m × $4.80/m per Notion BK 2026-05-28;
-//     supersedes earlier $93.50).
+//     excl. assembly & hardware." The FACTORY-PATH equivalent is ~$55 raw HDPE
+//     (20kg × $2.75/kg incl. delivery) — see `factoryDirectMaterials` below.
+//   Steel (gal pipe) $27/bed — DNA Steel Direct, Alice Springs (Notion BOM canonical;
+//     invoices live in Notion not Xero).
+//   Canvas $93.50/bed — Centre Canvas, Alice Springs. VERIFIED actual rate from 3 invoices
+//     2026 (50 + 110 × 2 covers). (Earlier $95 Notion-BK rounding superseded by actuals.)
 //   End caps $3.20/bed — 4 × $0.80 round ribbed caps.
-//   Screws $3.50/bed — frame fasteners (added 2026-05-28 from Notion BK).
-// THIS IS NOT THE FULLY-LOADED COST — see fullyLoadedCostPerBed below (adds Defy assembly
-// ~$55.95/bed, freight Sydney→Alice ~$874/shipment, facility labour + overhead, founder time).
+//   Screws $1.04/bed — 16 screws × $0.065 (Coastal Fasteners verified, 2026-04-16).
+//   Bolts $1.00/bed — 2 × ~$0.50 (estimate pending invoice line-item OCR).
+// THIS IS NOT THE FULLY-LOADED COST — see fullyLoadedCostPerBed below.
+//
+// NOTE: There is NO current "Defy fully-fabricated Single Bed" rate for the Stretch Bed.
+// INV-1507 $600/bed was for the DISCONTINUED Weave Bed (verified ex OCR 2026-05-28).
+// Defy sells us components/kits, not finished Stretch Beds.
 export const stretchBedBOM = [
   { component: 'HDPE Plastic Kit (legs, cut & finished)', qty: 1, unitCost: 344.05, supplier: 'Defy Manufacturing' },
   { component: 'Galvanised Steel (gal pipe)', qty: 1, unitCost: 27, supplier: 'DNA Steel Direct' },
-  { component: 'Canvas Sleeping Surface', qty: 1, unitCost: 95, supplier: 'Centre Canvas' },
+  { component: 'Canvas Sleeping Surface', qty: 1, unitCost: 93.50, supplier: 'Centre Canvas' },
   { component: 'Round Ribbed End Caps (27mm)', qty: 4, unitCost: 0.80, supplier: 'Hardware Supplier' },
-  { component: 'Frame Screws', qty: 1, unitCost: 3.50, supplier: 'Hardware Supplier' },
+  { component: 'Frame Screws (16 per bed)', qty: 16, unitCost: 0.065, supplier: 'Coastal Fasteners' },
+  { component: 'Frame Bolts (2 per bed)', qty: 2, unitCost: 0.50, supplier: 'Coastal Fasteners' },
 ] as const;
 
-// Direct materials only (Defy-kit path): $344.05 + $27 + $95 + $3.20 + $3.50 = $472.75
+// Direct materials only (Defy-kit path):
+//   $344.05 (HDPE) + $27 (steel) + $93.50 (canvas) + $3.20 (caps) + $1.04 (screws) + $1.00 (bolts) = $469.79
 export const stretchBedDirectMaterials = stretchBedBOM.reduce((sum, item) => sum + item.qty * item.unitCost, 0);
 
 /**
  * Factory-path direct cost per bed (raw shred → press → CNC → assemble in-house).
- * From Notion BK review 2026-05-28 (Ben + BK):
+ * Updated 2026-05-28 with verified-from-invoices numbers:
  *   Plastic raw + delivery: 20kg × $2.75/kg = $55 (HDPE shred + transport)
  *   Diesel: $15/bed (25L/day ÷ 5 beds for press + CNC)
  *   Labour: $80/bed ($400/day ÷ 5 beds at the factory)
  *   Steel poles: $27 (DNA Steel)
- *   Canvas: $95 (Centre Canvas)
- *   End caps: $3.20 + Screws: $3.50 = $6.70 hardware
- *   = $55 + $15 + $80 + $27 + $95 + $6.70 = $278.70
+ *   Canvas: $93.50 (Centre Canvas — actual invoice rate, not $95)
+ *   End caps: $3.20 + Screws: $1.04 + Bolts: $1.00 = $5.24 hardware
+ *   = $55 + $15 + $80 + $27 + $93.50 + $5.24 = $275.74
  *
- * This is the in-house production target. At 4 beds/day × ~250 working days = 1,000
- * beds/yr from one facility. Margin at $750 retail = $471.30 (63%).
+ * In-house production target. At 4 beds/day × ~250 working days = 1,000 beds/yr from
+ * one facility. Margin at $750 retail = $474.26 (63%).
  *
- * Use this as the trajectory number for funder asks: the capital ask brings us from
- * the Defy-kit path ($472.75 direct materials) down to factory path ($278.70 direct).
+ * Capital ask: brings us from Defy-kit path ($469.79 direct materials)
+ * down to factory path ($275.74 direct) — saves $194/bed at materials level, plus
+ * the value-add labour the markup pays for.
  */
-export const factoryDirectMaterials = 278.70;
+export const factoryDirectMaterials = 275.74;
 
 /**
  * Fully-loaded production cost per bed at current low volume (~100 units).


### PR DESCRIPTION
Two things shipped:

## 1. Data corrections (from deep invoice OCR)

OCR'd Centre Canvas + big Bunnings + INV-1507 + Coastal Fasteners actual PDFs:

| Was (v4) | Now (v5) | Reason |
|---|---|---|
| state_1_defy_fully_fabricated = $600 | **REMOVED** | INV-1507 was the discontinued Weave Bed, not current Stretch Bed |
| Canvas $95 | **$93.50** | Centre Canvas 3 invoices 2026 (270 covers @ $93.50) — verified actual |
| Screws $3.50 | **$1.04** (16 × $0.065) | Coastal Fasteners RB20247673190 verified |
| (no bolts line) | **+$1.00** (2 × $0.50) | Ben confirmed 2026-05-28 |
| Hardware total $6.70 | **$5.24** | caps $3.20 + screws $1.04 + bolts $1.00 |

New direct-cost totals (4 supply paths): Defy Kits $534.79 · Defy Panels $584.07 · Factory **$275.74** · Community $140.74.

Margin at $750: Factory **63%** · Community **81%**.

## 2. Interactive cost-model explorer at `/admin/cost-model`

The QBE-ready slider/matrix page Ben asked for. Live-recomputed:

- **Headline cards**: fully-loaded today, fully-loaded target, value-vs-commercial, capital payback years
- **25 sliders** across Materials / Labour & throughput / Volume & overhead / Market — each with the verified-default labelled
- **Direct cost matrix** — 4 paths × direct + margin + margin %
- **Fully-loaded breakdown** — Kirmos + founder + admin + field + freight = overhead/bed → fully-loaded by path
- **Idiot Index cards** — Musk-style markup ratios per element, colour-coded by severity. First-principles floor calculated live ($129/bed minimum) vs current Defy Kits ($535) = **$406/bed of supply-chain markup capturable in-house**.
- **Capital ask + payback panel** — QBE-ready: capital × savings/bed = payback in years. Auto-generates the pitch sentence.

Defaults from `cost-model-scenarios.json` + `supplier-quotes.ts`. Sliders override client-side; reset restores verified defaults.

## Build

- `npx tsc --noEmit` clean
- `pnpm build` compiled successfully

## Still open (next session)

- Pull DNA Steel + Centre Canvas invoice detail from Notion (currently quoted-not-OCR'd)
- Confirm INV-1731 freight $1,350 with Sam (Defy)
- Ask Defy for volume quote sheet (100/500/1000/5000)
- Retag the $120K+ misattributed Xero spend
- Verify Coastal Fasteners bolt rate when next invoice arrives

Plan: `goods-cost-evidence-funder-artifact`