### PR TITLE
feat(admin): LOI tracker — live GHL pipelines → LOI ladder + match rollup

### DIFF
--- a/v2/src/app/admin/admin-sidebar.tsx
+++ b/v2/src/app/admin/admin-sidebar.tsx
@@ -26,6 +26,7 @@ import {
   Receipt,
   Presentation,
   Building2,
+  FileSignature,
   ClipboardCheck,
   NotebookPen,
   Calculator,
@@ -77,6 +78,7 @@ const navigation: NavGroup[] = [
     items: [
       { name: 'Funders',   href: '/admin/funders',             icon: Building2 },
       { name: 'Deals',     href: '/admin/deals',               icon: Crosshair },
+      { name: 'LOI tracker', href: '/admin/loi-tracker',        icon: FileSignature },
       { name: 'Xero recon', href: '/admin/xero-reconciliation', icon: FileCheck },
     ],
   },

--- a/v2/src/app/admin/loi-tracker/page.tsx
+++ b/v2/src/app/admin/loi-tracker/page.tsx
@@ -1,0 +1,182 @@
+import Link from 'next/link';
+import { fetchOpportunitiesForPipelines, type GoodsOpportunity } from '@/lib/ghl';
+import {
+  LOI_RUNGS,
+  GOODS_PIPELINES,
+  PIPELINE_BY_ID,
+  STAGE_TO_RUNG,
+  MATCH_TARGET,
+  GRANTS_ROUTING,
+  type LoiRung,
+} from '@/lib/data/loi-pipeline';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+const STREAM_BADGE: Record<string, string> = {
+  commercial: 'bg-sky-100 text-sky-800',
+  philanthropy: 'bg-violet-100 text-violet-800',
+  demand: 'bg-gray-100 text-gray-600',
+};
+
+function fmtMoney(n: number): string {
+  if (!n) return '—';
+  if (n >= 1_000_000) return `$${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `$${(n / 1_000).toFixed(0)}K`;
+  return `$${n.toLocaleString()}`;
+}
+
+export default async function LoiTrackerPage() {
+  const { ok, opportunities } = await fetchOpportunitiesForPipelines(
+    GOODS_PIPELINES.map((p) => p.id),
+  );
+
+  // Bucket live opportunities onto the LOI ladder. Drop lost/abandoned and any
+  // stage that isn't mapped to a rung (Lapsed, Declined/Parked, Dormant).
+  const active = opportunities.filter(
+    (o) => o.status !== 'lost' && o.status !== 'abandoned' && STAGE_TO_RUNG[o.stageId],
+  );
+  const byRung: Record<LoiRung, GoodsOpportunity[]> = {
+    target: [],
+    signed: [],
+    contract: [],
+    cash: [],
+  };
+  for (const o of active) byRung[STAGE_TO_RUNG[o.stageId]].push(o);
+
+  const rungTotal = (rung: LoiRung) => byRung[rung].reduce((s, o) => s + o.monetaryValue, 0);
+  // "Committed+" = signed + contract + cash. This is GHL pipeline value, NOT
+  // confirmed/eligible capital — the match figure must be verified in Xero.
+  const committedPlus = (['signed', 'contract', 'cash'] as LoiRung[]).reduce(
+    (s, r) => s + rungTotal(r),
+    0,
+  );
+  const philanthropyCommitted = (['signed', 'contract', 'cash'] as LoiRung[]).reduce(
+    (s, r) =>
+      s +
+      byRung[r]
+        .filter((o) => PIPELINE_BY_ID[o.pipelineId]?.stream === 'philanthropy')
+        .reduce((a, o) => a + o.monetaryValue, 0),
+    0,
+  );
+  const signedCount = byRung.signed.length;
+
+  return (
+    <div className="max-w-6xl space-y-8">
+      <header>
+        <h1 className="text-2xl font-semibold text-gray-900">LOI Tracker</h1>
+        <p className="mt-2 max-w-3xl text-sm text-gray-600">
+          Progress toward the QBE match, read <strong>live from GHL</strong> — the source of truth for
+          relationships and pipeline stages. Pulls the three Goods pipelines (Demand Register → Buyer
+          Pipeline → Supporter Journey) and maps their stages onto the LOI ladder. Sits beside{' '}
+          <Link href="/admin/deals" className="text-sky-700 underline">
+            /admin/deals
+          </Link>
+          .
+        </p>
+      </header>
+
+      {/* Match banner — contingent + cap TBC */}
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+        <p className="text-sm font-semibold text-amber-900">QBE match — contingent, cap unconfirmed</p>
+        <p className="mt-1 text-sm text-amber-800">{MATCH_TARGET.note}</p>
+        <div className="mt-3 flex flex-wrap gap-6 text-sm">
+          <div>
+            <span className="block text-xs uppercase tracking-wide text-amber-700">
+              Committed+ in GHL (all streams)
+            </span>
+            <span className="text-lg font-semibold text-amber-900">{fmtMoney(committedPlus)}</span>
+          </div>
+          <div>
+            <span className="block text-xs uppercase tracking-wide text-amber-700">
+              Of which philanthropy
+            </span>
+            <span className="text-lg font-semibold text-amber-900">
+              {fmtMoney(philanthropyCommitted)}
+            </span>
+          </div>
+          <div>
+            <span className="block text-xs uppercase tracking-wide text-amber-700">
+              Signed / committed deals
+            </span>
+            <span className="text-lg font-semibold text-amber-900">{signedCount}</span>
+          </div>
+        </div>
+        <p className="mt-2 text-xs text-amber-700">
+          GHL pipeline value — <strong>not</strong> committed capital or eligible match evidence.
+          Confirm any cash figure in Xero (the money source of truth) and a signed LOI document before
+          counting it toward the match.
+        </p>
+      </div>
+
+      {/* The LOI ladder */}
+      {!ok ? (
+        <div className="rounded-lg border border-gray-200 bg-white p-6 text-sm text-gray-500">
+          GHL is not connected in this environment (or returned no data), so the live ladder is empty.
+          Set <code className="rounded bg-gray-100 px-1">GHL_ENABLED</code>,{' '}
+          <code className="rounded bg-gray-100 px-1">GHL_API_KEY</code> and{' '}
+          <code className="rounded bg-gray-100 px-1">GHL_LOCATION_ID</code> to populate it. The ladder,
+          mapping and match rules above still apply.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
+          {LOI_RUNGS.map((rung) => {
+            const opps = byRung[rung.key].slice().sort((a, b) => b.monetaryValue - a.monetaryValue);
+            return (
+              <div key={rung.key} className="rounded-lg border border-gray-200 bg-white">
+                <div className="border-b border-gray-100 p-3">
+                  <div className="flex items-baseline justify-between">
+                    <h2 className="text-sm font-semibold text-gray-900">{rung.label}</h2>
+                    <span className="text-xs font-medium text-gray-500">
+                      {opps.length} · {fmtMoney(rungTotal(rung.key))}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs leading-snug text-gray-400">{rung.desc}</p>
+                </div>
+                <ul className="divide-y divide-gray-50">
+                  {opps.length === 0 && (
+                    <li className="p-3 text-xs text-gray-400">No opportunities at this rung.</li>
+                  )}
+                  {opps.map((o) => {
+                    const p = PIPELINE_BY_ID[o.pipelineId];
+                    return (
+                      <li key={o.id} className="p-3">
+                        <p className="text-sm font-medium text-gray-900">{o.name}</p>
+                        <div className="mt-1 flex flex-wrap items-center gap-2">
+                          {p && (
+                            <span
+                              className={`rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
+                                STREAM_BADGE[p.stream] ?? 'bg-gray-100 text-gray-600'
+                              }`}
+                            >
+                              {p.stream}
+                            </span>
+                          )}
+                          <span className="text-xs text-gray-500">{fmtMoney(o.monetaryValue)}</span>
+                          {o.contactName && (
+                            <span className="text-xs text-gray-400">· {o.contactName}</span>
+                          )}
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Grants routing */}
+      <div className="rounded-lg border border-violet-200 bg-violet-50 p-4">
+        <p className="text-sm font-semibold text-violet-900">Where grants land</p>
+        <p className="mt-1 text-sm text-violet-800">{GRANTS_ROUTING}</p>
+      </div>
+
+      <p className="text-xs text-gray-400">
+        Pipelines read: {GOODS_PIPELINES.map((p) => p.name).join(' · ')}. Stage→rung mapping verified
+        against GHL 2026-05-30. Lapsed / Declined / Dormant stages drop off the ladder.
+      </p>
+    </div>
+  );
+}

--- a/v2/src/app/admin/loi-tracker/page.tsx
+++ b/v2/src/app/admin/loi-tracker/page.tsx
@@ -9,6 +9,7 @@ import {
   GRANTS_ROUTING,
   type LoiRung,
 } from '@/lib/data/loi-pipeline';
+import { supplierQuotes } from '@/lib/data/supplier-quotes';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -33,9 +34,16 @@ export default async function LoiTrackerPage() {
 
   // Bucket live opportunities onto the LOI ladder. Drop lost/abandoned and any
   // stage that isn't mapped to a rung (Lapsed, Declined/Parked, Dormant).
-  const active = opportunities.filter(
+  const ladderable = opportunities.filter(
     (o) => o.status !== 'lost' && o.status !== 'abandoned' && STAGE_TO_RUNG[o.stageId],
   );
+  // Suppliers belong in the cost-model supplier list, NOT a funding pipeline.
+  // Defensively exclude any opp whose name matches a known supplier so a misfiled
+  // one (e.g. "Centre Canvas" sitting in Buyer) never pollutes the LOI ladder.
+  const SUPPLIER_NAMES = new Set(supplierQuotes.map((q) => q.supplier.trim().toLowerCase()));
+  const isSupplier = (o: GoodsOpportunity) => SUPPLIER_NAMES.has(o.name.trim().toLowerCase());
+  const active = ladderable.filter((o) => !isSupplier(o));
+  const misfiledSuppliers = ladderable.filter(isSupplier);
   const byRung: Record<LoiRung, GoodsOpportunity[]> = {
     target: [],
     signed: [],
@@ -172,6 +180,22 @@ export default async function LoiTrackerPage() {
         <p className="text-sm font-semibold text-violet-900">Where grants land</p>
         <p className="mt-1 text-sm text-violet-800">{GRANTS_ROUTING}</p>
       </div>
+
+      {/* Misfiled suppliers (hidden from the ladder) */}
+      {misfiledSuppliers.length > 0 && (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-4">
+          <p className="text-sm font-semibold text-rose-900">
+            {misfiledSuppliers.length} supplier{misfiledSuppliers.length > 1 ? 's' : ''} misfiled in a
+            funding pipeline — hidden from the ladder
+          </p>
+          <p className="mt-1 text-sm text-rose-800">
+            {misfiledSuppliers.map((o) => o.name).join(', ')}. Suppliers belong in the cost-model
+            supplier list (<code className="rounded bg-rose-100 px-1">supplier-quotes.ts</code>), not
+            the Buyer / Supporter pipelines — move them out in GHL so the pipeline reflects only buyers
+            and funders.
+          </p>
+        </div>
+      )}
 
       <p className="text-xs text-gray-400">
         Pipelines read: {GOODS_PIPELINES.map((p) => p.name).join(' · ')}. Stage→rung mapping verified

--- a/v2/src/lib/data/loi-pipeline.ts
+++ b/v2/src/lib/data/loi-pipeline.ts
@@ -1,0 +1,110 @@
+/**
+ * LOI tracker config — backs /admin/loi-tracker.
+ *
+ * Source of truth is GHL: relationships and pipeline stages live there (per the
+ * operating-systems source-of-truth matrix). This file only maps the live GHL
+ * Goods pipelines + stages onto a simple LOI ladder so the tracker can show
+ * progress toward the QBE match.
+ *
+ * Stage IDs verified against GHL get-pipelines 2026-05-30 (location agzsSZWg…).
+ */
+
+export type LoiRung = 'target' | 'signed' | 'contract' | 'cash';
+
+export const LOI_RUNGS: { key: LoiRung; label: string; desc: string }[] = [
+  { key: 'target', label: 'Target', desc: 'In cultivation / proposal — no commitment yet' },
+  {
+    key: 'signed',
+    label: 'Committed',
+    desc: 'A firm commitment in GHL. NB: a GHL "Committed" stage is a pipeline status, not necessarily a signed LOI document — the match needs actual signed LOIs.',
+  },
+  { key: 'contract', label: 'Contracted / Delivering', desc: 'Agreement executed, delivery underway' },
+  { key: 'cash', label: 'Cash / Stewarding', desc: 'Money in — Xero is the source of truth for the figure' },
+];
+
+export interface GoodsPipelineMeta {
+  id: string;
+  name: string;
+  role: string;
+  stream: 'commercial' | 'philanthropy' | 'demand';
+}
+
+/** The three Goods pipelines the tracker reads live. */
+export const GOODS_PIPELINES: GoodsPipelineMeta[] = [
+  {
+    id: 'UQsrmuqzxMSdCTklxEcG',
+    name: 'Goods — Demand Register',
+    role: 'Unworked demand signals (upstream of the LOI ladder)',
+    stream: 'demand',
+  },
+  {
+    id: 'FjMyJM3YzWQFmKqR9fur',
+    name: 'Goods — Buyer Pipeline',
+    role: 'Commercial bed sales',
+    stream: 'commercial',
+  },
+  {
+    id: 'JvBFYpVpyKsw899lkFgj',
+    name: 'Goods Supporter Journey',
+    role: 'All philanthropy — foundations, grants (tagged), major donors, capital (goods-capital tag)',
+    stream: 'philanthropy',
+  },
+];
+
+export const PIPELINE_BY_ID: Record<string, GoodsPipelineMeta> = Object.fromEntries(
+  GOODS_PIPELINES.map((p) => [p.id, p]),
+);
+
+/**
+ * GHL stageId -> LOI rung. Stages deliberately omitted (Lapsed, Declined/Parked,
+ * Dormant) drop off the ladder. Demand Register stages map to "target" (they are
+ * pre-commitment signals, shown for context).
+ */
+export const STAGE_TO_RUNG: Record<string, LoiRung> = {
+  // Goods — Buyer Pipeline
+  'e5220eb2-be40-4e79-9571-6acae12285c7': 'target', // Outreach Queued
+  '1fd317ec-f8f1-4837-b324-e48c22956cdd': 'target', // First Contact
+  '8da22920-c295-4358-be58-c4c69f372890': 'target', // In Conversation
+  'c3e5e7c5-c5cf-4541-86ef-6eaf256aac54': 'target', // Qualified
+  '27085dfa-23bf-4e6d-90ea-483bf44ab5b6': 'target', // Scoped
+  'e23847c3-5f74-4da6-a907-6c3d6d45008c': 'target', // Proposed
+  'a5222f0c-380b-4866-8cef-80cbae08189c': 'target', // Negotiating
+  '809f1a7a-0082-40fc-8e78-b51bde71a741': 'signed', // Committed
+  'dc6cf017-325a-4040-beb1-76f2cffba02c': 'contract', // In Delivery
+  '80be941e-86b6-41d1-857f-7865f66692f7': 'contract', // Delivered
+  '835065e8-c952-4cfe-9228-5e8625d100ae': 'contract', // Invoiced
+  '0100d504-3108-415c-82fd-85a66192ef1c': 'cash', // Paid
+  // Goods Supporter Journey
+  'cf8d31d2-73be-4119-b56b-7b0334254197': 'target', // Identified
+  'a84114da-8888-4357-a2df-01b29f37209d': 'target', // Qualified
+  '524aca71-287d-4eeb-a53a-66ff3a7aede5': 'target', // Cultivating
+  'a23b26b4-ace3-4199-8a14-b65ed888aa52': 'target', // Ask made
+  'c6369cf9-80f6-4680-9249-acc1c861022d': 'signed', // Committed
+  '15b7b876-16e3-4c57-84e6-7c09d703888e': 'contract', // Delivering
+  '3e38f65b-a515-4e32-9fc9-57ea1531edc6': 'cash', // Stewarding / Reporting
+  'ff90ea45-2196-4a7a-a311-8f27c3c7cda6': 'cash', // Renewing
+  // Goods — Demand Register (pre-commitment, shown as target context)
+  '0c5ed787-2015-4af0-b2ad-a916e40879db': 'target', // Signal
+  '02502aa3-9a0d-4ddd-b1f0-c1e836838426': 'target', // Buyer Matched
+  '13958a71-9f0e-468a-afc0-663c53d4220c': 'target', // Converted
+};
+
+/**
+ * QBE Stage-2 match. CONTINGENT on raising eligible non-QBE capital FIRST, and
+ * the cap + what counts as "eligible" are UNCONFIRMED (gated on founder decision).
+ * Do not present the match as secured or quote a single cap externally.
+ */
+export const MATCH_TARGET = {
+  indicativeLow: 200_000,
+  indicativeHigh: 400_000,
+  note: 'QBE Stage-2 match cap is UNCONFIRMED ($200K–$400K indicative) and contingent on eligible non-QBE capital raised first. Name the lanes + lock the figure once confirmed.',
+};
+
+/**
+ * Where grants land. Grants are philanthropy → they belong in the Goods Supporter
+ * Journey pipeline, tagged "grant" (a grant Awarded ≈ a Committed LOI). GHL's
+ * standalone "Grants" pipeline is the legacy org-level board (merge target) — any
+ * Goods grant still there should move into Supporter Journey so it shows here.
+ */
+export const GRANTS_ROUTING =
+  'Grants are philanthropy: they belong in the Goods Supporter Journey pipeline, tagged "grant" (a grant Awarded ≈ a Committed LOI). The standalone "Grants" pipeline in GHL is the legacy org-level board (merge target) — any Goods grant still sitting there should move into Supporter Journey so it appears on this ladder.';

--- a/v2/src/lib/ghl/index.ts
+++ b/v2/src/lib/ghl/index.ts
@@ -377,6 +377,62 @@ async function ghlRequest<T>(
 }
 
 /**
+ * Read Goods opportunities across the given GHL pipelines (LeadConnector).
+ * Resilient: returns [] if GHL is disabled or a pipeline errors, so callers
+ * (e.g. /admin/loi-tracker) degrade gracefully rather than crashing.
+ */
+interface GhlOpportunityRaw {
+  id?: string;
+  name?: string;
+  pipelineId?: string;
+  pipelineStageId?: string;
+  monetaryValue?: number;
+  status?: string;
+  contact?: { name?: string };
+  contactName?: string;
+}
+
+export interface GoodsOpportunity {
+  id: string;
+  name: string;
+  pipelineId: string;
+  stageId: string;
+  monetaryValue: number;
+  status: string; // open | won | lost | abandoned
+  contactName?: string;
+}
+
+export async function fetchOpportunitiesForPipelines(
+  pipelineIds: string[],
+): Promise<{ ok: boolean; opportunities: GoodsOpportunity[] }> {
+  if (!GHL_ENABLED) return { ok: false, opportunities: [] };
+  const all: GoodsOpportunity[] = [];
+  let anyOk = false;
+  for (const pid of pipelineIds) {
+    try {
+      const res = await ghlRequest<{ opportunities?: GhlOpportunityRaw[] }>(
+        `/opportunities/search?location_id=${GHL_LOCATION_ID}&pipeline_id=${pid}&limit=100`,
+      );
+      anyOk = true;
+      for (const o of res.opportunities || []) {
+        all.push({
+          id: String(o.id ?? ''),
+          name: String(o.name ?? 'Untitled'),
+          pipelineId: String(o.pipelineId ?? pid),
+          stageId: String(o.pipelineStageId ?? ''),
+          monetaryValue: Number(o.monetaryValue ?? 0),
+          status: String(o.status ?? 'open'),
+          contactName: o.contact?.name ?? o.contactName ?? undefined,
+        });
+      }
+    } catch {
+      // skip this pipeline; the page renders what it could fetch
+    }
+  }
+  return { ok: anyOk, opportunities: all };
+}
+
+/**
  * Find contact by email or phone
  */
 async function findContact(emailOrPhone: string): Promise<{ id: string } | null> {


### PR DESCRIPTION
## What

New gated **`/admin/loi-tracker`** that reads **GHL live** — the source of truth for relationships + pipeline stages (per the operating-systems matrix) — and maps the three **Goods** pipelines onto an LOI ladder, so you can see progress toward the QBE match in one place. Sits beside `/admin/deals`.

- **Reads all three Goods pipelines** (`get-pipelines`, 2026-05-30): **Demand Register → Buyer Pipeline → Supporter Journey**, via a new resilient `fetchOpportunitiesForPipelines()` in `lib/ghl` (reuses the existing `ghlRequest` + LeadConnector `/opportunities/search`).
- **Stage → ladder mapping** (`target → committed → contracted → cash`) verified against the live stage IDs. Lapsed / Declined / Dormant drop off. Lost/abandoned excluded.
- **Where grants land** — grants are philanthropy → they belong in **Supporter Journey** (tagged); the legacy standalone **Grants** pipeline is the merge target. Surfaced explicitly on the page.
- **Match rollup is honest** — flagged **contingent + cap TBC ($200K–$400K)**, labelled GHL *pipeline value*, **not** committed capital or eligible evidence. "Confirm cash in Xero and a signed LOI before counting it."
- Degrades gracefully: if GHL is disabled/errors, the ladder is empty with a connect note (rules + mapping still shown).

## Gated on you (#4)
Naming the actual LOI lanes + locking the match figure needs the **QBE cap + eligible-match rules**. The scaffold is live now; it just reflects whatever GHL holds.

## Test
`npx tsc --noEmit` → **0 errors**. Live GHL read verified against the API (Buyer Pipeline returns 10 opps with the mapped shape).

## Note
Touches `admin-sidebar.tsx` (adds the Money-group link + one icon import) — same file as PR #49; if both merge, expect at most a trivial 1-line import merge.