### PR TITLE
feat(investors): shared-password investor cockpit at /investors

### DIFF
--- a/v2/.wiki-content/capital/paf-puaf-dgr.md
+++ b/v2/.wiki-content/capital/paf-puaf-dgr.md
@@ -18,13 +18,13 @@ Australian Private Ancillary Funds (PAFs) and Public Ancillary Funds (PuAFs) are
 
 ## Why it might matter to Goods
 
-This is a possible capital pathway only if the legal and DGR position is confirmed. Current ACT core facts say **A Kind Tractor Ltd** is ACNC-registered, dormant and **not DGR**, with the DGR application parked. Do not describe any **ACT Foundation** as a legal entity or assume DGR eligibility.
+This pathway needs a DGR-eligible charity to receive the loan. For Goods, that DGR is **The Butterfly Movement Ltd** (ACNC-registered, Item 1 DGR), the charity and DGR home from FY2026-27, gifted from TABOO Foundation. DGR is available only through Butterfly, never through Goods, A Curious Tractor Pty Ltd or A Kind Tractor Ltd directly. **A Kind Tractor Ltd** is dormant and not used and is not a DGR. Do not describe any **ACT Foundation** as a legal entity or assume DGR eligibility outside Butterfly.
 
-If A Kind Tractor Ltd later becomes an appropriate and eligible charitable vehicle, below-market loans from PAFs and PuAFs may be worth legal/accounting review. Until then, this page is a mechanism note, not a current Goods financing route.
+Once The Butterfly Movement Ltd is operational as the Goods charity/DGR home (FY2026-27), below-market loans from PAFs and PuAFs into Butterfly may be worth legal/accounting review. Until then, this page is a mechanism note, not a current Goods financing route.
 
 Practical opening moves:
-- Ask Standard Ledger and legal counsel whether A Kind Tractor Ltd can or should be used for any Goods funding pathway.
-- Check whether Mindaroo Foundation or Snow Foundation would even consider recoverable grant or below-market loan structures once the entity position is clear.
+- Confirm with Standard Ledger and legal counsel the timing and mechanics of routing PAF/PuAF below-market loans through The Butterfly Movement Ltd from FY2026-27.
+- Check whether Mindaroo Foundation or Snow Foundation would even consider recoverable grant or below-market loan structures once Butterfly is live.
 - PFI's repayable grant is already structured compatibly.
 
 ## Regulatory references
@@ -32,14 +32,14 @@ Practical opening moves:
 - **PuAFs:** Section 15 of the Public Ancillary Fund Guidelines 2022.
 - **PAFs:** Section 15 of the Private Ancillary Fund Guidelines 2019.
 
-## A Kind Tractor Ltd status
+## Entity and DGR status
 
 The current Goods pack should say:
 
-- A Curious Tractor Pty Ltd is the expected Goods trading home.
-- A Kind Tractor Ltd exists as the ACT charity.
-- Current ACT core facts say A Kind Tractor Ltd is dormant and not DGR.
-- DGR status and ancillary-fund eligibility must be verified before any funder-facing claim.
+- The Nicholas Marchesi sole trader (ABN 21 591 780 066) is the current operating entity today; trading migrates into A Curious Tractor Pty Ltd (ACN 697 347 676, t/a Goods on Country) this FY.
+- The Butterfly Movement Ltd is the charity and DGR home from FY2026-27 and the only Goods DGR pathway.
+- A Kind Tractor Ltd (ABN 73 669 029 341) is dormant and not used, and is not DGR.
+- DGR eligibility for any PAF/PuAF below-market loan runs through Butterfly only, and only from FY2026-27. Verify timing before any funder-facing claim.
 - ACT Foundation and ACT Ventures are not current legal entity names.
 
 See [[../governance/legal-structure]] and [[../sources/act-core-facts]].

--- a/v2/.wiki-content/enterprise/07-governance-data-reporting.md
+++ b/v2/.wiki-content/enterprise/07-governance-data-reporting.md
@@ -1,6 +1,6 @@
 # 7. Governance, Data and Reporting
 
-> Governance is real but early. We have founder accountability, A Curious Tractor Pty Ltd as the current company home, A Kind Tractor Ltd as dormant charitable infrastructure, a named Goods advisory board, community partner accountability, funder reporting, and emerging story/data infrastructure. We do not yet have a finished investor-ready governance system that shows who decides what, how conflicts are handled, how risk is reviewed, and how consent travels with stories and product data.
+> Governance is real but early. We have founder accountability, the Nicholas Marchesi sole trader as the current operating entity, A Curious Tractor Pty Ltd as the go-forward trading company (t/a Goods on Country, migrating this FY), The Butterfly Movement Ltd as the charity and DGR home from FY2026-27, A Kind Tractor Ltd dormant and not used, a named Goods advisory board, community partner accountability, funder reporting, and emerging story/data infrastructure. We do not yet have a finished investor-ready governance system that shows who decides what, how conflicts are handled, how risk is reviewed, and how consent travels with stories and product data.
 
 ## The human version
 
@@ -20,8 +20,8 @@ The governance job is to put enough structure around that trust so it can scale 
 
 | Area | What exists now | What it proves | What is not settled |
 | --- | --- | --- | --- |
