### PR TITLE
feat(admin/sidebar): align nav — add cost-model + 3 missing-but-active routes

### DIFF
--- a/v2/src/app/admin/admin-sidebar.tsx
+++ b/v2/src/app/admin/admin-sidebar.tsx
@@ -30,6 +30,10 @@ import {
   Receipt,
   Presentation,
   Building2,
+  ClipboardCheck,
+  NotebookPen,
+  Calculator,
+  PackagePlus,
 } from 'lucide-react';
 
 type NavItem = { name: string; href: string; icon: React.ComponentType<{ className?: string }> };
@@ -45,6 +49,7 @@ const navigation: NavGroup[] = [
       { name: 'Bed signals',    href: '/admin/bed-signals',   icon: Radar },
       { name: 'Trip preflight', href: '/admin/bed-preflight', icon: FileCheck },
       { name: 'Install (photos)', href: '/admin/install-bulk', icon: Camera },
+      { name: 'Install checklist', href: '/admin/install-checklist', icon: ClipboardCheck },
       { name: 'Assets',         href: '/admin/assets',        icon: Library },
       { name: 'Scans',          href: '/admin/scans',         icon: BarChart3 },
       { name: 'Photos',         href: '/admin/photos',        icon: Images },
@@ -61,6 +66,7 @@ const navigation: NavGroup[] = [
       { name: 'Messages',       href: '/admin/messages',      icon: MessageSquare },
       { name: 'Reach out',      href: '/admin/reach-out',     icon: Send },
       { name: 'Compassion',     href: '/admin/compassion',    icon: Heart },
+      { name: 'Field notes',    href: '/admin/field-notes',   icon: NotebookPen },
     ],
   },
   {
@@ -68,6 +74,7 @@ const navigation: NavGroup[] = [
     items: [
       { name: 'Fleet',          href: '/admin/fleet',         icon: Truck },
       { name: 'Production',     href: '/admin/production',    icon: Wrench },
+      { name: 'Cost model',     href: '/admin/cost-model',    icon: Calculator },
     ],
   },
   {
@@ -76,6 +83,7 @@ const navigation: NavGroup[] = [
       { name: 'Deals',          href: '/admin/deals',         icon: Crosshair },
       { name: 'Xero recon',     href: '/admin/xero-reconciliation', icon: FileCheck },
       { name: 'Orders',         href: '/admin/orders',        icon: ShoppingCart },
+      { name: 'Requests',       href: '/admin/requests',      icon: PackagePlus },
       { name: 'Products',       href: '/admin/products',      icon: Package },
     ],
   },


### PR DESCRIPTION
Audit of `/admin/*` directories vs the sidebar's nav list. Found 4 active routes not linked + 5 stale entries to flag.

## Added to nav (4 routes)

| Route | Group | Reason |
|---|---|---|
| **/admin/cost-model** | Operations | New v5 cost-model explorer (PR #31) — sliders + matrix + Idiot Index + QBE-ready capital ask |
| **/admin/install-checklist** | Today (next to 'Install (photos)') | Before/after install checklist, 229 lines, edited 2026-05-28 |
| **/admin/field-notes** | Today (end of group) | Internal trip stories, 175 lines |
| **/admin/requests** | Money | Requisition form, 164 lines |

## Intentionally NOT added
- **/admin/alice-fill** — one-off wizard for the 2026-05-21 Alice Springs trip catch-up. Adding clutters daily nav.

## Audit results — all existing links work
Every entry in the sidebar resolves to a real `page.tsx`. No 404s.

## Stale entries flagged (still working, but no edits in 3+ months)
- compassion (2026-01-22)
- messages (2026-01-22)
- products (2026-02-02)
- brand (2026-03-26, only 23 lines)
- team (2026-03-15, only 47 lines)

Recommend reviewing if each is actively used in the next session and pruning anything that isn't.

## Verification
- `npx tsc --noEmit` clean
- `pnpm build` compiled successfully

Plan: `goods-cost-evidence-funder-artifact`