### PR TITLE
feat(admin): operating-systems page — source-of-truth matrix + live data-freshness

### DIFF
--- a/v2/src/app/admin/admin-sidebar.tsx
+++ b/v2/src/app/admin/admin-sidebar.tsx
@@ -33,6 +33,7 @@ import {
   MoreHorizontal,
   ChevronDown,
   ChevronRight,
+  Network,
 } from 'lucide-react';
 
 type NavItem = { name: string; href: string; icon: React.ComponentType<{ className?: string }> };
@@ -46,6 +47,7 @@ const navigation: NavGroup[] = [
     group: 'Today',
     items: [
       { name: 'Dashboard', href: '/admin', icon: LayoutDashboard },
+      { name: 'Operating systems', href: '/admin/operating-systems', icon: Network },
     ],
   },
   {

--- a/v2/src/app/admin/operating-systems/page.tsx
+++ b/v2/src/app/admin/operating-systems/page.tsx
@@ -1,0 +1,224 @@
+import { createServiceClient } from '@/lib/supabase/server';
+import {
+  SYSTEM_OWNERS,
+  FRESHNESS_DOMAINS,
+  type SystemOwner,
+  type FreshnessDomain,
+} from '@/lib/data/operating-systems';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type FreshnessResult = FreshnessDomain & {
+  lastUpdated: string | null;
+  ageDays: number | null;
+  status: 'fresh' | 'aging' | 'stale' | 'unknown';
+};
+
+/**
+ * Live freshness — query the latest timestamp per domain. Each query is wrapped
+ * so a single bad table/column degrades to "unknown" rather than crashing the
+ * page. Columns verified against the live schema 2026-05-30.
+ */
+async function checkFreshness(): Promise<FreshnessResult[]> {
+  const supabase = createServiceClient();
+  return Promise.all(
+    FRESHNESS_DOMAINS.map(async (d): Promise<FreshnessResult> => {
+      try {
+        const { data, error } = await supabase
+          .from(d.table)
+          .select(d.column)
+          .order(d.column, { ascending: false })
+          .limit(1);
+        if (error || !data || data.length === 0) {
+          return { ...d, lastUpdated: null, ageDays: null, status: 'unknown' };
+        }
+        const iso = (data[0] as unknown as Record<string, string>)[d.column];
+        const ageDays = Math.floor((Date.now() - new Date(iso).getTime()) / DAY_MS);
+        const status =
+          ageDays <= d.staleAfterDays ? 'fresh' : ageDays <= d.staleAfterDays * 2 ? 'aging' : 'stale';
+        return { ...d, lastUpdated: iso, ageDays, status };
+      } catch {
+        return { ...d, lastUpdated: null, ageDays: null, status: 'unknown' };
+      }
+    }),
+  );
+}
+
+const STATUS_STYLE: Record<FreshnessResult['status'], { label: string; cls: string }> = {
+  fresh: { label: 'Fresh', cls: 'bg-emerald-100 text-emerald-800' },
+  aging: { label: 'Aging', cls: 'bg-amber-100 text-amber-800' },
+  stale: { label: 'Stale', cls: 'bg-red-100 text-red-800' },
+  unknown: { label: 'Unknown', cls: 'bg-gray-100 text-gray-600' },
+};
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString('en-AU', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+function OwnerCard({ s, accent }: { s: SystemOwner; accent: string }) {
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white p-4">
+      <div className="flex items-center gap-2">
+        <span className={`h-2 w-2 rounded-full ${accent}`} />
+        <p className="text-sm font-semibold text-gray-900">{s.name}</p>
+      </div>
+      <p className="mt-1 text-xs font-medium text-gray-500">{s.role}</p>
+      <p className="mt-2 text-xs leading-relaxed text-gray-600">{s.sourceOfTruthFor}</p>
+    </div>
+  );
+}
+
+export default async function OperatingSystemsPage() {
+  const freshness = await checkFreshness();
+  const dataOwners = SYSTEM_OWNERS.filter((s) => s.tier === 'data');
+  const narrative = SYSTEM_OWNERS.filter((s) => s.tier === 'narrative');
+  const support = SYSTEM_OWNERS.filter((s) => s.tier === 'support');
+
+  return (
+    <div className="max-w-5xl space-y-12">
+      <header>
+        <h1 className="text-2xl font-semibold text-gray-900">Operating Systems</h1>
+        <p className="mt-2 max-w-3xl text-sm text-gray-600">
+          How Goods&apos; systems fit together, who owns which truth, and whether the data behind our
+          external claims is fresh. Data flows <strong>one way</strong> into each owner — every system
+          is the source of truth for exactly one domain and reads the others; it never restates them.
+        </p>
+      </header>
+
+      {/* 1 — Operating-systems map */}
+      <section>
+        <h2 className="mb-1 text-lg font-semibold text-gray-900">Operating-systems map</h2>
+        <p className="mb-4 text-sm text-gray-500">
+          Three data owners feed one narrative; supporting systems sit alongside.
+        </p>
+
+        <p className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-400">
+          Data owners — each the single source of truth for one domain
+        </p>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {dataOwners.map((s) => (
+            <OwnerCard key={s.key} s={s} accent="bg-sky-500" />
+          ))}
+        </div>
+
+        <p className="my-3 text-center text-xs font-medium text-gray-400">
+          ↓ feed numbers into (never the reverse) ↓
+        </p>
+
+        <div className="grid grid-cols-1 gap-3">
+          {narrative.map((s) => (
+            <div key={s.key} className="rounded-lg border border-violet-200 bg-violet-50 p-4">
+              <div className="flex items-center gap-2">
+                <span className="h-2 w-2 rounded-full bg-violet-500" />
+                <p className="text-sm font-semibold text-gray-900">{s.name}</p>
+                <span className="text-xs font-medium text-gray-500">— {s.role}</span>
+              </div>
+              <p className="mt-2 text-xs leading-relaxed text-gray-600">{s.sourceOfTruthFor}</p>
+              <p className="mt-1 text-xs font-medium text-violet-700">{s.neverSourceFor}</p>
+            </div>
+          ))}
+        </div>
+
+        <p className="mb-2 mt-6 text-xs font-medium uppercase tracking-wide text-gray-400">
+          Supporting systems
+        </p>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {support.map((s) => (
+            <OwnerCard key={s.key} s={s} accent="bg-gray-400" />
+          ))}
+        </div>
+      </section>
+
+      {/* 2 — Source-of-truth matrix */}
+      <section>
+        <h2 className="mb-1 text-lg font-semibold text-gray-900">Source-of-truth matrix</h2>
+        <p className="mb-4 text-sm text-gray-500">
+          Where each fact lives. If two surfaces disagree, the owner below wins.
+        </p>
+        <div className="overflow-x-auto rounded-lg border border-gray-200">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-3 py-2 font-medium">System</th>
+                <th className="px-3 py-2 font-medium">Source of truth for</th>
+                <th className="px-3 py-2 font-medium">Reads</th>
+                <th className="px-3 py-2 font-medium">Never the source of</th>
+                <th className="px-3 py-2 font-medium">Where it lives</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {SYSTEM_OWNERS.map((s) => (
+                <tr key={s.key} className="align-top">
+                  <td className="px-3 py-3 font-medium text-gray-900">{s.name}</td>
+                  <td className="px-3 py-3 text-gray-600">{s.sourceOfTruthFor}</td>
+                  <td className="px-3 py-3 text-gray-500">{s.reads}</td>
+                  <td className="px-3 py-3 text-gray-600">{s.neverSourceFor}</td>
+                  <td className="px-3 py-3 text-xs text-gray-400">{s.lives}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {/* 3 — Data-freshness checklist (live) */}
+      <section>
+        <h2 className="mb-1 text-lg font-semibold text-gray-900">Data-freshness checklist</h2>
+        <p className="mb-4 text-sm text-gray-500">
+          Run before any external demo or funder claim. Status is live from Supabase right now.
+        </p>
+        <div className="overflow-x-auto rounded-lg border border-gray-200">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-3 py-2 font-medium">Status</th>
+                <th className="px-3 py-2 font-medium">Domain</th>
+                <th className="px-3 py-2 font-medium">Last updated</th>
+                <th className="px-3 py-2 font-medium">Backs the claim</th>
+                <th className="px-3 py-2 font-medium">If stale</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {freshness.map((f) => {
+                const st = STATUS_STYLE[f.status];
+                return (
+                  <tr key={f.id} className="align-top">
+                    <td className="px-3 py-3">
+                      <span
+                        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${st.cls}`}
+                      >
+                        {st.label}
+                      </span>
+                    </td>
+                    <td className="px-3 py-3 font-medium text-gray-900">{f.label}</td>
+                    <td className="whitespace-nowrap px-3 py-3 text-gray-600">
+                      {fmtDate(f.lastUpdated)}
+                      {f.ageDays !== null && (
+                        <span className="ml-1 text-xs text-gray-400">({f.ageDays}d)</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-gray-600">{f.backsClaim}</td>
+                    <td className="px-3 py-3 text-xs text-gray-500">{f.verify}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-3 text-xs text-gray-400">
+          Thresholds are per-domain (e.g. CRM stale after 14 days, fleet after 3). &ldquo;Aging&rdquo;
+          = past threshold; &ldquo;Stale&rdquo; = more than double it. &ldquo;Unknown&rdquo; = the
+          query did not return a row.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/v2/src/lib/data/operating-systems.ts
+++ b/v2/src/lib/data/operating-systems.ts
@@ -1,0 +1,158 @@
+/**
+ * Operating-systems reference data — backs /admin/operating-systems (QBE Area 6:
+ * Process & Technology). Three artifacts share this data:
+ *   1. the operating-systems map (diagram, rendered from SYSTEM_OWNERS)
+ *   2. the source-of-truth matrix (table, SYSTEM_OWNERS)
+ *   3. the data-freshness checklist (live, FRESHNESS_DOMAINS)
+ *
+ * Governing principle: data flows ONE WAY into each owner. Each system is the
+ * source of truth for exactly one domain and READS the others — it never
+ * restates them. (The grant-touching-the-buyer-board pattern is exactly what
+ * produced the stale Centrecorp $208K vs the real $123,332.)
+ */
+
+export interface SystemOwner {
+  key: string;
+  name: string;
+  role: string; // one-line "what it owns"
+  sourceOfTruthFor: string; // the domain it is canonical for
+  reads: string; // what it pulls from other systems
+  neverSourceFor: string; // what it must never be treated as the source of
+  lives: string; // where it physically lives / how to access
+  tier: 'data' | 'narrative' | 'support';
+}
+
+export const SYSTEM_OWNERS: SystemOwner[] = [
+  {
+    key: 'v2',
+    name: 'v2 admin + Supabase',
+    role: 'Physical & product truth',
+    sourceOfTruthFor:
+      'Assets (register + QR digital twins), production, cost model v6, public site + Stripe orders',
+    reads: 'Nothing — it is the primary record',
+    neverSourceFor: 'Funder relationships or money received (GHL + Xero own those)',
+    lives: 'Supabase cwsyhpiuepvdjtxaozwf · /admin',
+    tier: 'data',
+  },
+  {
+    key: 'ghl',
+    name: 'GoHighLevel (GHL)',
+    role: 'Relationships & pipeline',
+    sourceOfTruthFor:
+      'Every relationship and its pipeline stage — buyers, supporters, demand, capital conversations',
+    reads: 'Asset and demand signals from v2',
+    neverSourceFor: 'Dollars received — never sum money from pipeline cards',
+    lives: 'GHL location · synced via v2/src/lib/ghl',
+    tier: 'data',
+  },
+  {
+    key: 'xero',
+    name: 'Xero (ACT-GD)',
+    role: 'Money truth',
+    sourceOfTruthFor: 'All money invoiced, received and owed — the ONLY revenue source of truth',
+    reads: 'Nothing — it is the financial record',
+    neverSourceFor: 'Pipeline or forecast (that is GHL) — Xero is cash + invoices only',
+    lives: 'ACT-infra mirror tednluwflfhxyucgwigh (xero_invoices)',
+    tier: 'data',
+  },
+  {
+    key: 'notion',
+    name: 'Notion',
+    role: 'The QBE narrative',
+    sourceOfTruthFor:
+      'The human story we tell QBE — 12 diagnostic areas, decisions, the match contingency',
+    reads: 'Numbers from v2, Xero and GHL',
+    neverSourceFor: 'Any number — it pulls from the three data owners, never hand-keys figures',
+    lives: 'Notion · Goods. HQ',
+    tier: 'narrative',
+  },
+  {
+    key: 'el',
+    name: 'Empathy Ledger',
+    role: 'Consent-led stories & media',
+    sourceOfTruthFor: 'Storyteller consent, stories and media assets',
+    reads: 'The Goods project tag',
+    neverSourceFor: 'Asset or financial counts',
+    lives: 'EL Supabase · project goods (6bd47c8a…)',
+    tier: 'support',
+  },
+  {
+    key: 'drive',
+    name: 'Google Drive',
+    role: 'Documents & exports',
+    sourceOfTruthFor: 'Source documents, signed PDFs, CSV/xlsx exports',
+    reads: 'Generated reports from v2 and Notion',
+    neverSourceFor: 'Live data — Drive holds point-in-time exports, not the live figure',
+    lives: 'Drive · Goods folders',
+    tier: 'support',
+  },
+  {
+    key: 'grantscope',
+    name: 'Grantscope',
+    role: 'Funding-discovery brain',
+    sourceOfTruthFor:
+      'Grant matching and readiness analysis — who could fund this, and are we ready',
+    reads: 'Xero, GHL and v2 demand',
+    neverSourceFor: 'Asset or cost numbers — it must import v2 figures, not hard-code them',
+    lives: 'grantscope repo · goods-signals-workbench',
+    tier: 'support',
+  },
+];
+
+export interface FreshnessDomain {
+  id: string;
+  label: string;
+  backsClaim: string; // the external claim this data underpins
+  table: string; // Supabase table queried live
+  column: string; // timestamp column (verified against the live schema 2026-05-30)
+  staleAfterDays: number; // older than this = refresh before any external use
+  verify: string; // what to do / what it means if stale
+}
+
+export const FRESHNESS_DOMAINS: FreshnessDomain[] = [
+  {
+    id: 'assets',
+    label: 'Asset register',
+    backsClaim: '"496 beds deployed across 10 communities"',
+    table: 'assets',
+    column: 'created_time',
+    staleAfterDays: 45,
+    verify: 'Last asset minted to the register. Refresh after a new batch ships.',
+  },
+  {
+    id: 'crm',
+    label: 'CRM pipeline',
+    backsClaim: 'Buyer + funder pipeline status (never a committed dollar figure)',
+    table: 'crm_deals',
+    column: 'updated_at',
+    staleAfterDays: 14,
+    verify: 'Stale pipeline reads as abandoned. Touch every active deal before a demo.',
+  },
+  {
+    id: 'production',
+    label: 'Production',
+    backsClaim: 'Production capacity / "we are making beds"',
+    table: 'production_shifts',
+    column: 'created_at',
+    staleAfterDays: 30,
+    verify: 'No recent shift means: do not imply active production. Log the latest run.',
+  },
+  {
+    id: 'fleet',
+    label: 'Fleet telemetry',
+    backsClaim: 'Washing-machine usage / telemetry',
+    table: 'usage_logs',
+    column: 'created_at',
+    staleAfterDays: 3,
+    verify: 'Only ~1 of ~38 machines reports. Frame telemetry as pilot, not fleet-wide.',
+  },
+  {
+    id: 'orders',
+    label: 'Commerce (orders)',
+    backsClaim: 'Stripe shop / direct sales',
+    table: 'orders',
+    column: 'created_at',
+    staleAfterDays: 45,
+    verify: 'Low volume by design. Confirm before citing ecommerce traction.',
+  },
+];

--- a/wiki/outputs/2026-05-30-operating-systems-source-of-truth.md
+++ b/wiki/outputs/2026-05-30-operating-systems-source-of-truth.md
@@ -1,0 +1,64 @@
+# Operating Systems — Source of Truth, Freshness & Map (QBE Area 6)
+
+**Date:** 2026-05-30 · **Live version:** `/admin/operating-systems` (gated; freshness is live from Supabase).
+**Purpose:** close most of QBE Area 6 (Process & Technology) — make the operating backbone explainable, document who owns which truth, and give a repeatable freshness check before any external claim.
+
+**Governing principle:** data flows **one way** into each owner. Each system is the source of truth for exactly one domain and *reads* the others — it never restates them. (Restating is what produced the stale Centrecorp $208K vs the real $123,332.)
+
+---
+
+## 1. Operating-systems map
+
+```mermaid
+flowchart TD
+  subgraph OWN["Data owners — each canonical for one domain"]
+    V2["v2 admin + Supabase\nPhysical & product truth\n(assets, QR, production, cost model, Stripe)"]
+    GHL["GoHighLevel\nRelationships & pipeline stages"]
+    XERO["Xero (ACT-GD)\nMoney truth — invoiced/received/owed"]
+  end
+  NOTION["Notion — the QBE narrative\n(12 areas, decisions, match contingency)\nreads all three · hand-keys nothing"]
+  subgraph SUP["Supporting systems"]
+    EL["Empathy Ledger\nconsent-led stories & media"]
+    DRIVE["Google Drive\ndocuments & point-in-time exports"]
+    GS["Grantscope\nfunding-discovery brain\n(imports v2/Xero/GHL — never restates)"]
+  end
+  V2 --> NOTION
+  GHL --> NOTION
+  XERO --> NOTION
+  V2 -.-> GS
+  GHL -.-> GS
+  XERO -.-> GS
+```
+
+---
+
+## 2. Source-of-truth matrix
+
+| System | Source of truth for | Reads | Never the source of | Where it lives |
+|---|---|---|---|---|
+| **v2 admin + Supabase** | Assets (register + QR digital twins), production, cost model v6, public site + Stripe orders | Nothing — primary record | Funder relationships / money received | Supabase `cwsyhpiuepvdjtxaozwf` · `/admin` |
+| **GoHighLevel (GHL)** | Every relationship + its pipeline stage (buyers, supporters, demand, capital) | Asset/demand signals from v2 | Dollars received — never sum money from cards | GHL location · `v2/src/lib/ghl` |
+| **Xero (ACT-GD)** | All money invoiced, received, owed — the ONLY revenue source of truth | Nothing — financial record | Pipeline/forecast (that is GHL) | ACT-infra mirror `tednluwflfhxyucgwigh` (`xero_invoices`) |
+| **Notion** | The QBE narrative (12 areas, decisions, the match contingency) | Numbers from v2, Xero, GHL | Any number — pulls from the three owners, never hand-keys | Notion · Goods. HQ |
+| Empathy Ledger | Storyteller consent, stories, media assets | Goods project tag | Asset/financial counts | EL Supabase · project `goods` |
+| Google Drive | Source docs, signed PDFs, CSV/xlsx exports | Generated reports from v2/Notion | Live data — holds point-in-time exports | Drive · Goods folders |
+| Grantscope | Grant matching + readiness analysis | Xero, GHL, v2 demand | Asset/cost numbers — must import v2, not hard-code | grantscope repo · `goods-signals-workbench` |
+
+---
+
+## 3. Data-freshness checklist
+
+Run before any external demo or funder claim. The live page shows current status from Supabase; thresholds are per-domain. Snapshot **as of 2026-05-30**:
+
+| Status | Domain | Source (table.column) | Last updated | Stale after | Backs the claim |
+|---|---|---|---|---|---|
+| 🟢 Fresh | Asset register | `assets.created_time` | last batch ~14 May 2026 | 45d | "496 beds across 10 communities" |
+| 🔴 Stale | CRM pipeline | `crm_deals.updated_at` | 27 Mar 2026 (~64d) | 14d | Buyer/funder pipeline status (never a $ figure) |
+| 🔴 Stale | Production | `production_shifts.created_at` | 14 Mar 2026 (~77d) | 30d | Production capacity / "we are making beds" |
+| 🟢 Fresh | Fleet telemetry | `usage_logs.created_at` | 29 May 2026 | 3d | Washing-machine usage/telemetry (pilot, not fleet-wide) |
+| 🟢 Fresh | Commerce (orders) | `orders.created_at` | 25 May 2026 | 45d | Stripe shop / direct sales |
+
+**Action implied by this snapshot:** before any QBE demo, **touch the CRM pipeline** (stale ~64d → reads as abandoned) and **log/annotate production** (stale ~77d → do not imply active production). Fleet, orders and the register are current.
+
+---
+*Source data + columns verified against the live v2 schema (curl + service role, 2026-05-30). Canonical figures: `wiki/outputs/2026-05-29-qbe-canonical-numbers-sheet.md`.*


### PR DESCRIPTION
## What

Closes most of **QBE Area 6 (Process & Technology)** — makes the operating backbone explainable and gives a repeatable freshness check before any external claim. New gated page **`/admin/operating-systems`** renders three artifacts from one typed source (`lib/data/operating-systems.ts`):

1. **Operating-systems map** — three *data owners* (v2/Supabase = physical truth, GHL = relationships, Xero = money) feed one *narrative* owner (Notion), with supporting systems (Empathy Ledger, Drive, Grantscope) alongside. The rule it encodes: **data flows one way into each owner**; no system restates another's truth.
2. **Source-of-truth matrix** — for each system: what it owns, what it reads, what it must **never** be the source of, and where it lives. (Restating is exactly what produced the stale Centrecorp $208K vs the real $123,332.)
3. **Data-freshness checklist** — **live** per-domain status queried from Supabase at render: asset register, CRM pipeline, production, fleet telemetry, orders — each with its own stale threshold. As of today it flags **CRM (stale ~64d)** and **production (stale ~77d)** before a demo, while fleet/orders/register are fresh.

## Notes
- Gated by the existing `admin/layout.tsx` (auth + role); `force-dynamic` so it never prerenders a DB call.
- Each freshness query is isolated in try/catch → a bad table degrades to **"Unknown"**, never crashes the page.
- Timestamp columns verified against the **live** schema (curl + service role, 2026-05-30): `assets.created_time`, `crm_deals.updated_at`, `production_shifts.created_at`, `usage_logs.created_at`, `orders.created_at`.
- Portable mirror (for anyone without admin access / QBE): `wiki/outputs/2026-05-30-operating-systems-source-of-truth.md`.

## Test
`npx tsc --noEmit` → **0 errors**.