-| Legal vehicle | **A Curious Tractor Pty Ltd** is the expected trading home for Goods. | The work is moving out of sole-trader history and into a company vehicle. | Whether Goods stays inside ACT, becomes a subsidiary, or uses a hybrid/community-controlled structure. |
-| Wider ACT entity context | **A Kind Tractor Ltd** exists as charitable infrastructure in the wider ACT world. Current ACT core facts say it is dormant and not DGR. | There is charitable infrastructure to consider for grants and philanthropy if activated later. | It is not the main Goods operating vehicle today and should not be presented as active Goods governance. |
+| Legal vehicle | Goods operates today through the **Nicholas Marchesi sole trader** (ABN 21 591 780 066) and is migrating this FY into **A Curious Tractor Pty Ltd** (ACN 697 347 676, t/a Goods on Country). | The work is moving out of sole-trader history into the go-forward company. | Whether Goods sits as a sub-entity beneath A Curious Tractor, becomes a subsidiary, or uses a hybrid/community-controlled structure. |
+| Charity and DGR home | **The Butterfly Movement Ltd** is the charity and DGR home from FY2026-27, gifted from TABOO Foundation. **A Kind Tractor Ltd** is dormant and not used. | There is a confirmed charitable/DGR vehicle (Butterfly) for grants, gifts and philanthropy from FY2026-27. It is the only Goods DGR pathway. | Butterfly board composition, founding directors and the trading/charity contracting boundary. A Kind Tractor has no Goods role. |
 | Founder leadership | We currently carry the work day to day. | The work has clear accountable humans, not a faceless project. | Founder authority needs to be translated into roles, delegations and reporting lines. |
 | Advisory board | A Goods advisory board includes Kristy Bloomfield, Nicholas Marchesi OAM, Sally Grimsley-Ballard, Sam Davies, Judith Meiklejohn, Corey Tutt, April Long, Susan Clear, Nina Fitzgerald, Daniel Pittman and Shaun Fisher. | Goods has named external advice across community, manufacturing, design, philanthropy, health and social enterprise. | It is advisory, not a formal board with fiduciary authority. Adeem and Dr Simon Quilty sit in the wider support/partner network, not on the advisory board. |
 | Community accountability | Return visits, partner check-ins, story consent practice, photos/videos shared back, and ongoing conversations with people such as Dianne Stokes, Oonchiumpa, PICC and Tennant Creek partners. | Accountability is relational and place-based, not only upward to funders. | The practice needs a written consent, data and story-use standard before it scales. |
@@ -34,8 +34,9 @@ This is the real governance-adjacent network. It should be shown plainly, with r
 
 | Name / organisation | Current role | Governance relevance |
 | --- | --- | --- |
-| **A Curious Tractor Pty Ltd** | Current Goods trading home. | Company accountability, contracts, sales, finance, product liability and employment. |
-| **A Kind Tractor Ltd** | Wider ACT charity. Current ACT core facts say it is dormant and not DGR. | Possible philanthropy or charitable-purpose pathway if activated later, but not the current Goods operating vehicle. |
+| **A Curious Tractor Pty Ltd** | Go-forward Goods trading company (t/a Goods on Country), migrating this FY. | Company accountability, contracts, sales, finance, product liability and employment. |
+| **The Butterfly Movement Ltd** | Charity and DGR home from FY2026-27, gifted from TABOO Foundation. | The only Goods DGR pathway: philanthropy, gifts and DGR-eligible funding. Charitable-purpose accountability. |
+| **A Kind Tractor Ltd** | Dormant and not used (ABN 73 669 029 341). Not DGR. | No Goods role. Not the trading entity, charity home or DGR pathway. |
 | **Kristy Bloomfield / Oonchiumpa Consultancy** | Cultural lead, Alice Springs partner and potential production pathway. | First Nations leadership, Central Australian governance context and possible Supply Nation/IPP pathway. |
 | **Karen Liddle / Tanya Turner / Fred Campbell / Oonchiumpa** | Oonchiumpa leadership/operating context recorded in the compendium. | Local governance, management, youth pathway and community-led operating design. |
 | **Dianne Stokes** | Waramungu and Warlmanpa Elder, Tennant Creek co-designer and naming partner for Pakkimjalki Kari. | Story consent, product feedback, cultural authority and relationship accountability. |
@@ -87,7 +88,7 @@ This should be practical. It should help us run the work, not just impress funde
 | Board-ready risk register | Turns the working risk picture into owner, trigger, action and review cadence. | Draft base exists |
 | Story/data consent policy | Makes consent, withdrawal, image use, transcript use and dashboard access practical. | Draft practice exists |
 | Monthly Goods reporting pack | Brings finance, product, delivery, community feedback, risk and decisions into one rhythm. | Needed |
-| Legal-structure options note | Tests A Curious Tractor Pty Ltd, A Kind Tractor Ltd, Goods subsidiary, Aboriginal-controlled/local operators and IP/equipment/shared-services model. | Needed with legal input |
+| Legal-structure options note | Tests A Curious Tractor Pty Ltd, The Butterfly Movement Ltd (charity/DGR home), Goods subsidiary, Aboriginal-controlled/local operators and IP/equipment/shared-services model. A Kind Tractor Ltd is dormant and not used. | Needed with legal input |
 
 ## Data and story governance
 

--- a/v2/.wiki-content/enterprise/09-legal-structure.md
+++ b/v2/.wiki-content/enterprise/09-legal-structure.md
@@ -1,6 +1,6 @@
 # 9. Legal Structure
 
