### PR TITLE
fix(admin/calc): loop 1 — stop wrong/dishonest numbers reaching humans

### DIFF
--- a/v2/src/app/admin/trip-receipts/page.tsx
+++ b/v2/src/app/admin/trip-receipts/page.tsx
@@ -86,7 +86,8 @@ export default async function TripReceiptsPage() {
             <p className="mt-1 text-sm text-gray-500">
               Each trip (≥3 beds delivered to one community on one date) cross-referenced
               with Xero ACCPAY in a ±3-day to +14-day window. Missing receipts mean
-              trip overhead isn&apos;t entering Xero (often: paid through personal accounts).
+              trip overhead isn&apos;t matched to ACCPAY bills yet — a Xero payment-matching
+              gap (not debt), to be reconciled.
             </p>
           </div>
           <Link href="/admin/scans" className="text-xs text-blue-700 hover:underline">/admin/scans →</Link>
@@ -176,8 +177,9 @@ export default async function TripReceiptsPage() {
                     <li>☐ Staff time (FTE allocation)</li>
                   </ul>
                   <p className="mt-2 text-gray-500">
-                    Per the Day 3 financial review,{' '}
-                    $86k of bank-spend historically hasn&apos;t made it into ACCPAY.
+                    Some Goods bank-spend has historically not been matched to ACCPAY bills
+                    in Xero — a payment-matching gap, not debt (the 2026-05-29 cross-check
+                    found $0 paid from personal accounts and no director loan).
                     To close the gap on this trip, enter receipts in Xero
                     against <code>project_code = ACT-GD</code>.
                   </p>

--- a/v2/src/lib/data/cost-model-scenarios.ts
+++ b/v2/src/lib/data/cost-model-scenarios.ts
@@ -138,7 +138,7 @@ export function reconcileAgainstCanonicalBOM(): {
     factoryTotal: state4.direct_total,
     canonicalFactoryMaterials: factoryDirectMaterials,
     legacyFullyLoaded: fullyLoadedCostPerBed,
-    matches: state4.direct_total === factoryDirectMaterials,
+    matches: Math.abs(state4.direct_total - factoryDirectMaterials) < 0.01,
     bom: stretchBedBOM,
   };
 }

--- a/v2/src/lib/data/impact-model.ts
+++ b/v2/src/lib/data/impact-model.ts
@@ -98,7 +98,7 @@ export const REVENUE_SEGMENTS: RevenueSegment[] = [
     id: 'b2b',
     name: 'B2B Sales',
     description: 'Direct sales to organisations distributing to communities',
-    currentEvidence: '109 beds sold to Centrecorp (first substantial commercial transaction)',
+    currentEvidence: '109 beds to Centrecorp — institutional buyer at scale (income_type=grant, not commercial sale)',
     projectedShare: 45,
   },
   {
@@ -503,7 +503,7 @@ export const DEFAULT_OPPORTUNITIES: OptimizationOpportunity[] = [
   },
   {
     id: 'wise-employment',
-    title: 'Each bed sale creates ${TOTAL_LABOUR_HOURS_PER_BED.toFixed(1)} hours of employment',
+    title: `Each bed sale creates ${TOTAL_LABOUR_HOURS_PER_BED.toFixed(1)} hours of employment`,
     description: `At 1,500 beds/year, that's ${(1500 * TOTAL_LABOUR_HOURS_PER_BED).toLocaleString()} hours of employment for at-risk youth. The WISE model is the strongest impact narrative for QLD government funding.`,
     dimension: 'economic',
     potential: 'high',
@@ -511,8 +511,8 @@ export const DEFAULT_OPPORTUNITIES: OptimizationOpportunity[] = [
   },
   {
     id: 'b2b-pipeline',
-    title: 'B2B channel has strongest commercial evidence',
-    description: '109 beds sold to Centrecorp demonstrates demand. Emergency services are a natural fit: NT already calls them "cyclone beds." Secure letters of intent from potential B2B clients.',
+    title: 'B2B / institutional channel has strongest commercial evidence',
+    description: '109 beds granted to Centrecorp (an institutional buyer, income_type=grant) demonstrates demand at scale. Emergency services are a natural fit: NT already calls them "cyclone beds." Secure letters of intent from potential B2B/institutional clients.',
     dimension: 'economic',
     potential: 'high',
     dataSource: 'Revenue segments + meeting notes',

--- a/v2/src/lib/data/products.ts
+++ b/v2/src/lib/data/products.ts
@@ -2,6 +2,16 @@
 // Every page should import from here instead of hardcoding values.
 // NO PRICES — pricing is handled separately via Stripe/Supabase.
 
+/**
+ * HDPE diverted per Stretch Bed, in kilograms. Single source of truth for the
+ * plastic-diverted-per-bed factor used in impact/funder calculations — import
+ * this instead of hardcoding `* 20`.
+ * Source: STRETCH_BED.specs.plasticDiverted ("20kg HDPE per bed") + CLAUDE.md
+ * canonical product data (20kg of HDPE diverted per bed).
+ * KEY DATA FLAG: this 20kg figure is the design/spec value, not yet weighbridge-verified.
+ */
+export const PLASTIC_KG_PER_BED = 20;
+
 export const STRETCH_BED = {
   name: 'The Stretch Bed',
   slug: 'stretch-bed',

--- a/v2/src/lib/funders/metrics.ts
+++ b/v2/src/lib/funders/metrics.ts
@@ -6,6 +6,7 @@
  */
 
 import type { MetricResolver, ReportContext } from './types';
+import { PLASTIC_KG_PER_BED } from '@/lib/data/products';
 
 async function fetchXero<T = unknown>(
   ctx: ReportContext,
@@ -55,8 +56,8 @@ const bedsThisPeriodAllStatuses: MetricResolver = async (ctx) => {
 const plasticKgTransferred: MetricResolver = async (ctx) => {
   const res = await scopedAssetsQuery(ctx).in('status', ['deployed', 'allocated']);
   const beds = res.count ?? 0;
-  const kg = beds * 20;
-  return `**${kg.toLocaleString()} kg** (${(kg / 1000).toFixed(2)} tonnes) — ${beds} beds × 20 kg HDPE`;
+  const kg = beds * PLASTIC_KG_PER_BED;
+  return `**${kg.toLocaleString()} kg** (${(kg / 1000).toFixed(2)} tonnes) — ${beds} beds × ${PLASTIC_KG_PER_BED} kg HDPE`;
 };
 
 const communitiesServed: MetricResolver = async (ctx) => {
@@ -81,47 +82,72 @@ const commitmentProgressBar: MetricResolver = async (ctx) => {
     // Money-only commitments — render an AUD bar instead
     const total = c.totalAud;
     const paid = c.paidToDateAud ?? 0;
-    const pct = total > 0 ? Math.round((paid / total) * 100) : 0;
-    const filled = Math.round(pct / 5);
+    const rawPct = total > 0 ? Math.round((paid / total) * 100) : 0;
+    const pct = Math.max(0, Math.min(100, rawPct));
+    const filled = Math.max(0, Math.min(20, Math.round(rawPct / 5)));
     const bar = '▓'.repeat(filled) + '░'.repeat(20 - filled);
     return `\`\`\`\nCommitment:  $${total.toLocaleString('en-AU')}\nPaid:        ${bar} ${pct}%  ($${paid.toLocaleString('en-AU')})\n\`\`\``;
   }
   // Unit-based commitments — count delivered units in period, respecting
-  // optional community scope.
+  // optional community scope. Delivery can exceed the original commitment
+  // (e.g. 496 beds against a 109-unit commitment), so clamp the bar to 0-20
+  // segments and the displayed pct to 0-100 — an unclamped `'░'.repeat(20-filled)`
+  // throws RangeError on overshoot and surfaces as a [METRIC ERROR] in the deck.
   const periodRes = await scopedAssetsQuery(ctx).in('status', ['deployed', 'allocated']);
   const periodCount = periodRes.count ?? 0;
   const total = c.totalUnits;
-  const pct = total > 0 ? Math.round((periodCount / total) * 100) : 0;
-  const filled = Math.round(pct / 5);
+  const rawPct = total > 0 ? Math.round((periodCount / total) * 100) : 0;
+  const pct = Math.max(0, Math.min(100, rawPct));
+  const filled = Math.max(0, Math.min(20, Math.round(rawPct / 5)));
   const bar = '▓'.repeat(filled) + '░'.repeat(20 - filled);
   return `\`\`\`\n${c.unitLabel ?? 'units'} commitment:  ${total} ${c.unitLabel ?? ''}\nDelivered this period: ${bar} ${pct}%  (${periodCount} ${c.unitLabel ?? ''})\n\`\`\``;
 };
 
 const xeroDrawnAud: MetricResolver = async (ctx) => {
   const c = ctx.funder.commitment;
+  // CRITICAL: filter out VOIDED/DELETED invoices at the query. Without this the
+  // reduce sums voided invoices into the funder doc — live-confirmed $832,832
+  // (sum of all incl. voided) vs the correct $123,332 paid for Centrecorp.
   const qs = [
     'select=total,amount_paid,invoice_number,date,status',
     `type=eq.ACCREC`,
+    `status=not.in.(VOIDED,DELETED)`,
     `project_code=eq.${ctx.funder.xeroProjectCode}`,
     `contact_name=eq.${encodeURIComponent(ctx.funder.contactName)}`,
   ].join('&');
   const rows = await fetchXero<{ total: number; amount_paid: number; invoice_number: string; date: string; status: string }>(ctx, qs);
-  const totalRaised = rows.reduce((s, r) => s + (r.total || 0), 0);
-  const totalPaid = rows.reduce((s, r) => s + (r.amount_paid || 0), 0);
+  // Defence-in-depth: also strip any VOIDED/DELETED that slip through the query.
+  const live = rows.filter((r) => r.status !== 'VOIDED' && r.status !== 'DELETED');
+  // A zero result is almost always a contact_name drift (the Xero contact_name
+  // not matching funder.contactName), not a genuine $0. Surface it explicitly
+  // so a naming mismatch can't masquerade as "raised $0 / paid $0".
+  if (live.length === 0) {
+    const commitmentLine = c.totalAud
+      ? `Commitment: **$${c.totalAud.toLocaleString('en-AU')}** ex-GST`
+      : '';
+    return [
+      commitmentLine,
+      `_[METRIC NOTE: no non-voided Xero ACCREC invoices matched contact_name="${ctx.funder.contactName}" (project_code=${ctx.funder.xeroProjectCode}). Check the Xero contact name matches funder.contactName before trusting a $0.]_`,
+    ].filter(Boolean).join('  \n');
+  }
+  const totalRaised = live.reduce((s, r) => s + (r.total || 0), 0);
+  const totalPaid = live.reduce((s, r) => s + (r.amount_paid || 0), 0);
   const commitmentLine = c.totalAud
     ? `Commitment: **$${c.totalAud.toLocaleString('en-AU')}** ex-GST`
     : '';
   return [
     commitmentLine,
-    `Xero ACCREC invoices raised (${rows.length}): **$${totalRaised.toLocaleString('en-AU', { maximumFractionDigits: 0 })}**`,
-    `Amount paid against those invoices: **$${totalPaid.toLocaleString('en-AU', { maximumFractionDigits: 0 })}**`,
+    `Xero ACCREC invoices raised, non-voided (${live.length}): **$${totalRaised.toLocaleString('en-AU', { maximumFractionDigits: 0 })}** inc-GST`,
+    `Amount paid against those invoices: **$${totalPaid.toLocaleString('en-AU', { maximumFractionDigits: 0 })}** inc-GST`,
   ].filter(Boolean).join('  \n');
 };
 
 const xeroTripOverhead: MetricResolver = async (ctx) => {
-  // ACCPAY in the period window — closest proxy for trip-overhead cost
-  // (caveat: trip overhead often paid through personal accounts and not in
-  // ACCPAY; see wiki/outputs/2026-05-22-utopia-trip-report.md for detail).
+  // ACCPAY in the period window — closest proxy for trip-overhead cost.
+  // Caveat: a trip's spend may not all be matched to ACCPAY bills yet (a Xero
+  // payment-matching gap, not debt — the 2026-05-29 cross-check found $0 from
+  // personal accounts and no director loan). See
+  // wiki/outputs/2026-05-22-utopia-trip-report.md for detail.
   const qs = [
     'select=total,contact_name,date',
     `type=eq.ACCPAY`,
@@ -132,7 +158,7 @@ const xeroTripOverhead: MetricResolver = async (ctx) => {
   const rows = await fetchXero<{ total: number; contact_name: string; date: string }>(ctx, qs);
   const total = rows.reduce((s, r) => s + (r.total || 0), 0);
   if (rows.length === 0) {
-    return `**$0** — no ACCPAY invoices entered in Xero for this period yet (receipts often paid through personal accounts; reconciliation pending).`;
+    return `— not yet reconciled in Xero (no ACCPAY bills matched to this period; a payment-matching gap, not debt).`;
   }
   return `**$${total.toLocaleString('en-AU', { maximumFractionDigits: 0 })}** across ${rows.length} ACCPAY invoice${rows.length === 1 ? '' : 's'}.`;
 };
@@ -186,9 +212,13 @@ const financialsAtAGlance: MetricResolver = async (ctx) => {
   const rows: string[] = [];
   rows.push('| Item | Value |');
   rows.push('|---|---|');
+  // Basis labels are deliberate: the commitment is a grant-commitment ex-GST
+  // figure; paid/to-be-paid are cash (inc-GST) and Xero invoices are inc-GST.
+  // Do NOT relabel cash figures as ex-GST to match the commitment line — they
+  // are different bases and were drifting into a false ex-GST label.
   rows.push(`| **Total commitment** | $${c.totalAud.toLocaleString('en-AU')} ex-GST |`);
-  if (c.paidToDateAud !== undefined) rows.push(`| **Paid to date** | $${c.paidToDateAud.toLocaleString('en-AU')} |`);
-  if (c.toBePaidAud !== undefined) rows.push(`| **To be paid** | $${c.toBePaidAud.toLocaleString('en-AU')} |`);
+  if (c.paidToDateAud !== undefined) rows.push(`| **Paid to date** | $${c.paidToDateAud.toLocaleString('en-AU')} inc-GST (cash) |`);
+  if (c.toBePaidAud !== undefined) rows.push(`| **To be paid** | $${c.toBePaidAud.toLocaleString('en-AU')} inc-GST (cash) |`);
   if (c.invoicesRaisedAud !== undefined) rows.push(`| **Xero invoices raised** | $${c.invoicesRaisedAud.toLocaleString('en-AU')} inc-GST |`);
   if (c.reportsSubmitted) rows.push(`| **Reports submitted** | ${c.reportsSubmitted} |`);
   if (c.nextReportDue) rows.push(`| **Next report due** | ${c.nextReportDue} |`);


### PR DESCRIPTION
Loop 1 of the admin calculation enterprise-readiness fixes (full review + plan: `wiki/outputs/2026-05-29-qbe-investment-sweep/04-admin-calc-enterprise-review.md`). These are the surgical, high-impact, low-coupling fixes that put wrong or dishonest numbers in front of a human.

- **`funders/metrics.ts`** — `xeroDrawnAud` was summing **VOIDED/DELETED** invoices into funder reports (**$832,832** vs correct **$123,332**); now status-filtered + a visible empty-result note. `commitmentProgressBar` clamps 0–20 (kills a **RangeError** that printed `[METRIC ERROR]` in funder decks). GST labels made honest; plastic via `PLASTIC_KG_PER_BED`; trip-overhead empty state; de-staled comment.
- **`data/products.ts`** — adds `PLASTIC_KG_PER_BED = 20`.
- **`data/impact-model.ts`** — fixes a single-quoted string that shipped literal **`${...}`** text to the public `/impact` page; Centrecorp "commercial → granted/institutional buyer" (income_type=grant) at lines 101 + 515.
- **`admin/trip-receipts`** — drops the retired "$86k personal accounts / director loan" framing → "Xero payment-matching gap (not debt)".
- **`data/cost-model-scenarios.ts`** — float-equality guard in the BOM reconciler.

`npm run build` passes. **Loop 2** (single-source-of-truth refactor: collapse the 4 cost-per-bed definitions, `verifiedFinancials`, bed-count reconciliation, xero-reconciliation rewrite, production dual-model) is tracked in the review doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)