### PR TITLE
feat(admin): audience comms segments + per-audience impact report templates

### DIFF
--- a/v2/src/app/admin/admin-sidebar.tsx
+++ b/v2/src/app/admin/admin-sidebar.tsx
@@ -25,6 +25,7 @@ import {
   Images,
   Receipt,
   Presentation,
+  FileText,
   Building2,
   FileSignature,
   ClipboardCheck,
@@ -102,6 +103,7 @@ const moreNavigation: NavItem[] = [
   { name: 'Reach out',       href: '/admin/reach-out',     icon: Send },
   // Funder collateral (Funders is the hub; these are sub-pages)
   { name: 'Funder reports',  href: '/admin/reports',       icon: Presentation },
+  { name: 'Impact reports',  href: '/admin/reports/impact', icon: FileText },
   { name: 'Deck preview',    href: '/admin/deck',          icon: Presentation },
   // Money detail
   { name: 'Orders',          href: '/admin/orders',        icon: ShoppingCart },

--- a/v2/src/app/admin/reach-out/campaign-segment-panel.tsx
+++ b/v2/src/app/admin/reach-out/campaign-segment-panel.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Card, CardContent } from '@/components/ui/card';
+import { AlertCircle, Copy, Check, FileText, Megaphone, Users, Mail } from 'lucide-react';
+import type { AudienceSegment } from '@/lib/ghl/smart-lists';
+
+interface Props {
+  segment: AudienceSegment;
+  reportName: string;
+  reportHref: string;
+}
+
+interface SegmentPreview {
+  enabled: boolean;
+  kind: 'tag' | 'pipeline-stage';
+  unit?: 'contacts' | 'opportunities';
+  count: number;
+  withEmail?: number;
+  softCap: number;
+  hardCap: number;
+  sample?: Array<{ name: string | null; email?: string | null; value?: number; contactName?: string | null }>;
+}
+
+export function CampaignSegmentPanel({ segment, reportName, reportHref }: Props) {
+  // Starts in the loading state; the parent remounts this per segment (key=id),
+  // so the effect only sets state from the fetch callbacks (no sync setState).
+  const [preview, setPreview] = useState<SegmentPreview | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/admin/reach-out/preview?segmentId=${encodeURIComponent(segment.id)}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled) return;
+        if (data.error) setError(data.error);
+        else setPreview(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [segment.id]);
+
+  const tag = segment.source.kind === 'tag' ? segment.source.tag : null;
+  const count = preview?.count ?? 0;
+  const overSoft = count > segment.softCap;
+  const overHard = count > segment.hardCap;
+  const unit = preview?.unit ?? (segment.source.kind === 'tag' ? 'contacts' : 'opportunities');
+
+  function copyTag() {
+    if (!tag) return;
+    navigator.clipboard.writeText(tag).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }
+
+  return (
+    <Card>
+      <CardContent className="space-y-5">
+        <header>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-base font-semibold">{segment.name}</h2>
+            <span className="rounded-full bg-violet-100 px-2 py-0.5 text-[11px] font-medium text-violet-800">
+              {segment.supportLevel}
+            </span>
+          </div>
+          <p className="mt-1 text-sm text-gray-600">{segment.description}</p>
+        </header>
+
+        {/* Live size + cap status */}
+        {loading ? (
+          <p className="text-sm text-gray-500">Resolving live size from GHL…</p>
+        ) : error ? (
+          <div className="flex items-start gap-2 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            <span>{error}</span>
+          </div>
+        ) : preview ? (
+          <div className="rounded border border-gray-200 bg-gray-50 p-3 text-sm">
+            <div className="mb-2 flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+              <Users className="h-3.5 w-3.5" /> Live size
+            </div>
+            {preview.enabled ? (
+              <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
+                <span>
+                  <strong className="text-lg text-gray-900">{count}</strong> {unit}
+                </span>
+                {typeof preview.withEmail === 'number' && (
+                  <span className="text-gray-600">
+                    <strong className="text-gray-900">{preview.withEmail}</strong> with an email
+                  </span>
+                )}
+                <span className="text-xs text-gray-400">
+                  caps: {segment.softCap} soft · {segment.hardCap} hard
+                </span>
+              </div>
+            ) : (
+              <p className="text-amber-700">
+                GHL not connected here — build the smart list in GHL to see the size. The recipe below
+                still applies.
+              </p>
+            )}
+            {preview.enabled && overSoft && !overHard && (
+              <div className="mt-2 flex items-start gap-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+                <AlertCircle className="h-3 w-3 shrink-0" />
+                <span>
+                  {count} exceeds the recommended {segment.softCap} for this segment. Fine for a
+                  broadcast newsletter; double-check for a high-touch list.
+                </span>
+              </div>
+            )}
+            {preview.enabled && overHard && (
+              <div className="mt-2 flex items-start gap-2 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-800">
+                <AlertCircle className="h-3 w-3 shrink-0" />
+                <span>
+                  {count} exceeds the hard cap of {segment.hardCap}. Tighten the GHL filter (stage / tag)
+                  before sending a campaign this wide.
+                </span>
+              </div>
+            )}
+            {preview.enabled && preview.sample && preview.sample.length > 0 && (
+              <details className="mt-2 text-xs">
+                <summary className="cursor-pointer text-gray-500 hover:text-gray-700">
+                  Sample ({preview.sample.length})
+                </summary>
+                <ul className="mt-2 space-y-1 text-gray-600">
+                  {preview.sample.map((s, i) => (
+                    <li key={i} className="flex flex-wrap items-center gap-2">
+                      <span>{s.name || s.contactName || '(no name)'}</span>
+                      {s.email && <span className="font-mono text-gray-400">{s.email}</span>}
+                      {typeof s.value === 'number' && s.value > 0 && (
+                        <span className="text-gray-400">${s.value.toLocaleString()}</span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            )}
+          </div>
+        ) : null}
+
+        {/* How to build in GHL */}
+        <div className="rounded border border-gray-200 p-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-gray-900">
+            <Megaphone className="h-4 w-4 text-gray-500" /> Build this smart list in GHL
+          </div>
+          <p className="mt-1 text-sm text-gray-700">{segment.ghlSmartListRecipe}</p>
+          {tag && (
+            <button
+              onClick={copyTag}
+              className="mt-2 inline-flex items-center gap-1.5 rounded border border-gray-300 bg-white px-2 py-1 font-mono text-xs text-gray-700 hover:bg-gray-50"
+            >
+              {copied ? <Check className="h-3 w-3 text-emerald-600" /> : <Copy className="h-3 w-3" />}
+              {tag}
+            </button>
+          )}
+        </div>
+
+        {/* Recommended report */}
+        <Link
+          href={reportHref}
+          className="flex items-start gap-3 rounded border border-sky-200 bg-sky-50 p-3 transition-colors hover:bg-sky-100"
+        >
+          <FileText className="mt-0.5 h-4 w-4 shrink-0 text-sky-700" />
+          <div>
+            <div className="text-sm font-semibold text-sky-900">Recommended report: {reportName}</div>
+            <p className="mt-0.5 text-xs text-sky-800">{segment.campaignNote}</p>
+          </div>
+        </Link>
+
+        {/* No in-app send */}
+        <div className="flex items-start gap-2 rounded border border-gray-200 bg-gray-50 p-3 text-xs text-gray-600">
+          <Mail className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+          <span>
+            <strong className="text-gray-800">GHL owns the send.</strong> This tool only defines the
+            segment. To send: build the smart list above in GHL, attach the recommended report as an
+            email campaign / workflow, and send from GHL. There is no in-app send for audience segments —
+            that keeps high-value funder/buyer lists off the SMS blast path.
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/v2/src/app/admin/reach-out/page.tsx
+++ b/v2/src/app/admin/reach-out/page.tsx
@@ -1,97 +1,147 @@
 import Link from 'next/link';
-import { SMART_LISTS } from '@/lib/ghl/smart-lists';
+import { SMART_LISTS, AUDIENCE_SEGMENTS, findAudienceSegment } from '@/lib/ghl/smart-lists';
+import { findReportTemplate } from '@/lib/data/report-templates';
 import { Card, CardContent } from '@/components/ui/card';
-import { Send, Users } from 'lucide-react';
+import { Send, Users, Megaphone } from 'lucide-react';
 import { ComposeForm } from './compose-form';
+import { CampaignSegmentPanel } from './campaign-segment-panel';
 
 export const dynamic = 'force-dynamic';
 
 export default async function ReachOutPage({
   searchParams,
 }: {
-  searchParams: Promise<{ list?: string; tag?: string }>;
+  searchParams: Promise<{ list?: string; tag?: string; segment?: string }>;
 }) {
   const params = await searchParams;
   const selectedListId = params.list || null;
   const selectedCustomTag = params.tag || null;
+  const selectedSegmentId = params.segment || null;
   const selectedList = selectedListId ? SMART_LISTS.find((l) => l.id === selectedListId) : null;
+  const selectedSegment = selectedSegmentId ? findAudienceSegment(selectedSegmentId) : null;
+  const selectedReport = selectedSegment ? findReportTemplate(selectedSegment.recommendedReportId) : null;
+  const nothingSelected = !selectedListId && !selectedCustomTag && !selectedSegmentId;
 
   return (
     <div className="space-y-6 pb-16">
       <header>
         <h1 className="text-2xl font-bold tracking-tight">Reach out</h1>
         <p className="mt-1 text-sm text-gray-600">
-          Send a single SMS to everyone in a tag-based smart list. Outbound texts cost
-          ~AU$0.05 per 160-character segment per recipient. Always preview before sending.
+          Two ways to reach people. <strong>SMS lists</strong> send a single text in-app (~AU$0.05 per
+          160-char segment per recipient — always preview first). <strong>Audience segments</strong> are
+          level-of-support email lists that you send via a GHL campaign — this tool only defines the
+          segment and the report to attach.
         </p>
       </header>
 
       <div className="grid gap-6 lg:grid-cols-3">
-        {/* List picker */}
-        <div className="lg:col-span-1">
-          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-500">
-            Smart lists
-          </h2>
-          <ul className="space-y-2">
-            {SMART_LISTS.map((list) => {
-              const isSelected = list.id === selectedListId;
-              return (
-                <li key={list.id}>
-                  <Link
-                    href={`/admin/reach-out?list=${list.id}`}
-                    className={`block rounded-lg border p-3 transition-colors ${
-                      isSelected
-                        ? 'border-emerald-400 bg-emerald-50'
-                        : 'border-gray-200 bg-white hover:bg-gray-50'
-                    }`}
-                  >
-                    <div className="flex items-start justify-between gap-2">
-                      <span className="text-sm font-semibold text-gray-900">{list.name}</span>
-                      <Users className="h-4 w-4 shrink-0 text-gray-400" />
-                    </div>
-                    <p className="mt-1 text-xs text-gray-600">{list.description}</p>
-                    <div className="mt-2 font-mono text-[10px] text-gray-400">{list.tag}</div>
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
+        {/* Picker */}
+        <div className="lg:col-span-1 space-y-6">
+          {/* Audience segments (GHL email campaigns) */}
+          <div>
+            <h2 className="mb-2 flex items-center gap-1.5 text-sm font-semibold uppercase tracking-wide text-gray-500">
+              <Megaphone className="h-3.5 w-3.5" /> Audience segments · email via GHL
+            </h2>
+            <ul className="space-y-2">
+              {AUDIENCE_SEGMENTS.map((seg) => {
+                const isSelected = seg.id === selectedSegmentId;
+                return (
+                  <li key={seg.id}>
+                    <Link
+                      href={`/admin/reach-out?segment=${seg.id}`}
+                      className={`block rounded-lg border p-3 transition-colors ${
+                        isSelected
+                          ? 'border-violet-400 bg-violet-50'
+                          : 'border-gray-200 bg-white hover:bg-gray-50'
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <span className="text-sm font-semibold text-gray-900">{seg.name}</span>
+                        <span className="shrink-0 rounded-full bg-violet-100 px-1.5 py-0.5 text-[10px] font-medium text-violet-700">
+                          {seg.supportLevel}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs text-gray-600">{seg.description}</p>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
 
-          <div className="mt-6 rounded-lg border border-gray-200 bg-white p-3">
-            <div className="text-sm font-semibold text-gray-900">Custom tag</div>
-            <p className="mt-1 text-xs text-gray-600">
-              Use any GHL tag, e.g. <code className="rounded bg-gray-100 px-1">goods-asset-gb0-156-1</code>{' '}
-              to text only the people linked to a specific bed.
-            </p>
-            <form method="get" className="mt-2 flex gap-2">
-              <input
-                type="text"
-                name="tag"
-                placeholder="goods-…"
-                defaultValue={selectedCustomTag || ''}
-                className="flex-1 rounded border border-gray-300 px-2 py-1 text-xs"
-              />
-              <button
-                type="submit"
-                className="rounded bg-gray-900 px-2 py-1 text-xs font-medium text-white hover:bg-gray-700"
-              >
-                Use
-              </button>
-            </form>
+          {/* SMS lists */}
+          <div>
+            <h2 className="mb-2 flex items-center gap-1.5 text-sm font-semibold uppercase tracking-wide text-gray-500">
+              <Send className="h-3.5 w-3.5" /> SMS lists · send in-app
+            </h2>
+            <ul className="space-y-2">
+              {SMART_LISTS.map((list) => {
+                const isSelected = list.id === selectedListId;
+                return (
+                  <li key={list.id}>
+                    <Link
+                      href={`/admin/reach-out?list=${list.id}`}
+                      className={`block rounded-lg border p-3 transition-colors ${
+                        isSelected
+                          ? 'border-emerald-400 bg-emerald-50'
+                          : 'border-gray-200 bg-white hover:bg-gray-50'
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <span className="text-sm font-semibold text-gray-900">{list.name}</span>
+                        <Users className="h-4 w-4 shrink-0 text-gray-400" />
+                      </div>
+                      <p className="mt-1 text-xs text-gray-600">{list.description}</p>
+                      <div className="mt-2 font-mono text-[10px] text-gray-400">{list.tag}</div>
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+
+            <div className="mt-4 rounded-lg border border-gray-200 bg-white p-3">
+              <div className="text-sm font-semibold text-gray-900">Custom tag (SMS)</div>
+              <p className="mt-1 text-xs text-gray-600">
+                Use any GHL tag, e.g. <code className="rounded bg-gray-100 px-1">goods-asset-gb0-156-1</code>{' '}
+                to text only the people linked to a specific bed.
+              </p>
+              <form method="get" className="mt-2 flex gap-2">
+                <input
+                  type="text"
+                  name="tag"
+                  placeholder="goods-…"
+                  defaultValue={selectedCustomTag || ''}
+                  className="flex-1 rounded border border-gray-300 px-2 py-1 text-xs"
+                />
+                <button
+                  type="submit"
+                  className="rounded bg-gray-900 px-2 py-1 text-xs font-medium text-white hover:bg-gray-700"
+                >
+                  Use
+                </button>
+              </form>
+            </div>
           </div>
         </div>
 
-        {/* Compose form */}
+        {/* Right pane */}
         <div className="lg:col-span-2">
-          {!selectedListId && !selectedCustomTag ? (
+          {nothingSelected ? (
             <Card>
               <CardContent className="flex flex-col items-center justify-center py-16 text-center">
                 <Send className="h-10 w-10 text-gray-300" />
                 <p className="mt-4 text-sm text-gray-600">
-                  Pick a smart list on the left to compose a message.
+                  Pick an audience segment (email via GHL) or an SMS list on the left.
                 </p>
               </CardContent>
             </Card>
+          ) : selectedSegment ? (
+            <CampaignSegmentPanel
+              key={selectedSegment.id}
+              segment={selectedSegment}
+              reportName={selectedReport?.name || selectedSegment.recommendedReportId}
+              reportHref={`/admin/reports/impact/${selectedSegment.recommendedReportId}`}
+            />
           ) : (
             <ComposeForm
               listId={selectedListId}

--- a/v2/src/app/admin/reports/impact/[templateId]/page.tsx
+++ b/v2/src/app/admin/reports/impact/[templateId]/page.tsx
@@ -58,7 +58,9 @@ export default async function ImpactReportPage({
       communityQuote: d.communityQuote,
     }));
 
-  const stories = await empathyLedger.getStories({
+  // Canonical Goods project only (not the goods-on-country aggregate), theme-ranked
+  // — keeps funder/buyer/supporter collateral on-message.
+  const stories = await empathyLedger.getReportStories({
     theme: template.storyTheme,
     limit: template.storyLimit,
   });

--- a/v2/src/app/admin/reports/impact/[templateId]/page.tsx
+++ b/v2/src/app/admin/reports/impact/[templateId]/page.tsx
@@ -1,0 +1,111 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ArrowLeft, Megaphone } from 'lucide-react';
+import { findReportTemplate } from '@/lib/data/report-templates';
+import { fetchImpactData } from '@/lib/data/impact-fetcher';
+import { IMPACT_DIMENSIONS, type ImpactDimension } from '@/lib/data/impact-model';
+import { empathyLedger } from '@/lib/empathy-ledger/client';
+import {
+  ImpactReport,
+  type ResolvedReportMetric,
+  type ReportDimensionSummary,
+} from '@/components/reports/impact-report';
+import { AUDIENCE_SEGMENTS } from '@/lib/ghl/smart-lists';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export default async function ImpactReportPage({
+  params,
+}: {
+  params: Promise<{ templateId: string }>;
+}) {
+  const { templateId } = await params;
+  const template = findReportTemplate(templateId);
+  if (!template) notFound();
+
+  // Live impact snapshot (falls back to the static model if the live pull fails).
+  let dimensions: ImpactDimension[] = IMPACT_DIMENSIONS;
+  try {
+    const snapshot = await fetchImpactData();
+    if (snapshot?.dimensions?.length) dimensions = snapshot.dimensions;
+  } catch {
+    // keep the static model
+  }
+
+  // Resolve featured metrics: live `current` if present, else the Year-1 target.
+  const metricById = new Map<string, ImpactDimension['metrics'][number]>();
+  for (const d of dimensions) for (const m of d.metrics) metricById.set(m.id, m);
+  const metrics: ResolvedReportMetric[] = template.featuredMetricIds
+    .map((id) => metricById.get(id))
+    .filter((m): m is NonNullable<typeof m> => Boolean(m))
+    .map((m) => ({
+      id: m.id,
+      name: m.name,
+      unit: m.unit,
+      value: m.current ?? m.targets.year1 ?? null,
+      isLive: m.current != null,
+      sourceDetail: m.sourceDetail,
+    }));
+
+  const dimSummaries: ReportDimensionSummary[] = template.featuredDimensionIds
+    .map((id) => dimensions.find((d) => d.id === id))
+    .filter((d): d is ImpactDimension => Boolean(d))
+    .map((d) => ({
+      id: d.id,
+      name: d.name,
+      description: d.description,
+      communityQuote: d.communityQuote,
+    }));
+
+  const stories = await empathyLedger.getStories({
+    theme: template.storyTheme,
+    limit: template.storyLimit,
+  });
+
+  const servingSegments = AUDIENCE_SEGMENTS.filter((s) => s.recommendedReportId === template.id);
+  const generatedAt = new Date().toISOString().slice(0, 10);
+
+  return (
+    <div className="space-y-6 pb-16">
+      {/* Admin chrome (not part of the shareable report) */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Link
+          href="/admin/reports/impact"
+          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4" /> All report templates
+        </Link>
+        {servingSegments.length > 0 && (
+          <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+            <Megaphone className="h-3.5 w-3.5" /> Serves:
+            {servingSegments.map((s) => (
+              <Link
+                key={s.id}
+                href={`/admin/reach-out?segment=${s.id}`}
+                className="rounded-full bg-violet-100 px-2 py-0.5 font-medium text-violet-700 hover:bg-violet-200"
+              >
+                {s.name}
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
+        Template preview. To use it: build the matching audience segment’s smart list in GHL and attach
+        this as an email campaign. Metrics are live; stories are consent-filtered from Empathy Ledger.
+      </div>
+
+      <div className="rounded-xl border border-gray-200 bg-white p-6 sm:p-10">
+        <ImpactReport
+          template={template}
+          metrics={metrics}
+          dimensions={dimSummaries}
+          stories={stories}
+          generatedAt={generatedAt}
+        />
+      </div>
+    </div>
+  );
+}

--- a/v2/src/app/admin/reports/impact/page.tsx
+++ b/v2/src/app/admin/reports/impact/page.tsx
@@ -1,0 +1,80 @@
+import Link from 'next/link';
+import { ArrowLeft, FileText, Megaphone } from 'lucide-react';
+import { IMPACT_REPORT_TEMPLATES, AUDIENCE_LABELS } from '@/lib/data/report-templates';
+import { AUDIENCE_SEGMENTS } from '@/lib/ghl/smart-lists';
+
+export const dynamic = 'force-dynamic';
+
+export default function ImpactReportTemplatesPage() {
+  return (
+    <div className="space-y-6 pb-16">
+      <div>
+        <Link
+          href="/admin/reports"
+          className="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
+        >
+          <ArrowLeft className="h-4 w-4" /> Funder reports
+        </Link>
+      </div>
+
+      <header>
+        <h1 className="text-2xl font-bold tracking-tight">Impact report templates</h1>
+        <p className="mt-1 max-w-3xl text-sm text-gray-600">
+          Reusable, audience-framed impact reports — each showcases live impact metrics + consented
+          Empathy Ledger stories. They’re the content behind the{' '}
+          <Link href="/admin/reach-out" className="text-violet-700 underline">
+            audience segments
+          </Link>
+          : pick a segment, build its smart list in GHL, attach the recommended report as a campaign.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {IMPACT_REPORT_TEMPLATES.map((t) => {
+          const serving = AUDIENCE_SEGMENTS.filter((s) => s.recommendedReportId === t.id);
+          return (
+            <div key={t.id} className="flex flex-col rounded-lg border border-gray-200 bg-white p-5">
+              <div className="flex items-start justify-between gap-2">
+                <span className="rounded-full bg-sky-100 px-2 py-0.5 text-[11px] font-medium text-sky-800">
+                  {AUDIENCE_LABELS[t.audience]}
+                </span>
+                <FileText className="h-4 w-4 shrink-0 text-gray-300" />
+              </div>
+              <h2 className="mt-2 font-serif text-lg font-bold text-gray-900">{t.name}</h2>
+              <p className="mt-1 text-sm text-gray-600">{t.subhead}</p>
+
+              <div className="mt-3 text-xs text-gray-500">
+                <span className="font-medium text-gray-600">Features:</span>{' '}
+                {t.featuredMetricIds.join(', ')}
+              </div>
+
+              {serving.length > 0 && (
+                <div className="mt-3 flex flex-wrap items-center gap-1.5 text-xs text-gray-500">
+                  <Megaphone className="h-3.5 w-3.5" />
+                  {serving.map((s) => (
+                    <Link
+                      key={s.id}
+                      href={`/admin/reach-out?segment=${s.id}`}
+                      className="rounded-full bg-violet-100 px-2 py-0.5 font-medium text-violet-700 hover:bg-violet-200"
+                    >
+                      {s.name}
+                    </Link>
+                  ))}
+                </div>
+              )}
+
+              <div className="mt-4 border-t border-gray-100 pt-3">
+                <Link
+                  href={`/admin/reports/impact/${t.id}`}
+                  className="inline-flex items-center gap-1.5 rounded bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-700"
+                >
+                  Preview report
+                </Link>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/v2/src/app/api/admin/reach-out/preview/route.ts
+++ b/v2/src/app/api/admin/reach-out/preview/route.ts
@@ -1,17 +1,82 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { ghl } from '@/lib/ghl';
-import { findSmartList } from '@/lib/ghl/smart-lists';
+import { ghl, fetchOpportunitiesForPipelines } from '@/lib/ghl';
+import { findSmartList, findAudienceSegment } from '@/lib/ghl/smart-lists';
+import { STAGE_TO_RUNG } from '@/lib/data/loi-pipeline';
 import { requireAdmin } from '@/lib/auth/admin';
 
 export const runtime = 'nodejs';
 
 /**
- * Preview a smart list — returns the count + sample of contacts that would
- * receive a message. Admin-only (with local-dev bypass).
+ * Preview a smart list or audience segment — returns the live size so the
+ * reach-out picker can show counts + cap warnings. Admin-only (local-dev bypass).
+ *
+ * - `?segmentId=` → an AUDIENCE_SEGMENT (email-campaign segment). Tag segments
+ *   resolve to a contact count; pipeline-stage segments resolve to a live count
+ *   of open opportunities at the matching LOI rungs.
+ * - `?listId=` / `?tag=` → an SMS SmartList / custom tag (legacy behaviour).
  */
 export async function GET(request: NextRequest) {
   const guard = await requireAdmin(request);
   if (guard) return guard;
+
+  // ── Audience segment (GHL email campaign) ──────────────────────────────
+  const segmentId = request.nextUrl.searchParams.get('segmentId');
+  if (segmentId) {
+    const segment = findAudienceSegment(segmentId);
+    if (!segment) return NextResponse.json({ error: 'Unknown audience segment' }, { status: 404 });
+
+    if (!ghl.isEnabled()) {
+      return NextResponse.json({
+        enabled: false,
+        segmentId,
+        kind: segment.source.kind,
+        count: 0,
+        softCap: segment.softCap,
+        hardCap: segment.hardCap,
+      });
+    }
+
+    if (segment.source.kind === 'tag') {
+      const contacts = await ghl.findContactsByTag(segment.source.tag, 250);
+      const withEmail = contacts.filter((c) => c.email && c.email.includes('@')).length;
+      return NextResponse.json({
+        enabled: true,
+        segmentId,
+        kind: 'tag',
+        unit: 'contacts',
+        count: contacts.length,
+        withEmail,
+        softCap: segment.softCap,
+        hardCap: segment.hardCap,
+        sample: contacts.slice(0, 10).map((c) => ({
+          name: c.contactName || [c.firstName, c.lastName].filter(Boolean).join(' ') || null,
+          email: c.email,
+        })),
+      });
+    }
+
+    // pipeline-stage: count open opps at the matching rungs (live from GHL).
+    const { ok, opportunities } = await fetchOpportunitiesForPipelines([segment.source.pipelineId]);
+    const rungs = new Set(segment.source.rungs);
+    const matched = opportunities.filter(
+      (o) =>
+        o.status !== 'lost' &&
+        o.status !== 'abandoned' &&
+        rungs.has(STAGE_TO_RUNG[o.stageId]),
+    );
+    return NextResponse.json({
+      enabled: ok,
+      segmentId,
+      kind: 'pipeline-stage',
+      unit: 'opportunities',
+      count: matched.length,
+      softCap: segment.softCap,
+      hardCap: segment.hardCap,
+      sample: matched
+        .slice(0, 10)
+        .map((o) => ({ name: o.name, value: o.monetaryValue, contactName: o.contactName ?? null })),
+    });
+  }
 
   const listId = request.nextUrl.searchParams.get('listId');
   const customTag = request.nextUrl.searchParams.get('tag');

--- a/v2/src/components/reports/impact-report.tsx
+++ b/v2/src/components/reports/impact-report.tsx
@@ -1,0 +1,158 @@
+import Image from 'next/image';
+import type { ImpactReportTemplate } from '@/lib/data/report-templates';
+import type { EmpathyLedgerStory } from '@/lib/empathy-ledger/types';
+
+/** A metric resolved against the live impact snapshot (or its target fallback). */
+export interface ResolvedReportMetric {
+  id: string;
+  name: string;
+  unit: string;
+  value: number | null;
+  /** true if `value` is a live/current figure, false if it's a target fallback. */
+  isLive: boolean;
+  sourceDetail: string;
+}
+
+export interface ReportDimensionSummary {
+  id: string;
+  name: string;
+  description: string;
+  communityQuote?: { text: string; author: string; context: string };
+}
+
+interface Props {
+  template: ImpactReportTemplate;
+  metrics: ResolvedReportMetric[];
+  dimensions: ReportDimensionSummary[];
+  stories: EmpathyLedgerStory[];
+  generatedAt: string;
+}
+
+function formatValue(m: ResolvedReportMetric): string {
+  if (m.value == null) return '—';
+  const v = m.unit === '$' || m.unit === '$/bed' ? `$${Math.round(m.value).toLocaleString()}` : m.value.toLocaleString();
+  if (m.unit === '%') return `${m.value}%`;
+  if (m.unit === '$' || m.unit === '$/bed') return v;
+  return `${v}${m.unit ? ` ${m.unit}` : ''}`;
+}
+
+/**
+ * Presentational impact report — audience-framed, showcasing live impact metrics
+ * + consented Empathy Ledger stories. No data fetching here; the page resolves
+ * everything and passes it in, so this component is safe to mount publicly later.
+ */
+export function ImpactReport({ template, metrics, dimensions, stories, generatedAt }: Props) {
+  return (
+    <article className="mx-auto max-w-3xl space-y-10">
+      {/* Hero */}
+      <header className="space-y-3 border-b border-gray-200 pb-8">
+        <p className="text-xs font-semibold uppercase tracking-wide text-emerald-700">
+          Goods on Country · Impact report
+        </p>
+        <h1 className="font-serif text-3xl font-bold leading-tight text-gray-900">{template.headline}</h1>
+        <p className="text-lg text-gray-600">{template.subhead}</p>
+        <p className="text-sm leading-relaxed text-gray-700">{template.intro}</p>
+      </header>
+
+      {/* Headline metrics */}
+      {metrics.length > 0 && (
+        <section>
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">By the numbers</h2>
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            {metrics.map((m) => (
+              <div key={m.id} className="rounded-lg border border-gray-200 bg-white p-4">
+                <div className="font-serif text-2xl font-bold text-gray-900">{formatValue(m)}</div>
+                <div className="mt-1 text-xs font-medium text-gray-700">{m.name}</div>
+                <div className="mt-1 text-[10px] uppercase tracking-wide text-gray-400">
+                  {m.isLive ? 'Live' : 'Year-1 target'}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Proof points */}
+      {template.proofPoints.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-gray-500">Why it matters</h2>
+          <ul className="space-y-2">
+            {template.proofPoints.map((p, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm text-gray-700">
+                <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500" />
+                <span>{p}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Impact dimensions + community quotes */}
+      {dimensions.length > 0 && (
+        <section className="space-y-4">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500">The impact</h2>
+          {dimensions.map((d) => (
+            <div key={d.id} className="rounded-lg border border-gray-200 bg-white p-5">
+              <h3 className="font-serif text-lg font-bold text-gray-900">{d.name}</h3>
+              <p className="mt-1 text-sm text-gray-600">{d.description}</p>
+              {d.communityQuote && (
+                <blockquote className="mt-3 border-l-2 border-emerald-300 pl-3 text-sm italic text-gray-700">
+                  “{d.communityQuote.text}”
+                  <footer className="mt-1 text-xs not-italic text-gray-500">
+                    — {d.communityQuote.author}
+                    {d.communityQuote.context ? `, ${d.communityQuote.context}` : ''}
+                  </footer>
+                </blockquote>
+              )}
+            </div>
+          ))}
+        </section>
+      )}
+
+      {/* Empathy Ledger stories */}
+      <section>
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-gray-500">Voices from community</h2>
+        {stories.length === 0 ? (
+          <p className="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-gray-500">
+            No published Empathy Ledger stories matched this theme yet. When storytellers publish
+            (consent-verified) they appear here automatically.
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {stories.map((s) => {
+              const img = s.featuredImageUrl || s.storyImageUrl;
+              const author = s.storytellerName || s.authorName;
+              const blurb = s.excerpt || s.summary;
+              return (
+                <div key={s.id} className="flex gap-4 rounded-lg border border-gray-200 bg-white p-4">
+                  {img && (
+                    <div className="relative hidden h-24 w-24 shrink-0 overflow-hidden rounded-md sm:block">
+                      <Image src={img} alt={s.title} fill className="object-cover" sizes="96px" />
+                    </div>
+                  )}
+                  <div className="min-w-0">
+                    <h3 className="font-semibold text-gray-900">{s.title}</h3>
+                    {author && <p className="text-xs text-gray-500">{author}</p>}
+                    {blurb && <p className="mt-1 line-clamp-3 text-sm text-gray-600">{blurb}</p>}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      {/* CTA */}
+      <section className="rounded-lg border border-emerald-200 bg-emerald-50 p-6">
+        <h2 className="font-serif text-xl font-bold text-emerald-900">{template.callToAction.label}</h2>
+        <p className="mt-2 text-sm text-emerald-800">{template.callToAction.body}</p>
+      </section>
+
+      <footer className="border-t border-gray-200 pt-4 text-xs text-gray-400">
+        Generated {generatedAt}. Metrics resolve live against the impact model (Year-1 targets shown where
+        a live value isn’t yet measured); stories are consent-filtered from Empathy Ledger. Template:{' '}
+        <code>{template.id}</code>.
+      </footer>
+    </article>
+  );
+}

--- a/v2/src/lib/data/report-templates.ts
+++ b/v2/src/lib/data/report-templates.ts
@@ -1,0 +1,174 @@
+/**
+ * Audience-targeted impact-report templates (Workstream D).
+ *
+ * Reusable report shells that showcase live Empathy Ledger stories (Goods
+ * project `6bd47c8a-…`) + the canonical impact metrics, framed for a specific
+ * audience. Each template is rendered by `/admin/reports/impact/[templateId]`
+ * and is the CONTENT a staffer uses to build the matching GHL email campaign.
+ *
+ * These feed Workstream C: every `AUDIENCE_SEGMENT` in `ghl/smart-lists.ts`
+ * names a `recommendedReportId` here, so the reach-out picker can say
+ * "this segment → that report → build the GHL campaign".
+ *
+ * Numbers are NOT invented here — the renderer resolves `featuredMetricIds`
+ * against `impact-model.ts` (the canonical, quarantined source). Stories come
+ * live + consent-filtered from Empathy Ledger.
+ */
+
+export type ReportAudience = 'funder' | 'procurement' | 'supporter' | 'supply-partner';
+
+export interface ImpactReportTemplate {
+  /** Stable id — used in the URL and referenced by smart-list segments. */
+  id: string;
+  audience: ReportAudience;
+  /** Friendly name shown in the picker + page title. */
+  name: string;
+  /** Hero line. */
+  headline: string;
+  /** One-sentence subhead under the headline. */
+  subhead: string;
+  /** Audience-specific framing paragraph that opens the report. */
+  intro: string;
+  /**
+   * Impact dimensions to feature, in order. Ids from IMPACT_DIMENSIONS in
+   * impact-model.ts (health | environmental | economic | community-ownership |
+   * production).
+   */
+  featuredDimensionIds: string[];
+  /**
+   * Headline metric ids to pull to the top of the report. Ids from the metrics
+   * inside IMPACT_DIMENSIONS (e.g. beds-delivered, plastic-diverted).
+   */
+  featuredMetricIds: string[];
+  /** Theme passed to empathyLedger.getStories() to select on-message stories. */
+  storyTheme?: string;
+  /** How many EL stories to show. */
+  storyLimit: number;
+  /** 3–5 proof points tuned to what this audience cares about. */
+  proofPoints: string[];
+  /** The single ask the report drives toward. */
+  callToAction: { label: string; body: string };
+  /** Voice/framing guidance for the staffer adapting it into a GHL campaign. */
+  audienceNotes: string;
+  /** C segment ids this report serves. */
+  servesSegments: string[];
+}
+
+export const IMPACT_REPORT_TEMPLATES: ImpactReportTemplate[] = [
+  {
+    id: 'funder-impact',
+    audience: 'funder',
+    name: 'Funder impact report',
+    headline: 'What your investment is doing on country',
+    subhead:
+      'Health, environment and community-ownership outcomes from the beds and machines you helped fund.',
+    intro:
+      'This report leads with outcomes, not activity. It is built for foundations and impact investors — the people who want to see that capital converted into measurable change in remote communities, and a credible path to scale. Pair it with the LOI ladder when stewarding an active funder, or as the evidence pack when making an ask.',
+    featuredDimensionIds: ['health', 'environmental', 'community-ownership'],
+    featuredMetricIds: ['beds-delivered', 'plastic-diverted', 'communities-served', 'employment-hours'],
+    storyTheme: 'impact',
+    storyLimit: 4,
+    proofPoints: [
+      'Quality beds delivered into homes across remote communities — counted live from the asset register, not estimated.',
+      'Recycled HDPE diverted from landfill per bed, addressing the documented waste cycle in remote towns.',
+      'Community-led production and employment hours — the ownership model, not just the product.',
+      'Every dollar traceable: figures reconcile to Xero, assets to the register, stories to consented storytellers.',
+    ],
+    callToAction: {
+      label: 'Renew / scale the partnership',
+      body: 'Talk to us about the next tranche, a multi-year commitment, or co-designing the community-ownership transition.',
+    },
+    audienceNotes:
+      'Active funders (already giving): stewardship tone — "here is what your money did". Prospect funders (cultivating): pitch tone — "here is the proof, here is the ask". Same report, switch the opening line and the CTA emphasis. Never claim DGR is live for Goods (the Butterfly routing is FY2026-27).',
+    servesSegments: ['funder-active', 'funder-prospect'],
+  },
+  {
+    id: 'procurement-buyer',
+    audience: 'procurement',
+    name: 'Procurement & buyer brief',
+    headline: 'A bed built for remote conditions — and the numbers behind it',
+    subhead:
+      'Durability, total cost of ownership, and the social-procurement pathway for housing bodies and government buyers.',
+    intro:
+      'This brief is for procurement officers, housing bodies and government buyers. It leads with the things a buyer underwrites: product survival in the field, cost per unit at volume, delivery track record, and the Indigenous social-procurement pathway. Community stories are the proof the product is wanted and used, not the headline.',
+    featuredDimensionIds: ['health', 'production', 'economic'],
+    featuredMetricIds: ['product-survival-rate', 'beds-delivered', 'cost-per-unit', 'units-per-month'],
+    storyTheme: 'testimonial',
+    storyLimit: 3,
+    proofPoints: [
+      'Designed for remote conditions: washable canvas, recycled-HDPE legs, galvanised steel poles — 200 kg capacity, 5-year warranty, 10+ year design life.',
+      'Field-proven survival rate tracked per asset via QR — you can see which beds are still in service.',
+      'Cost per unit falls with volume; institutional pricing supports a real procurement line, not a one-off.',
+      'Indigenous social-procurement pathway (Supply Nation / state preferences) — buying Goods counts toward your targets.',
+    ],
+    callToAction: {
+      label: 'Scope an order',
+      body: 'Tell us community count and bed numbers and we will return a delivered-price quote and a delivery timeline.',
+    },
+    audienceNotes:
+      'Buyers want certainty, not charity. Lead with spec, warranty and TCO. Keep stories short and use them as evidence of demand/fit. This is the report behind the Buyer Pipeline.',
+    servesSegments: ['buyer'],
+  },
+  {
+    id: 'supporter-update',
+    audience: 'supporter',
+    name: 'Supporter update',
+    headline: 'Beds in homes, plastic out of landfill — thanks to you',
+    subhead: 'A warm, story-first update for the people who back Goods on Country.',
+    intro:
+      'This is the update for individual supporters, donors and the newsletter list. It is story-first and warm: real people, real homes, a number or two to show momentum, and an easy way to stay involved. Keep it human — the impact dashboard is one tap away for anyone who wants the detail.',
+    featuredDimensionIds: ['environmental', 'health', 'community-ownership'],
+    featuredMetricIds: ['beds-delivered', 'plastic-diverted', 'communities-served'],
+    storyTheme: 'community',
+    storyLimit: 5,
+    proofPoints: [
+      'Every bed is a better night’s sleep for a family in a remote community.',
+      'Each bed keeps roughly 20 kg of plastic out of landfill and the desert.',
+      'The work is community-led — local people make, deliver and own the production.',
+    ],
+    callToAction: {
+      label: 'Sponsor a bed / share the story',
+      body: 'Sponsor a bed for a family, or forward this to someone who would care. Small actions compound.',
+    },
+    audienceNotes:
+      'Warm, grounded, community-first voice (brand voice rules). Lead with a person, not a metric. Centre Indigenous voices and agency. This serves the newsletter / sponsor audience — the broad supporter list.',
+    servesSegments: ['supporter'],
+  },
+  {
+    id: 'supply-partner',
+    audience: 'supply-partner',
+    name: 'Supply-partner brief',
+    headline: 'The impact your components enable — and the ramp ahead',
+    subhead:
+      'For the suppliers and vendors who make Goods possible: where the parts go, and the production scale-up coming.',
+    intro:
+      'This brief is for supply partners — the HDPE, steel, canvas and fastener suppliers, and the service vendors behind production. It shows them the human outcome their components enable and the volume ramp ahead, so prioritising Goods (and sharpening pricing at scale) is an obvious call. It is a relationship and forecasting tool, not a fundraising ask.',
+    featuredDimensionIds: ['production', 'environmental', 'community-ownership'],
+    featuredMetricIds: ['units-per-month', 'plastic-diverted', 'local-feedstock-pct', 'employment-hours'],
+    storyTheme: 'impact',
+    storyLimit: 2,
+    proofPoints: [
+      'Your components end up in homes across remote communities — here is the outcome, not just the PO.',
+      'Production is ramping: the unit-per-month trajectory means growing, repeatable volume.',
+      'On-country manufacturing and local feedstock — a supply chain with a social and circular-economy story buyers value.',
+    ],
+    callToAction: {
+      label: 'Lock in volume pricing',
+      body: 'Let us forecast together for the ramp and agree volume pricing / lead times so we can both plan.',
+    },
+    audienceNotes:
+      'Practical and forward-looking. Suppliers care about volume, reliability and lead time — frame impact as the reason the volume is real and growing. Detail on parts/MOQ/lead time lives in supplier-quotes.ts; this is the relationship layer.',
+    servesSegments: ['supplier', 'vendor'],
+  },
+];
+
+export function findReportTemplate(id: string): ImpactReportTemplate | undefined {
+  return IMPACT_REPORT_TEMPLATES.find((t) => t.id === id);
+}
+
+export const AUDIENCE_LABELS: Record<ReportAudience, string> = {
+  funder: 'Funders',
+  procurement: 'Procurement & buyers',
+  supporter: 'Supporters & donors',
+  'supply-partner': 'Suppliers & vendors',
+};

--- a/v2/src/lib/empathy-ledger/client.ts
+++ b/v2/src/lib/empathy-ledger/client.ts
@@ -604,6 +604,30 @@ export const empathyLedger = {
       return [];
     }
   },
+
+  /**
+   * Stories for an impact report. Canonical Goods project ONLY (project_id-scoped,
+   * NOT the `goods-on-country` aggregate that also pulls adjacent projects like
+   * BG-Fit / youth-justice), consent-filtered, then theme-RANKED: stories whose
+   * themes/tags match `theme` come first, topped up with the rest so a report is
+   * never empty when Goods stories exist. Use this for funder/buyer/supporter
+   * collateral; use getStories() when you actually want the aggregated set.
+   */
+  async getReportStories(params: { theme?: string; limit?: number } = {}): Promise<EmpathyLedgerStory[]> {
+    if (!ENABLE_EMPATHY_LEDGER) return [];
+    const limit = params.limit ?? 4;
+    const pool = filterByConsent(await this.getProjectStories({ limit: 40, syndicatedOnly: true }));
+    if (!params.theme) return pool.slice(0, limit);
+
+    const needle = params.theme.toLowerCase();
+    const onTheme = (s: EmpathyLedgerStory): boolean => {
+      const themes = (s.themes || []).map((x) => (typeof x === 'string' ? x : x?.name ?? '').toLowerCase());
+      const tags = (s.tags || []).map((x) => x.toLowerCase());
+      return [...themes, ...tags].some((x) => x.includes(needle));
+    };
+    return [...pool.filter(onTheme), ...pool.filter((s) => !onTheme(s))].slice(0, limit);
+  },
+
   /**
    * Fetch galleries for the Goods project from EL Supabase.
    * Uses project_galleries → galleries → gallery_media_associations → media_assets.

--- a/v2/src/lib/ghl/smart-lists.ts
+++ b/v2/src/lib/ghl/smart-lists.ts
@@ -1,13 +1,25 @@
 /**
  * Curated GHL smart lists for the admin reach-out tool.
  *
- * Each entry maps a friendly name onto a single tag (or set of tags) that
- * GHL can filter on. The tag MUST be one we actually apply somewhere in
- * src/lib/ghl/index.ts — otherwise the list will return zero contacts.
+ * Two distinct things live here:
  *
- * Add new lists conservatively. Each new list is one more way to accidentally
- * SMS-blast hundreds of community members; keep it intentional.
+ *  1. SMART_LISTS — SMS lists. Each maps a friendly name onto a single tag GHL
+ *     filters on, and the in-app reach-out tool sends an SMS directly. The tag
+ *     MUST be one we actually apply (forms, claims, sweeps) or the list is empty.
+ *
+ *  2. AUDIENCE_SEGMENTS — "level of support" segments for EMAIL campaigns. These
+ *     are DEFINITIONS ONLY: each names the GHL tag/pipeline-stage that defines the
+ *     audience + the recipe to build the smart list in GHL. The send happens in a
+ *     GHL email campaign — the app never emails these people. (Ben, 2026-05-30:
+ *     "GHL owns the send; code only defines the segments.") This keeps the
+ *     high-value funder/buyer/supplier lists off the in-app SMS blast path.
+ *
+ * Add lists/segments conservatively. Each one is another way to accidentally
+ * blast hundreds of contacts; keep it intentional and capped.
  */
+
+import type { LoiRung } from '@/lib/data/loi-pipeline';
+import { GOODS_PIPELINES } from '@/lib/data/loi-pipeline';
 
 export interface SmartList {
   /** Stable identifier used in URLs and API calls */
@@ -91,6 +103,165 @@ export const SMART_LISTS: SmartList[] = [
 
 export function findSmartList(id: string): SmartList | undefined {
   return SMART_LISTS.find((l) => l.id === id);
+}
+
+// ============================================================================
+// AUDIENCE SEGMENTS — level-of-support segments for GHL email campaigns.
+// Definitions only. No in-app send: GHL owns the send.
+// ============================================================================
+
+const SUPPORTER_JOURNEY_PIPELINE_ID =
+  GOODS_PIPELINES.find((p) => p.stream === 'philanthropy')?.id ?? '';
+const BUYER_PIPELINE_ID = GOODS_PIPELINES.find((p) => p.stream === 'commercial')?.id ?? '';
+
+/**
+ * How GHL computes membership for a segment.
+ *  - `tag`: contacts carrying a single tag (resolvable live via findContactsByTag).
+ *  - `pipeline-stage`: contacts with an open opportunity in a pipeline at one of
+ *    the given LOI rungs (resolved live via the loi-pipeline stage map). `alsoTag`
+ *    documents an extra tag the GHL smart list should AND-in (e.g. audience-funder);
+ *    the in-app count can't intersect tags onto opps, so it counts opps at the rung
+ *    and the recipe spells out the tag condition to add in GHL.
+ */
+export type SegmentSource =
+  | { kind: 'tag'; tag: string }
+  | { kind: 'pipeline-stage'; pipelineId: string; rungs: LoiRung[]; alsoTag?: string };
+
+export interface AudienceSegment {
+  /** Stable id used in URLs + the reach-out picker. */
+  id: string;
+  /** Friendly name shown in the picker. */
+  name: string;
+  /** Where this audience sits on the level-of-support ladder. */
+  supportLevel: string;
+  /** Who is in this segment + why you'd email them. */
+  description: string;
+  /** How membership is computed (tag or pipeline-stage). */
+  source: SegmentSource;
+  /** The exact filter to build the matching smart list in the GHL UI. */
+  ghlSmartListRecipe: string;
+  /** Advisory cap — UI warns when the live count exceeds this. */
+  softCap: number;
+  /** Hard cap — a reminder of the largest campaign this segment should drive. */
+  hardCap: number;
+  /** The impact-report template that fits this audience (report-templates.ts). */
+  recommendedReportId: string;
+  /** What kind of GHL campaign to attach + cadence guidance. */
+  campaignNote: string;
+}
+
+export const AUDIENCE_SEGMENTS: AudienceSegment[] = [
+  {
+    id: 'funder-active',
+    name: 'Funders — active',
+    supportLevel: 'Committed / giving',
+    description:
+      'Funders who have committed or are giving — sitting at the committed → delivering → cash/stewarding rungs of the Supporter Journey. Steward them: show what the money did.',
+    source: {
+      kind: 'pipeline-stage',
+      pipelineId: SUPPORTER_JOURNEY_PIPELINE_ID,
+      rungs: ['signed', 'contract', 'cash'],
+      alsoTag: 'audience-funder',
+    },
+    ghlSmartListRecipe:
+      'Opportunity in "Goods Supporter Journey" at stage Committed, Delivering, Stewarding/Reporting or Renewing — AND contact tag is audience-funder.',
+    softCap: 40,
+    hardCap: 120,
+    recommendedReportId: 'funder-impact',
+    campaignNote:
+      'Stewardship cadence: a quarterly impact report + renewal/scale ask. Small, high-value list — personalise where you can.',
+  },
+  {
+    id: 'funder-prospect',
+    name: 'Funders — prospect',
+    supportLevel: 'In cultivation',
+    description:
+      'Funders being cultivated or asked but not yet committed — the target rung of the Supporter Journey (Identified, Qualified, Cultivating, Ask made). Use the impact report as the proof behind the ask.',
+    source: {
+      kind: 'pipeline-stage',
+      pipelineId: SUPPORTER_JOURNEY_PIPELINE_ID,
+      rungs: ['target'],
+      alsoTag: 'audience-funder',
+    },
+    ghlSmartListRecipe:
+      'Opportunity in "Goods Supporter Journey" at stage Identified, Qualified, Cultivating or Ask made — AND contact tag is audience-funder.',
+    softCap: 80,
+    hardCap: 250,
+    recommendedReportId: 'funder-impact',
+    campaignNote:
+      'Cultivation cadence: lead with the impact report as evidence, then the ask. Never claim DGR is live for Goods (Butterfly routing is FY2026-27).',
+  },
+  {
+    id: 'buyer',
+    name: 'Buyers & procurement',
+    supportLevel: 'Commercial pipeline',
+    description:
+      'Procurement orgs, housing bodies and government buyers in the Goods Buyer Pipeline. They underwrite spec, warranty and total cost of ownership — not charity.',
+    source: {
+      kind: 'pipeline-stage',
+      pipelineId: BUYER_PIPELINE_ID,
+      rungs: ['target', 'signed', 'contract', 'cash'],
+    },
+    ghlSmartListRecipe:
+      'Opportunity in "Goods — Buyer Pipeline" (any active stage). Grantscope-sourced buyer prospects also carry the goods-buyer-target tag if you want to widen the net.',
+    softCap: 50,
+    hardCap: 150,
+    recommendedReportId: 'procurement-buyer',
+    campaignNote:
+      'Procurement cadence: the buyer brief + a delivered-price offer. Keep it spec-first; stories are evidence of demand, not the headline.',
+  },
+  {
+    id: 'supplier',
+    name: 'Suppliers (BOM / plant)',
+    supportLevel: 'Supply partner',
+    description:
+      'Component and plant suppliers — HDPE, steel, canvas, fasteners, plastic-plant builders. The emailable current-supplier list. Detail (price, MOQ, lead time) lives in supplier-quotes.ts.',
+    source: { kind: 'tag', tag: 'goods-supplier' },
+    ghlSmartListRecipe: 'Contact tag is goods-supplier (optionally goods-supplier-active for current only).',
+    softCap: 30,
+    hardCap: 80,
+    recommendedReportId: 'supply-partner',
+    campaignNote:
+      'Relationship cadence: the supply-partner brief + a volume forecast. Drives prioritisation and volume pricing, not fundraising.',
+  },
+  {
+    id: 'vendor',
+    name: 'Vendors (services / logistics)',
+    supportLevel: 'Service partner',
+    description:
+      'Service, logistics, print and tech vendors who keep production moving (freight, IoT, tooling, design). Tagged goods-vendor in the supplier/vendor sweep.',
+    source: { kind: 'tag', tag: 'goods-vendor' },
+    ghlSmartListRecipe: 'Contact tag is goods-vendor (sub-tags: vendor-freight, vendor-tech, vendor-print, vendor-services).',
+    softCap: 40,
+    hardCap: 100,
+    recommendedReportId: 'supply-partner',
+    campaignNote:
+      'Lighter touch than suppliers — periodic update + forecasting where relevant. Same supply-partner report works.',
+  },
+  {
+    id: 'supporter',
+    name: 'Supporters & donors',
+    supportLevel: 'Community of support',
+    description:
+      'Individual supporters and the newsletter list — the broad warm audience. Donors who sponsored a bed also carry goods-sponsor.',
+    source: { kind: 'tag', tag: 'goods-newsletter' },
+    ghlSmartListRecipe:
+      'Contact tag is goods-newsletter (the supporter/subscriber list). For the donor sub-segment, AND-in goods-sponsor.',
+    softCap: 800,
+    hardCap: 3000,
+    recommendedReportId: 'supporter-update',
+    campaignNote:
+      'Newsletter cadence: warm, story-first supporter update. Lead with a person, not a metric. This is the big list — respect opt-outs.',
+  },
+];
+
+export function findAudienceSegment(id: string): AudienceSegment | undefined {
+  return AUDIENCE_SEGMENTS.find((s) => s.id === id);
+}
+
+/** The defining tag for a segment, if it is tag-based (else null). */
+export function segmentTag(segment: AudienceSegment): string | null {
+  return segment.source.kind === 'tag' ? segment.source.tag : null;
 }
 
 /**


### PR DESCRIPTION
## What
Workstreams **C** (audience comms layer) and **D** (per-audience impact report templates) from the suppliers → pipelines → comms → reports vision. **Stacked on #50** — reuses `loi-pipeline.ts`, so this targets `feat/admin-loi-tracker` (retarget to `main` once #50 lands).

### C — Audience comms layer (definitions only; **GHL owns the send**)
- `lib/ghl/smart-lists.ts` gains **`AUDIENCE_SEGMENTS`** — 6 *level-of-support* segments alongside the existing SMS lists:
  - **Funders — active** (Supporter Journey @ committed/delivering/cash + `audience-funder`), **Funders — prospect** (cultivation/ask + `audience-funder`), **Buyers & procurement** (Buyer Pipeline), **Suppliers** (`goods-supplier`), **Vendors** (`goods-vendor`), **Supporters & donors** (`goods-newsletter`).
  - Each declares the **GHL smart-list recipe**, soft/hard **caps**, and the recommended impact report. Funder/buyer reuse the **`loi-pipeline.ts`** pipeline/stage taxonomy rather than duplicating it.
- **No in-app send for segments** (per the decision: GHL campaigns own email). `/admin/reach-out` now has two sections — *Audience segments · email via GHL* and *SMS lists · send in-app*. Selecting a segment shows a **read-only `CampaignSegmentPanel`**: live size, cap warnings, the recipe (copy-tag), the report link, and a "GHL owns the send" banner.
- **Preview API** extended (`?segmentId=`): tag segments → contact count (`findContactsByTag`); pipeline-stage segments → live open-opp count (`fetchOpportunitiesForPipelines` + `STAGE_TO_RUNG`).

### D — Per-audience Empathy Ledger impact reports
- `lib/data/report-templates.ts` — **4 reusable templates** (funder / procurement / supporter / supply-partner). Each binds **live** to `fetchImpactData()` (same source as `/impact`) + consent-filtered **Empathy Ledger** stories by theme + dimension community quotes, and declares the C segments it serves.
- Routes: **`/admin/reports/impact`** (index) + **`/admin/reports/impact/[templateId]`** (live preview), cross-linked both ways with the segments. Presentational `ImpactReport` component is public-ready (admin-gated for now). Added to the sidebar.

## Test
`npx tsc --noEmit` → **0 errors**. `eslint` clean on all touched files. **Not** browser-verified (admin routes are auth-gated); built on data paths already shipped (`fetchOpportunitiesForPipelines`, `empathyLedger.getStories`, `fetchImpactData`).

## Notes / known edges
- Funder segment **in-app counts** show all philanthropy opps at the rung; `audience-funder` is documented as the GHL AND-condition (our opp fetch doesn't carry tags). Tightenable later by adding `contactId`+tags to the fetch.
- `supporter` segment assumes a live `goods-newsletter` tag — the preview shows the true count when opened.
- Touches `admin-sidebar.tsx` (one link + one icon import) — same file as #49/#50; expect at most a trivial 1-line import merge.