-> The legal structure is not finished, and the pack should say that plainly. Goods has moved from Nicholas Marchesi OAM's sole-trader history toward A Curious Tractor Pty Ltd as the current trading home. A Kind Tractor Ltd exists in the wider ACT world, but it is not the active Goods vehicle. The legal work now is to design a structure that can sell products, receive the right capital, protect purpose, carry risk, and make community-owned production real.
+> The legal structure is in transition, and the pack should say that plainly. Goods operates today through the Nicholas Marchesi sole trader (ABN 21 591 780 066) and is migrating everything this financial year (FY2026-27) into A Curious Tractor Pty Ltd (ACN 697 347 676), trading as Goods on Country. The charity and DGR home from FY2026-27 is The Butterfly Movement Ltd, gifted from TABOO Foundation. A Kind Tractor Ltd exists in the wider ACT world but is dormant and not used. The legal work now is to design the structure underneath that so it can sell products, receive the right capital, protect purpose, carry risk, and make community-owned production real.
 
 ## The human version
 
@@ -12,10 +12,11 @@ Goods needs enough structure for funders, lenders, customers and product liabili
 
 | Fact | Current position | Why it matters |
 | --- | --- | --- |
-| Historic operating position | Goods operated for a long period through Nicholas Marchesi OAM's sole-trader structure. | Some old records, contracts or financial traces may sit outside the new company shape. |
-| Current company vehicle | A Curious Tractor Pty Ltd has recently been registered. | This is the practical current home for Goods trading activity unless legal advice changes it. |
-| Charity entity | A Kind Tractor Ltd exists in the broader ACT world. Current ACT core facts say it is dormant and not DGR. | It may help with philanthropy if activated later, but it is not the main Goods vehicle today. |
-| Goods-specific entity | Not yet settled. | The QBE pack should not imply a mature Goods subsidiary, CLG or hybrid structure exists. |
+| Current operating entity (today) | Goods operates today through the Nicholas Marchesi sole trader, ABN 21 591 780 066. | This is where trading sits right now. Records, contracts and financial traces need clean migration into the go-forward company this FY. |
+| Go-forward trading company | A Curious Tractor Pty Ltd, ACN 697 347 676, trading as Goods on Country. All Goods activity migrates into it this financial year (FY2026-27). | This becomes the practical home for Goods trading activity once migration completes. |
+| Charity and DGR home | The Butterfly Movement Ltd (ACNC-registered, Item 1 DGR), operational from FY2026-27 (around 1 July 2026). Gifted/transitioned from TABOO Foundation, which continues as the same legal entity. | This is the only DGR pathway for Goods. Philanthropy, gifts and DGR-eligible funding flow through Butterfly, never through Goods, A Curious Tractor or A Kind Tractor directly. |
+| A Kind Tractor Ltd | Dormant and not used. ABN 73 669 029 341. Its ACNC disease-prevention subtype application drew an RFI on 10 April 2024. Not DGR. | Not the trading entity, not the charity home and not a DGR pathway. The QBE pack should not present it as the Goods vehicle. |
+| Goods-specific sub-entity | Not yet settled. | The QBE pack should not imply a mature Goods subsidiary, CLG or hybrid structure exists beneath A Curious Tractor Pty Ltd. |
 | Community production entities | Desired direction, not final legal design. | This is where ownership, local enterprise, machinery, IP, liability and shared services all meet. |
 | Mission lock | No formal Goods-specific lock is confirmed. | Purpose protection needs legal form before larger capital or scale decisions. |
 
@@ -36,9 +37,9 @@ Goods needs enough structure for funders, lenders, customers and product liabili
 
 | Possible structure | Useful for | Main risk | Current status |
 | --- | --- | --- | --- |
-| Goods stays inside A Curious Tractor Pty Ltd | Fastest path for trading, contracts, shared services and operational continuity. | Goods purpose and finances can blur into broader ACT activity. | Current practical direction. Needs clean internal reporting. |
-| Goods becomes a separate subsidiary | Cleaner accounts, board, investment readiness and liability separation. | Adds administration before operations may be ready. | Possible future step. Not confirmed. |
-| A Kind Tractor Ltd supports specific charitable work | Philanthropy, donations, community benefit activities and some grant eligibility if activated and legally appropriate. | Can pull Goods toward charity delivery rather than product ownership and commercial discipline. | Entity exists, but not the active Goods vehicle. DGR status should not be claimed as settled. |
+| Goods trades through A Curious Tractor Pty Ltd | Fastest path for trading, contracts, shared services and operational continuity. | Goods purpose and finances can blur into broader ACT activity. | Confirmed go-forward direction. Migration from the sole trader completes this FY. Needs clean internal reporting. |
+| Goods becomes a separate subsidiary | Cleaner accounts, board, investment readiness and liability separation. | Adds administration before operations may be ready. | Possible future step beneath A Curious Tractor Pty Ltd. Not confirmed. |
+| The Butterfly Movement Ltd carries charitable and DGR work | Philanthropy, donations, gifts, community benefit activities and DGR-eligible funding from FY2026-27. | Can pull Goods toward charity delivery rather than product ownership and commercial discipline if the boundary is not intentional. | Confirmed charity and DGR home from FY2026-27, gifted from TABOO Foundation. This is the only Goods DGR pathway. A Kind Tractor Ltd is dormant and not used for this. |
 | Aboriginal-controlled or locally owned production entity | Local ownership of collection, production, repair, delivery and jobs. | Needs governance, capability, quality control, capital and clear service agreements. | Strategic direction. Legal form unresolved. |
 | Central holding/shared-services entity | Holds IP, machinery, brand, training, funding relationships and R&D. | Can become too centralised if community entities have limited real control. | Concept under review. |
 | Franchise, licence, equipment rental or fee-for-service model | Gives local operators a way to use designs/equipment and receive support. | Could feel extractive if fees, IP and decision rights are not designed carefully. | Needs legal and community review. |
@@ -62,11 +63,11 @@ The legal model therefore needs to answer:
 
 ## Charity trade-off
 
-A charity structure could help with philanthropic funding, gifts and specific community benefit work.
+The charity structure is The Butterfly Movement Ltd, operational as the Goods charity and DGR home from FY2026-27. It can help with philanthropic funding, gifts, DGR-eligible giving and specific community benefit work.
 
 The risk is strategic drift. If Goods becomes mainly a charity distributor, the product may be judged by whether funders like it rather than whether residents, local producers and communities choose it. The current purpose is sharper than that: desirable, repairable, washable products that people actually want and that can move production and value On-Country.
 
-The structure may need both charitable and commercial functions, but the distinction must be intentional.
+The structure deliberately splits the two functions: A Curious Tractor Pty Ltd trades and sells products, The Butterfly Movement Ltd holds the charitable and DGR function. The distinction must stay intentional. A Kind Tractor Ltd is dormant and not used for either function.
 
 ## Mission protection
 
@@ -90,7 +91,7 @@ That is strong enough to guide early work. It is not enough to carry larger capi
 - Whether debt should sit with ACT, Goods, a subsidiary, a project vehicle or local production entity.
 - How to separate product liability from community production participation.
 - How IP, machinery, brand and training should be licensed or shared.
-- Whether A Kind Tractor Ltd should be used, kept separate or ignored for Goods.
+- How the trading function (A Curious Tractor Pty Ltd) and the charitable/DGR function (The Butterfly Movement Ltd) interact, contract and share costs.
 - What mission lock is credible and practical.
 - What structure best supports Aboriginal-controlled or locally owned production.
 - What data and story ownership clauses need to sit in contracts, consent forms and partner agreements.

--- a/v2/.wiki-content/governance/board-structure.md
+++ b/v2/.wiki-content/governance/board-structure.md
@@ -4,18 +4,20 @@
 
 ## Current legal and entity position
 
-- **A Curious Tractor Pty Ltd** is the primary trading entity being stood up for ACT work from 1 July 2026.
-- **Nicholas Marchesi OAM's sole-trader structure** is still part of the transition history and continues until the Pty cutover is complete.
-- **A Kind Tractor Ltd** is the charity in the ACT ecosystem. It is currently dormant and is not the main Goods operating vehicle.
+- **Nicholas Marchesi sole trader** (ABN 21 591 780 066) is the current operating entity today. All activity is migrating into the Pty this financial year.
+- **A Curious Tractor Pty Ltd** (ACN 697 347 676), trading as Goods on Country, is the go-forward trading and operating company. All Goods activity migrates into it this FY (FY2026-27).
+- **The Butterfly Movement Ltd** is the charity and DGR home from FY2026-27, gifted from TABOO Foundation. It is the only Goods DGR pathway.
+- **A Kind Tractor Ltd** (ABN 73 669 029 341) is dormant and not used. It is not the trading entity, the charity home or a DGR pathway.
 - **ACT Foundation** and **ACT Ventures** should not be used as legal entity names. They are older conceptual labels, not current entities.
-- Goods still needs a settled structure for product sales, grants, philanthropy, working capital, liability, shared services, IP, machinery, local production and community ownership.
+- Goods still needs a settled structure beneath this for product sales, grants, philanthropy, working capital, liability, shared services, IP, machinery, local production and community ownership.
 
 | Entity / structure | Current status | Goods relevance | What is not settled |
 | --- | --- | --- | --- |
-| **A Curious Tractor Pty Ltd** | Registered Pty Ltd. Directors recorded in ACT core facts as Benjamin Knight and Nicholas Marchesi OAM. Primary ACT trading entity from 1 July 2026. | Expected trading home for Goods while the Goods-specific structure is worked through. | Delegations, Goods-specific reporting, product liability, capital readiness, IP and community-production agreements. |
-| **Nicholas Marchesi OAM sole trader** | Historic and transition operating structure. ACT core facts record hard cutover intent to the Pty from 30 June 2026. | Some older Goods invoices, grants, contracts or financial records may still sit here. | Contract novation, invoice cutover, finance history and clean handover into the Pty. |
-| **A Kind Tractor Ltd** | Company limited by guarantee and ACNC-registered charity in the ACT ecosystem. Current ACT core facts say it is dormant and not DGR. | Possible backstop for charitable mission or DGR-only funders if activated later. | Whether it should be used for any Goods purpose at all. Do not present it as active Goods governance. |
-| **Future Goods or community operating entities** | Desired direction, not final legal design. | Possible vehicles for local collection, recycling, production, repair, sales or plant ownership. | Legal form, ownership, decision rights, machinery, brand, warranty, quality control and community governance. |
+| **Nicholas Marchesi sole trader** | Current operating entity today. ABN 21 591 780 066. ACT core facts record cutover intent to the Pty this FY. | Current home for Goods trading, invoices, grants and records. All migrating into the Pty this FY. | Contract novation, invoice cutover, finance history and clean handover into the Pty. |
+| **A Curious Tractor Pty Ltd** | Registered Pty Ltd. ACN 697 347 676. Directors recorded in ACT core facts as Benjamin Knight and Nicholas Marchesi OAM. Trading as Goods on Country. | Go-forward trading and operating home for Goods. All activity migrates into it this FY. | Delegations, Goods-specific reporting, product liability, capital readiness, IP and community-production agreements. |
+| **The Butterfly Movement Ltd** | Company limited by guarantee, ACNC-registered charity, Item 1 DGR. Operational as the Goods charity/DGR home from FY2026-27 (around 1 July 2026). Gifted/transitioned from TABOO Foundation (same legal entity continues). | The only Goods DGR pathway. Philanthropy, gifts and DGR-eligible funding flow through it, never through Goods, A Curious Tractor or A Kind Tractor directly. | Board composition, founding directors, the trading/charity contracting boundary and shared-cost recovery. |
+| **A Kind Tractor Ltd** | Company limited by guarantee. ABN 73 669 029 341. Dormant and not used. ACNC disease-prevention subtype application drew an RFI on 10 April 2024. Not DGR. | Not the trading entity, the charity home or a DGR pathway. Do not present it as active Goods governance. | Nothing for Goods. It is dormant and not used. |
+| **Future community operating entities** | Desired direction, not final legal design. | Possible vehicles for local collection, recycling, production, repair, sales or plant ownership. | Legal form, ownership, decision rights, machinery, brand, warranty, quality control and community governance. |
 
 ## Goods advisory board
 

--- a/v2/.wiki-content/governance/compliance.md
+++ b/v2/.wiki-content/governance/compliance.md
@@ -6,9 +6,10 @@
 
 | Regulator | Entity | State |
 |---|---|---|
-| **ACNC** | A Kind Tractor Ltd | Registered. Current ACT core facts say dormant and not DGR. |
-| **ASIC** | A Curious Tractor Pty Ltd | Registered, current |
-| **ATO** | A Curious Tractor Pty Ltd / A Kind Tractor Ltd / Nicholas Marchesi OAM sole trader | BAS, GST and DGR positions need legal/accounting confirmation before relying on them for Goods |
+| **ACNC** | The Butterfly Movement Ltd | Registered charity. Item 1 DGR. Operational as the Goods charity/DGR home from FY2026-27, gifted from TABOO Foundation (same legal entity continues). The only Goods DGR pathway. |
+| **ACNC** | A Kind Tractor Ltd (ABN 73 669 029 341) | Dormant and not used. Disease-prevention subtype application drew an RFI on 10 April 2024. Not DGR. Not the Goods charity home. |
+| **ASIC** | A Curious Tractor Pty Ltd (ACN 697 347 676) | Registered, current. Go-forward trading company, t/a Goods on Country. |
+| **ATO** | Nicholas Marchesi sole trader (ABN 21 591 780 066) / A Curious Tractor Pty Ltd / The Butterfly Movement Ltd | Sole trader is the current operating entity; trading migrates to the Pty this FY. DGR sits only with Butterfly from FY2026-27. BAS, GST and DGR positions need legal/accounting confirmation before relying on them for Goods. |
 | **ORIC** | (prospective) | Not registered; may be relevant when community-controlled operating entity spins up |
 
 ## Insurance (held by QBE)
@@ -21,7 +22,8 @@ Specifics available on request; coverage matched to current scale.
 
 ## Audit state
 
-- **A Kind Tractor Ltd** has its own charity compliance context.
+- **The Butterfly Movement Ltd** carries the charity compliance and ACNC reporting context as the Goods charity/DGR home from FY2026-27.
+- **A Kind Tractor Ltd** is dormant and not used; it carries no Goods compliance role.
 - **Goods-only audit** not yet performed (not required; considered for 2027 as trading volume grows).
 
 ## Related

--- a/v2/.wiki-content/governance/legal-structure.md
+++ b/v2/.wiki-content/governance/legal-structure.md
@@ -1,14 +1,16 @@
 # Legal Structure
 
-> Goods is currently moving under A Curious Tractor Pty Ltd. The wider ACT structure includes A Kind Tractor Ltd, but Goods' legal model is still being worked out. Do not present the dual-entity model, mission lock or community-ownership vehicle as finished.
+> Goods operates today through the Nicholas Marchesi sole trader and is migrating this FY into A Curious Tractor Pty Ltd (t/a Goods on Country). The charity and DGR home from FY2026-27 is The Butterfly Movement Ltd. A Kind Tractor Ltd is dormant and not used. The Goods legal model underneath this is still being worked out. Do not present the sub-entity model, mission lock or community-ownership vehicle as finished.
 
 ## Current state
 
-Goods is expected to trade through A Curious Tractor Pty Ltd.
+Goods operates today through the Nicholas Marchesi sole trader (ABN 21 591 780 066).
 
-Before that, much of the work sat under Nicholas Marchesi OAM's sole-trader setup. The company structure is new enough that legal and capital decisions should be treated as live.
+It is migrating everything this financial year (FY2026-27) into A Curious Tractor Pty Ltd (ACN 697 347 676), trading as Goods on Country. This is the go-forward trading and operating company. The migration is in progress, so legal and capital decisions should be treated as live.
 
-A Kind Tractor Ltd exists as the ACT charity. Current ACT core facts say it is dormant and not DGR. Goods is not currently operating as a charity-led program.
+The charity and DGR home is The Butterfly Movement Ltd, operational from FY2026-27 (around 1 July 2026), gifted/transitioned from TABOO Foundation (the same legal entity continues). DGR is available only through Butterfly, never through Goods, A Curious Tractor or A Kind Tractor directly.
+
+A Kind Tractor Ltd (ABN 73 669 029 341) is dormant and not used. It is not the trading entity, the charity home or a DGR pathway. Its ACNC disease-prevention subtype application drew an RFI on 10 April 2024.
 
 Do not use ACT Foundation or ACT Ventures as legal entity names. They are older conceptual labels, not current legal entities.
 
@@ -28,18 +30,18 @@ Do not use ACT Foundation or ACT Ventures as legal entity names. They are older 
 
 Several possibilities are being considered:
 
-- keep Goods inside A Curious Tractor Pty Ltd for now
-- create a Goods-specific subsidiary or sub-entity
-- use A Kind Tractor Ltd only where a charitable function genuinely fits
+- trade Goods through A Curious Tractor Pty Ltd (the confirmed go-forward home)
+- create a Goods-specific subsidiary or sub-entity beneath it
+- run charitable and DGR-eligible activity through The Butterfly Movement Ltd (A Kind Tractor Ltd stays dormant and is not used)
 - create Aboriginal-controlled or locally owned operating entities for recycling, production, sales and maintenance
 - use a head entity for IP, equipment, R&D, funding and shared services
 - structure local relationships through licence, fee-for-service, franchise-like models or another community-led form
 
 ## Charity question
 
-A charitable pathway can unlock philanthropy. It can also make the work feel like distribution rather than product ownership.
+The charitable pathway runs through The Butterfly Movement Ltd from FY2026-27. It can unlock philanthropy and DGR-eligible giving. It can also make the work feel like distribution rather than product ownership.
 
-That is the trade-off to hold: philanthropy may be needed, but Goods is trying to prove products people want and can own.
+That is the trade-off to hold: philanthropy may be needed, but Goods is trying to prove products people want and can own. The split is deliberate: A Curious Tractor Pty Ltd trades, The Butterfly Movement Ltd carries the charitable and DGR function.
 
 ## Mission protection
 

--- a/v2/.wiki-content/sources/act-core-facts.md
+++ b/v2/.wiki-content/sources/act-core-facts.md
@@ -14,17 +14,22 @@
 
 ## Current entity facts
 
+Confirmed by Ben on 29 May 2026. The current operating entity today is the Nicholas Marchesi sole trader. A Curious Tractor Pty Ltd is the go-forward trading company that Goods is migrating everything into this financial year (FY2026-27). The Butterfly Movement Ltd is the charity and DGR home from FY2026-27.
+
 | Entity | Type | Status | Goods relevance |
 | --- | --- | --- | --- |
-| **A Curious Tractor Pty Ltd** | Pty Ltd | Registered with ASIC on 24 April 2026. ACT core facts record Benjamin Knight and Nicholas Marchesi OAM as directors. | Primary ACT trading entity from 1 July 2026 and expected current trading home for Goods while the Goods structure is worked through. |
-| **Nicholas Marchesi OAM sole trader** | Individual trading structure | ACT core facts record this as trading until 30 June 2026, with the Pty cutover intended from 1 July 2026. | Historic and transition home for Goods, consulting and grant revenue. Some older contracts, invoices and records may still sit here. |
-| **A Kind Tractor Ltd** | Company limited by guarantee and charity | ACNC-registered. ACT core facts say it is dormant and not DGR, with DGR application parked. | Possible charitable mission holder or backstop for DGR-only funders if activated later. It is not the main Goods operating vehicle today. |
-| **Future Goods or community operating entities** | Not settled | Still being designed. | Possible local vehicles for recycling, production, repair, sales, maintenance, plant ownership and community governance. |
+| **Nicholas Marchesi sole trader** | Individual trading structure. ABN 21 591 780 066. | The current operating entity today. ACT core facts record the cutover to the Pty intended this financial year. | Current home for Goods trading, consulting and grant revenue. All activity is migrating into A Curious Tractor Pty Ltd this FY. |
+| **A Curious Tractor Pty Ltd** | Pty Ltd. ABN 36 697 347 676, ACN 697 347 676. | Registered with ASIC. Directors recorded as Benjamin Knight and Nicholas Marchesi OAM. | Go-forward trading and operating company, trading as Goods on Country. All operations migrate to it this financial year (FY2026-27). |
+| **The Butterfly Movement Ltd** | Company limited by guarantee, ACNC-registered charity, Item 1 DGR. | Operational as the Goods charity and DGR home from FY2026-27 (around 1 July 2026). Gifted/transitioned from TABOO Foundation, which continues as the same legal entity. | The only DGR pathway for Goods. Philanthropy, gifts and DGR-eligible funding flow through Butterfly, never through Goods, A Curious Tractor or A Kind Tractor directly. |
+| **A Kind Tractor Ltd** | Company limited by guarantee. ABN 73 669 029 341. | Dormant and not used. Its ACNC disease-prevention subtype application drew an RFI on 10 April 2024. Not DGR. | Not the trading entity, not the charity home and not a DGR pathway. Treat as dormant, not used. The Goods charity/DGR home is The Butterfly Movement Ltd. |
+| **Future community operating entities** | Not settled | Still being designed. | Possible local vehicles for recycling, production, repair, sales, maintenance, plant ownership and community governance. |
 
 ## Naming rule
 
-- Use **A Curious Tractor Pty Ltd** on first reference, then **the Pty** if needed.
-- Use **A Kind Tractor Ltd** on first reference, then **the charity** if needed.
+- The current operating entity today is the **Nicholas Marchesi sole trader** (ABN 21 591 780 066).
+- Use **A Curious Tractor Pty Ltd** (ABN 36 697 347 676, ACN 697 347 676), trading as Goods on Country, on first reference for the go-forward trading company, then **the Pty** if needed.
+- Use **The Butterfly Movement Ltd** on first reference for the charity and DGR home, then **the charity** if needed.
+- **A Kind Tractor Ltd** (ABN 73 669 029 341) is dormant and not used. It is not the Goods trading entity, charity home or DGR pathway. If named, mark it dormant and not used.
 - Do not use **ACT Foundation** or **ACT Ventures** as legal entity names. They are older conceptual labels in older material, not real current entities.
 
 ## Relevant people and service providers
@@ -42,9 +47,9 @@
 ## Review notes
 
 - Older Goods documents may still contain the conceptual labels **ACT Foundation** or **ACT Ventures**. Treat those as stale naming unless a later legal document proves otherwise.
-- Goods grant data and ACT core facts may conflict on DGR status. The current pack should not claim DGR status as settled.
-- Before sending legal or funder-facing documents, reconcile A Kind Tractor Ltd details with Standard Ledger, ASIC, ACNC and any current ATO status.
-- The Goods pack should describe A Kind Tractor Ltd as possible charitable infrastructure, not as the active Goods vehicle.
+- DGR is available only through The Butterfly Movement Ltd, and only from FY2026-27. Goods, A Curious Tractor and A Kind Tractor are never DGR directly.
+- Before sending legal or funder-facing documents, reconcile The Butterfly Movement Ltd and A Curious Tractor Pty Ltd details with Standard Ledger, ASIC, ACNC and any current ATO status.
+- The Goods pack should describe **A Kind Tractor Ltd** as dormant and not used, not as the Goods vehicle or a DGR pathway.
 
 ## Related
 

--- a/v2/src/app/admin/cost-model/cost-model-workspace.tsx
+++ b/v2/src/app/admin/cost-model/cost-model-workspace.tsx
@@ -24,14 +24,14 @@ const SKINS: { key: SkinKey; label: string; tagline: string }[] = [
   { key: 'investment', label: 'Investment', tagline: 'Margin waterfall · brokerage · debt' },
 ];
 
-function parseSkin(raw: string | null): SkinKey {
-  return raw === 'tesla' || raw === 'terminal' || raw === 'investment' || raw === 'mc' ? raw : 'mc';
+function parseSkin(raw: string | null, fallback: SkinKey = 'mc'): SkinKey {
+  return raw === 'tesla' || raw === 'terminal' || raw === 'investment' || raw === 'mc' ? raw : fallback;
 }
 
-export function CostModelWorkspace() {
+export function CostModelWorkspace({ defaultSkin = 'mc' }: { defaultSkin?: SkinKey }) {
   const router = useRouter();
   const params = useSearchParams();
-  const skin = parseSkin(params.get('skin'));
+  const skin = parseSkin(params.get('skin'), defaultSkin);
 
   // ONE shared engine instance — every skin renders the same locked numbers.
   const cm = useCostModel();

--- a/v2/src/app/api/investors/auth/route.ts
+++ b/v2/src/app/api/investors/auth/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+const COOKIE_NAME = 'investors_auth';
+const THIRTY_DAYS = 60 * 60 * 24 * 30;
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}));
+  const { password } = body as { password?: string };
+  const expected = process.env.INVESTORS_PASSWORD || 'goods2026';
+
+  if (!password || password !== expected) {
+    return NextResponse.json({ error: 'Incorrect password.' }, { status: 401 });
+  }
+
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(COOKIE_NAME, password, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: THIRTY_DAYS,
+    path: '/',
+  });
+  return response;
+}
+
+export async function DELETE() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(COOKIE_NAME, '', { maxAge: 0, path: '/' });
+  return response;
+}

--- a/v2/src/app/investors/login/page.tsx
+++ b/v2/src/app/investors/login/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Rocket } from 'lucide-react';
+
+function LoginForm() {
+  const params = useSearchParams();
+  const from = params.get('from') || '/investors';
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch('/api/investors/auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        setError(j.error || 'Incorrect password.');
+        setLoading(false);
+        return;
+      }
+      window.location.href = from;
+    } catch {
+      setError('Something went wrong. Try again.');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-stone-50 flex items-center justify-center px-6">
+      <div className="w-full max-w-md">
+        <div className="flex items-center gap-2 text-sm font-semibold text-stone-900">
+          <Rocket className="h-4 w-4" strokeWidth={1.5} />
+          Goods on Country · Investor Cockpit
+        </div>
+        <h1 className="mt-6 text-3xl font-serif tracking-tight text-stone-900">
+          Enter the password
+        </h1>
+        <p className="mt-3 text-sm text-stone-600 leading-relaxed">
+          The live, verified bed cost model and investment view — shared with QBE and
+          investment partners of Goods on Country. If you don&apos;t have the password,
+          contact Ben at ben@benjamink.com.au.
+        </p>
+        <form onSubmit={handleSubmit} className="mt-8 space-y-4">
+          <div>
+            <label
+              htmlFor="pw"
+              className="block text-xs font-semibold uppercase tracking-wider text-stone-500"
+            >
+              Password
+            </label>
+            <input
+              id="pw"
+              type="password"
+              autoComplete="current-password"
+              autoFocus
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-2 w-full rounded-md border border-stone-300 bg-white px-4 py-2.5 text-sm text-stone-900 focus:border-[#C45C3E] focus:outline-none focus:ring-1 focus:ring-[#C45C3E]"
+              required
+            />
+          </div>
+          {error && (
+            <p className="text-sm text-red-600" role="alert">
+              {error}
+            </p>
+          )}
+          <button
+            type="submit"
+            disabled={loading || !password}
+            className="w-full rounded-md bg-[#C45C3E] px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-[#a74d33] disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? 'Checking…' : 'Open the cockpit'}
+          </button>
+        </form>
+        <p className="mt-8 text-xs text-stone-400">Goods on Country · A Curious Tractor</p>
+      </div>
+    </div>
+  );
+}
+
+export default function InvestorsLoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/v2/src/app/investors/page.tsx
+++ b/v2/src/app/investors/page.tsx
@@ -1,0 +1,37 @@
+/**
+ * Investor cockpit (/investors) — the SAME verified cost-model engine + skins as
+ * /admin/cost-model, but behind the lightweight shared-password gate in proxy.ts
+ * (INVESTORS_PASSWORD) instead of the admin email/allowlist auth.
+ *
+ * This is the door QBE / investment partners click from the Notion QBE Diagnostic
+ * pages: one shared password, then the live Investment + Mission Control cockpit.
+ * All math is locked client-side (no admin data), so nothing auth-gated leaves the
+ * engine. Renders standalone (conditional-chrome hides the public site nav on
+ * /investors) so the cockpit owns the full viewport, exactly like the admin route.
+ *
+ * Defaults to the Investment skin (margin waterfall · brokerage · debt-service) —
+ * the most decision-relevant view for this audience; Mission Control / Tesla /
+ * Terminal are one toggle away and the choice is shareable via ?skin=.
+ */
+import { Suspense } from 'react';
+import { CostModelWorkspace } from '@/app/admin/cost-model/cost-model-workspace';
+
+export const metadata = {
+  title: 'Investor Cockpit — Goods on Country',
+  description:
+    'Live verified bed cost model + investment view. Marginal-cost-first, QBE-ready capital case.',
+};
+
+export default function InvestorsCockpitPage() {
+  return (
+    <div className="w-full px-4 sm:px-6">
+      <Suspense
+        fallback={
+          <div className="py-20 text-center text-sm text-gray-400">Loading cost model…</div>
+        }
+      >
+        <CostModelWorkspace defaultSkin="investment" />
+      </Suspense>
+    </div>
+  );
+}

--- a/v2/src/components/layout/conditional-chrome.tsx
+++ b/v2/src/components/layout/conditional-chrome.tsx
@@ -8,7 +8,7 @@ import { ImpactBanner } from './impact-banner';
 // Routes that should render WITHOUT the public site header, footer, and impact banner.
 // Funder briefs are confidential investor docs and should not display the public nav.
 // Field-notes are full-bleed immersive scrollytelling — they own the whole viewport.
-const STANDALONE_PATH_PREFIXES = ['/funders', '/insiders', '/admin', '/field-notes'];
+const STANDALONE_PATH_PREFIXES = ['/funders', '/insiders', '/investors', '/admin', '/field-notes'];
 
 // Routes where the global ImpactBanner competes with page-specific stats.
 // These pages carry their own product/place numbers, so suppress the global strip.

--- a/v2/src/proxy.ts
+++ b/v2/src/proxy.ts
@@ -12,6 +12,9 @@ const PASSWORD_COOKIE = 'impact_auth'
 // Insiders wiki password gate (shared password, cookie-based)
 const INSIDERS_COOKIE = 'insiders_auth'
 
+// Investor cockpit password gate (shared password, cookie-based) — QBE / investment partners
+const INVESTORS_COOKIE = 'investors_auth'
+
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname
 
@@ -39,6 +42,23 @@ export async function proxy(request: NextRequest) {
     const expectedPassword = process.env.INSIDERS_PASSWORD || 'goods2026'
     if (authCookie !== expectedPassword) {
       const loginUrl = new URL('/insiders/login', request.url)
+      loginUrl.searchParams.set('from', pathname)
+      return NextResponse.redirect(loginUrl)
+    }
+  }
+
+  // Investor cockpit — shared password gate (QBE / investment partners).
+  // Same lightweight cookie pattern as /insiders: one shared password, then the
+  // live cost-model + investment cockpit. The login page and auth route stay public.
+  if (
+    (pathname === '/investors' || pathname.startsWith('/investors/')) &&
+    pathname !== '/investors/login' &&
+    pathname !== '/api/investors/auth'
+  ) {
+    const authCookie = request.cookies.get(INVESTORS_COOKIE)?.value
+    const expectedPassword = process.env.INVESTORS_PASSWORD || 'goods2026'
+    if (authCookie !== expectedPassword) {
+      const loginUrl = new URL('/investors/login', request.url)
       loginUrl.searchParams.set('from', pathname)
       return NextResponse.redirect(loginUrl)
     }


### PR DESCRIPTION
## What

Adds **`/investors`** — the live cost-model + investment cockpit behind a lightweight shared-password gate, the door QBE / investment partners click from the Notion QBE Diagnostic pages. Mirrors the proven `/insiders` pattern.

- **`/investors`** wraps the **same verified `CostModelWorkspace`**, defaulting to the `investment` skin (margin waterfall · brokerage · debt-service). `?skin=` still overrides, so Mission Control / Tesla / Terminal are one toggle away.
- **`/investors/login`** + **`/api/investors/auth`** — cookie auth (30-day, httpOnly, secure in prod), login + auth route stay public.
- **`proxy.ts`** gates `/investors/*`.
- **`conditional-chrome.tsx`** renders `/investors` standalone (no public site nav), like `/admin`.
- **`CostModelWorkspace`** gains an optional `defaultSkin` prop — backward-compatible, `/admin/cost-model` unchanged.

All math stays client-side — **no admin/auth-gated data leaves the engine** through the cheaper gate.

A second commit aligns the **insiders-wiki legal/governance/capital pages** to the canonical entity structure (sole trader → A Curious Tractor Pty Ltd t/a Goods on Country; charity + DGR via The Butterfly Movement Ltd from FY2026-27; A Kind Tractor Ltd dormant).

## Before sharing with QBE

Set **`INVESTORS_PASSWORD`** in the Vercel project — the gate falls back to a default if it's unset.

## Test

`npx tsc --noEmit` → **0 errors**. New routes are simple reuse of an already-shipping component (Suspense-wrapped for `useSearchParams`).