### PR TITLE
fix(impact): canonical asset counts + Stretch-only plastic + /api/impact-summary

### DIFF
--- a/v2/scripts/check-asset-drift.mjs
+++ b/v2/scripts/check-asset-drift.mjs
@@ -1,0 +1,110 @@
+/**
+ * READ-ONLY drift guard for the canonical deployed-asset figures.
+ *
+ * Recomputes the SAME rollup logic as getCanonicalAssetRollup() in
+ * src/lib/data/impact-fetcher.ts (status='deployed', sum `quantity`,
+ * Stretch/Basket split, plastic = Stretch beds × 20kg) against the LIVE
+ * `assets` register, then compares to the values frozen in
+ * src/lib/data/asset-canonical.ts (CANONICAL_ASSETS). Exits non-zero and
+ * prints every drifted field if the static constants no longer match live.
+ *
+ * This is the guard that keeps the hardcoded public/funder numbers honest.
+ * If it fails: either the register changed (update asset-canonical.ts +
+ * every surface) or a bad write landed in the register (investigate first).
+ *
+ *   node --env-file=.env.local scripts/check-asset-drift.mjs   (run from v2/)
+ *
+ * NEVER use the Supabase MCP for v2 data — it points at the wrong project.
+ * Uses NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY from .env.local.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+// Mirror of CANONICAL_ASSETS in src/lib/data/asset-canonical.ts. The .ts file
+// is the single source of truth; this is the guard's expected snapshot. Keep
+// the two in lockstep — that lockstep is exactly what this script enforces.
+// NOTE: the register can only yield PHYSICALLY-DEPLOYED washers (28); the
+// public "working" figure (14) is a telemetry call, not derivable here — so we
+// compare washers against washersDeployed.
+const CANONICAL_ASSETS = {
+  bedsDeployed: 496,
+  stretchBedsDeployed: 133,
+  basketBedsDeployed: 363,
+  washersDeployed: 28,
+  communitiesServed: 9,
+  plasticKg: 2660,
+};
+const PLASTIC_KG_PER_BED = 20;
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/['"]/g, '');
+const key = (process.env.SUPABASE_SERVICE_ROLE_KEY || '').replace(/['"]/g, '');
+if (!url || !key) {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY (run with --env-file=.env.local).');
+  process.exit(2);
+}
+const supabase = createClient(url, key);
+
+// Pull all rows (paginate), then reduce in JS exactly like impact-fetcher.ts.
+const rows = [];
+for (let from = 0; ; from += 1000) {
+  const { data, error } = await supabase
+    .from('assets')
+    .select('product, status, quantity, community')
+    .range(from, from + 999);
+  if (error) { console.error('fetch error:', error.message); process.exit(2); }
+  rows.push(...data);
+  if (data.length < 1000) break;
+}
+
+const qty = (r) => r.quantity ?? 1;
+const sum = (arr) => arr.reduce((s, r) => s + qty(r), 0);
+const isBed = (p) => /bed/i.test(p ?? '');
+const isStretch = (p) => /stretch/i.test(p ?? '');
+const isWasher = (p) => /washing|washer/i.test(p ?? '');
+
+const deployed = rows.filter((r) => r.status === 'deployed');
+const deployedBeds = deployed.filter((r) => isBed(r.product));
+const bedsDeployed = sum(deployedBeds);
+const stretchBedsDeployed = sum(deployedBeds.filter((r) => isStretch(r.product)));
+const basketBedsDeployed = bedsDeployed - stretchBedsDeployed;
+const washersDeployed = sum(deployed.filter((r) => isWasher(r.product)));
+
+const communityCounts = deployed.reduce((acc, r) => {
+  const c = r.community || 'Unknown';
+  acc[c] = (acc[c] || 0) + qty(r);
+  return acc;
+}, {});
+const communitiesServed = Object.keys(communityCounts).filter(
+  (c) => c !== 'Unknown' && c !== 'Pending Delivery',
+).length;
+
+const plasticKg = stretchBedsDeployed * PLASTIC_KG_PER_BED;
+
+const live = {
+  bedsDeployed,
+  stretchBedsDeployed,
+  basketBedsDeployed,
+  washersDeployed,
+  communitiesServed,
+  plasticKg,
+};
+
+console.log(`Live assets register (${url}):`);
+console.log(`  deployed rows: ${deployed.length}  deployed units: ${sum(deployed)}`);
+for (const [k, v] of Object.entries(live)) console.log(`  ${k.padEnd(20)} ${v}`);
+
+const drift = [];
+for (const [k, expected] of Object.entries(CANONICAL_ASSETS)) {
+  if (live[k] !== expected) drift.push({ field: k, expected, live: live[k] });
+}
+
+if (drift.length) {
+  console.error('\nDRIFT DETECTED — CANONICAL_ASSETS no longer matches the live register:');
+  for (const d of drift) {
+    console.error(`  ${d.field}: canonical=${d.expected}  live=${d.live}  (Δ ${d.live - d.expected})`);
+  }
+  console.error('\nFix: reconcile src/lib/data/asset-canonical.ts (and every surface) to live,');
+  console.error('or investigate whether a bad write landed in the assets register.');
+  process.exit(1);
+}
+
+console.log('\nOK — all canonical asset figures match the live register.');

--- a/v2/src/app/about/page.tsx
+++ b/v2/src/app/about/page.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import type { Metadata } from 'next';
+import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
 
 export const metadata: Metadata = {
   title: 'About',
@@ -31,9 +32,9 @@ const CHARCOAL = '#2E2E2E';
 const SAGE = '#8B9D77';
 
 const FACTS = [
-  { value: '520+', label: 'beds across Australia' },
-  { value: '14', label: 'washing machines confirmed on Country' },
-  { value: '8', label: 'communities partnered' },
+  { value: String(CANONICAL_ASSETS.bedsDeployed), label: 'beds across Australia' },
+  { value: String(CANONICAL_ASSETS.washersWorking), label: 'washing machines confirmed on Country' },
+  { value: String(CANONICAL_ASSETS.communitiesServed), label: 'communities partnered' },
   { value: '20kg', label: 'plastic diverted per bed' },
 ];
 
@@ -80,7 +81,7 @@ export default function AboutPage() {
         </p>
         <p className="text-lg leading-relaxed mb-10" style={{ color: `${CHARCOAL}cc` }}>
           We started in 2023 with a question about preventable disease. We&apos;ve since
-          delivered over five hundred beds across eight communities, and the model is now
+          delivered 496 beds across 9 communities, and the model is now
           headed toward community ownership.
         </p>
 

--- a/v2/src/app/api/admin/parliament-followup/route.ts
+++ b/v2/src/app/api/admin/parliament-followup/route.ts
@@ -10,7 +10,7 @@ Great to meet you at Parliament House today.
 
 That Stretch Bed you scanned? It started as recycled plastic collected from remote communities, was pressed into legs, paired with galvanised steel poles and heavy-duty canvas, and assembled right here for the event.
 
-We've delivered 400+ beds across 8 communities — from Palm Island to Tennant Creek to Utopia Homelands. Each one is tracked from manufacture to delivery (you saw how that works when you scanned the QR code).
+We've delivered 496 beds across 9 communities — from Palm Island to Tennant Creek to Utopia Homelands. Each one is tracked from manufacture to delivery (you saw how that works when you scanned the QR code).
 
 But beds are just the start. We're also building:
 

--- a/v2/src/app/api/impact-summary/route.ts
+++ b/v2/src/app/api/impact-summary/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { getCanonicalAssetRollup } from '@/lib/data/impact-fetcher';
+
+export const dynamic = 'force-dynamic';
+
+// Public, read-only impact numbers — safe to expose cross-origin so external
+// surfaces (e.g. Empathy Ledger's impact / theory-of-change display) can read
+// the CURRENT figures instead of keeping a stale local copy.
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+/**
+ * Canonical asset summary — the single live source for Goods deployment
+ * numbers. Backed by getCanonicalAssetRollup() (status='deployed', summed by
+ * quantity, Stretch/Basket split, plastic = Stretch beds only). Consumers
+ * (Empathy Ledger TOC, partners, anyone) should FETCH this, never hardcode the
+ * numbers — that is how they drift. Short-cached so it is always near-live.
+ */
+export async function GET() {
+  try {
+    const a = await getCanonicalAssetRollup();
+    const body = {
+      source: 'goodsoncountry.com — canonical asset register (status=deployed)',
+      generatedAt: new Date().toISOString(),
+      beds: {
+        deployed: a.bedsDeployed,
+        stretch: a.stretchBedsDeployed,
+        basket: a.basketBedsDeployed,
+      },
+      washers: {
+        working: a.washersWorking,
+        deployed: a.washersDeployed,
+      },
+      communitiesServed: a.communitiesServed,
+      plasticDivertedKg: a.plasticKg,
+      // MODELLED: ~2.5 people per household per bed.
+      livesImpactedModelled: Math.round(a.bedsDeployed * 2.5),
+      notes: {
+        plastic: 'Stretch beds only (recycled HDPE). Basket beds are not a plastic-diversion product.',
+        washers: '14 telemetry-working of 28 physically deployed.',
+        basis: "status='deployed', summed by quantity; excludes pipeline/requested placeholders.",
+      },
+    };
+    return NextResponse.json(body, {
+      headers: {
+        ...CORS,
+        'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=600',
+      },
+    });
+  } catch (error) {
+    console.error('[impact-summary] failed:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch asset summary' },
+      { status: 500, headers: CORS },
+    );
+  }
+}
+
+export async function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS });
+}

--- a/v2/src/app/basket-bed-plans/page.tsx
+++ b/v2/src/app/basket-bed-plans/page.tsx
@@ -76,7 +76,7 @@ export default function BasketBedPlansPage() {
                           <li>&bull; Flat-packable and easy to transport to remote communities</li>
                           <li>&bull; No tools required for assembly</li>
                           <li>&bull; Stackable for efficient freight</li>
-                          <li>&bull; Served hundreds of families across 8+ communities</li>
+                          <li>&bull; Served hundreds of families across 9 communities</li>
                           <li>&bull; Proved the concept that purpose-built beds are needed</li>
                         </ul>
                       </div>

--- a/v2/src/app/design/mission-forward/page.tsx
+++ b/v2/src/app/design/mission-forward/page.tsx
@@ -171,12 +171,12 @@ export default function MissionForwardPage() {
           <div className="max-w-2xl mx-auto mt-16">
             <div className="flex justify-between text-sm text-white/60 mb-2">
               <span>Progress to 1,000 beds</span>
-              <span>389 / 1,000</span>
+              <span>496 / 1,000</span>{/* canonical: see asset-canonical.ts */}
             </div>
             <div className="h-4 bg-white/20 rounded-full overflow-hidden">
               <div
                 className="h-full rounded-full"
-                style={{ width: '38.9%', backgroundColor: '#E07A3E' }}
+                style={{ width: '49.6%', backgroundColor: '#E07A3E' }}
               />
             </div>
           </div>
@@ -274,7 +274,8 @@ export default function MissionForwardPage() {
 
             <div className="grid md:grid-cols-3 gap-6">
               {[
-                { percentage: '400+', label: 'Beds Delivered', desc: 'Across 8+ communities' },
+                // canonical: see asset-canonical.ts
+                { percentage: '496', label: 'Beds Delivered', desc: 'Across 9 communities' },
                 { percentage: '60%', label: 'Scabies Reduction', desc: 'From community laundries' },
                 { percentage: '$6', label: 'Healthcare Saved', desc: 'Per $1 invested' },
               ].map((item) => (

--- a/v2/src/app/get-involved/page.tsx
+++ b/v2/src/app/get-involved/page.tsx
@@ -19,9 +19,9 @@ export const metadata: Metadata = {
 
 // Real numbers, pulled from the canonical data files (no invented stats).
 const totals = getDeploymentTotals();
-// "400+ beds in homes since 2023" lives in goodsBedStats as the last atom.
+// "496 beds in homes since 2023" lives in goodsBedStats as the last atom.
 const bedsInHomes =
-  goodsBedStats.find((s) => s.label.includes('beds in homes'))?.value ?? '400+';
+  goodsBedStats.find((s) => s.label.includes('beds in homes'))?.value ?? '496'; // canonical: see asset-canonical.ts
 
 const WAYS = [
   {

--- a/v2/src/app/press/page.tsx
+++ b/v2/src/app/press/page.tsx
@@ -40,8 +40,8 @@ const logoVariants = [
 ] as const;
 
 const keyFacts = [
-  { value: '400+', label: 'Stretch Beds delivered', verified: true },
-  { value: '8+', label: 'Communities', verified: true },
+  { value: '496', label: 'Beds delivered', verified: true }, // canonical: see asset-canonical.ts (133 Stretch + 363 Basket)
+  { value: '9', label: 'Communities', verified: true },
   { value: '20kg', label: 'HDPE diverted per bed', verified: true },
   { value: '200kg', label: 'Load capacity', verified: true },
   { value: '5 min', label: 'Assembly time, no tools', verified: true },
@@ -79,12 +79,12 @@ const shareableSnippets = [
   {
     title: 'Tweet / LinkedIn (280 chars)',
     body:
-      'Goods on Country: First Nations communities designing the goods they need. Stretch Bed: recycled plastic, galvanised steel, Australian canvas. 400+ delivered across 8+ communities. Designed On-Country, made On-Country. goodsoncountry.com',
+      'Goods on Country: First Nations communities designing the goods they need. Stretch Bed: recycled plastic, galvanised steel, Australian canvas. 496 delivered across 9 communities. Designed On-Country, made On-Country. goodsoncountry.com',
   },
   {
     title: 'Email signature blurb (60 words)',
     body:
-      'Goods on Country is a social enterprise delivering health hardware to First Nations communities. The flagship Stretch Bed is designed On-Country with the families who use it: recycled HDPE plastic, galvanised steel, heavy-duty canvas. 400+ beds delivered. Long-term goal: transfer manufacturing to community-owned enterprises. goodsoncountry.com',
+      'Goods on Country is a social enterprise delivering health hardware to First Nations communities. The flagship Stretch Bed is designed On-Country with the families who use it: recycled HDPE plastic, galvanised steel, heavy-duty canvas. 496 beds delivered. Long-term goal: transfer manufacturing to community-owned enterprises. goodsoncountry.com',
   },
   {
     title: 'One-line for intros',

--- a/v2/src/app/stories/page.tsx
+++ b/v2/src/app/stories/page.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { storytellerProfiles, storytellerEnrichment, videoGallery } from '@/lib/data/content';
 import { curatedQuotes } from '@/lib/data/curated-quotes';
+import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
 import type { SyndicationStoryteller } from '@/lib/empathy-ledger/types';
 import type { Metadata } from 'next';
 
@@ -274,7 +275,7 @@ export default async function StoriesPage() {
               { value: String(storytellerCount), label: 'Storytellers', sub: `across ${communityCount} places` },
               { value: '500+', label: 'Minutes', sub: 'of community feedback' },
               { value: String(communityCount), label: 'Communities', sub: 'across remote Australia' },
-              { value: '520+', label: 'Beds Delivered', sub: 'and counting' },
+              { value: String(CANONICAL_ASSETS.bedsDeployed), label: 'Beds Delivered', sub: 'and counting' },
             ].map((stat) => (
               <div key={stat.label}>
                 <p className="text-2xl md:text-3xl font-bold">{stat.value}</p>

--- a/v2/src/app/story/page.tsx
+++ b/v2/src/app/story/page.tsx
@@ -85,8 +85,8 @@ const TIMELINE = [
   { year: '2020', title: 'The Pattern', description: 'Orange Sky expands to remote communities. Nic sees people without beds, without washing machines, children with skin infections cascading into heart disease.' },
   { year: '2022', title: 'The Question', description: '"What can we actually build that makes a difference?" Goods project kicks off with an advisory session in November.' },
   { year: '2023', title: 'A Curious Tractor', description: 'Organisation formally founded. First bed prototypes developed with the Bloomfield family "around the fire."' },
-  { year: '2024', title: '400+ Beds', description: 'Active pilots deliver beds across Palm Island, Tennant Creek, Mt Isa, Kalgoorlie, and more. Community feedback shapes every iteration.' },
-  { year: '2025', title: 'Washing Machines', description: 'Pakkimjalki Kari, named in Warumungu language by Elder Dianne Stokes. Commercial-grade, one-button operation. 8+ communities served.' },
+  { year: '2024', title: '496 Beds', description: 'Active pilots deliver beds across Palm Island, Tennant Creek, Mt Isa, Kalgoorlie, and more. Community feedback shapes every iteration.' },
+  { year: '2025', title: 'Washing Machines', description: 'Pakkimjalki Kari, named in Warumungu language by Elder Dianne Stokes. Commercial-grade, one-button operation. 9 communities served.' },
 ];
 
 function PhotoGallery({ photos }: { photos: { src: string | undefined; alt: string; label: string }[] }) {

--- a/v2/src/app/wiki/community/partner-guide/page.tsx
+++ b/v2/src/app/wiki/community/partner-guide/page.tsx
@@ -32,11 +32,11 @@ export default function PartnerGuidePage() {
 
         <div className="grid md:grid-cols-3 gap-6 not-prose my-8">
           <div className="text-center p-4 bg-green-50 rounded-lg">
-            <div className="text-3xl font-bold text-green-600">400+</div>
+            <div className="text-3xl font-bold text-green-600">496</div>
             <div className="text-sm text-gray-600 mt-1">Beds deployed</div>
           </div>
           <div className="text-center p-4 bg-green-50 rounded-lg">
-            <div className="text-3xl font-bold text-green-600">15+</div>
+            <div className="text-3xl font-bold text-green-600">9</div>
             <div className="text-sm text-gray-600 mt-1">Communities served</div>
           </div>
           <div className="text-center p-4 bg-green-50 rounded-lg">

--- a/v2/src/components/layout/impact-banner.tsx
+++ b/v2/src/components/layout/impact-banner.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
+import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
 
 const stats = [
-  { value: '520+', label: 'beds across Australia' },
-  { value: '8', label: 'communities' },
+  { value: String(CANONICAL_ASSETS.bedsDeployed), label: 'beds across Australia' },
+  { value: String(CANONICAL_ASSETS.communitiesServed), label: 'communities' },
   { value: '20kg', label: 'plastic diverted per bed' },
 ];
 

--- a/v2/src/components/marketing/impact-stats.tsx
+++ b/v2/src/components/marketing/impact-stats.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
+import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
 
 interface ImpactStat {
   value: number | string;
@@ -18,8 +19,8 @@ interface ImpactStatsProps {
 }
 
 const defaultStats: ImpactStat[] = [
-  { value: 389, label: 'Beds Delivered' },
-  { value: 8, label: 'Communities Served' },
+  { value: CANONICAL_ASSETS.bedsDeployed, label: 'Beds Delivered' },
+  { value: CANONICAL_ASSETS.communitiesServed, label: 'Communities Served' },
   { value: 1500, label: 'Lives Impacted', prefix: '~' },
   { value: 100, label: 'Community Designed & Led', suffix: '%' },
 ];

--- a/v2/src/lib/data/asset-canonical.ts
+++ b/v2/src/lib/data/asset-canonical.ts
@@ -1,0 +1,6 @@
+/** Canonical deployed-asset figures. Source of truth = the assets register
+ *  (project cwsyhpiuepvdjtxaozwf), reconciled 2026-05-30. Static surfaces import
+ *  THIS; server components prefer getCanonicalAssetRollup() in impact-fetcher.ts
+ *  (live). Plastic = Stretch beds only (Basket Beds are not a plastic product).
+ *  Drift from the live register is caught by scripts/check-asset-drift.mjs. */
+export const CANONICAL_ASSETS = { bedsDeployed: 496, stretchBedsDeployed: 133, basketBedsDeployed: 363, washersWorking: 14, washersDeployed: 28, communitiesServed: 9, distinctCommunities: 10, plasticKg: 2660 } as const;

--- a/v2/src/lib/data/compendium.ts
+++ b/v2/src/lib/data/compendium.ts
@@ -9,6 +9,7 @@
  */
 
 import { PLASTIC_KG_PER_BED } from './products';
+import { CANONICAL_ASSETS } from './asset-canonical';
 
 // ---------------------------------------------------------------------------
 // Advisory Board
@@ -360,7 +361,7 @@ export interface CommunityDeployment {
 // (Supabase `assets`) is authoritative; these per-community numbers are the
 // labelled static fallback, reconciled 2026-05-29 to the locked canonical split:
 //   Tennant Creek 159, Utopia 147, Palm Island 131, Kalgoorlie 20, Maningrida 18,
-//   Alice Springs 16, Mt Isa 2, Darwin 1, Canberra 1 = 495 deployed beds.
+//   Alice Springs 16, Mt Isa 2, Darwin 1, Canberra 2 = 496 deployed beds.
 // This array is the SINGLE source for the static deployed-bed count via
 // getDeploymentTotals(); content.ts derives its counts from EXPECTED_DEPLOYED_BEDS.
 export const deployments: CommunityDeployment[] = [
@@ -372,7 +373,7 @@ export const deployments: CommunityDeployment[] = [
   { id: 'utopia', community: 'Utopia Homelands', state: 'NT', beds: 147, washers: 0, status: 'active', partner: 'Oonchiumpa' },
   { id: 'mt-isa', community: 'Mt Isa', traditionalName: 'Kalkadoon', state: 'QLD', beds: 2, washers: 0, status: 'testing', partner: 'BG Fit & Men\'s Shed' },
   { id: 'darwin', community: 'Darwin', state: 'NT', beds: 1, washers: 1, status: 'testing', partner: 'Red Dust' },
-  { id: 'canberra', community: 'Canberra', state: 'NT', beds: 1, washers: 0, status: 'testing' },
+  { id: 'canberra', community: 'Canberra', state: 'NT', beds: 2, washers: 0, status: 'testing' },
 ];
 
 /**
@@ -380,7 +381,7 @@ export const deployments: CommunityDeployment[] = [
  * count used across content.ts, funder pages, and the impact summary. The live
  * Supabase register stays authoritative; this is the labelled static fallback.
  */
-export const EXPECTED_DEPLOYED_BEDS = 495;
+export const EXPECTED_DEPLOYED_BEDS = 496; // canonical: see asset-canonical.ts (bedsDeployed)
 
 export function getDeploymentTotals() {
   const beds = deployments.reduce((s, d) => s + d.beds, 0);
@@ -621,9 +622,10 @@ export const productionFacility = {
 
 export const environmentalImpact = {
   plasticPerBed: { min: PLASTIC_KG_PER_BED, max: 25, unit: 'kg HDPE' },
-  // Derived from the canonical deployed-bed count × PLASTIC_KG_PER_BED (single
-  // source). 495 × 20 = 9,900 kg. (Was a stale 9,225 literal.)
-  totalDivertedToDate: EXPECTED_DEPLOYED_BEDS * PLASTIC_KG_PER_BED,
+  // Plastic = STRETCH beds only (133 × 20kg = 2,660 kg). Basket Beds are NOT a
+  // plastic product, so this is NOT an all-beds × 20 figure. Canonical: see
+  // asset-canonical.ts (plasticKg); live source = getCanonicalAssetRollup().
+  totalDivertedToDate: CANONICAL_ASSETS.plasticKg,
   atScale: { units: 5000, tonnes: 125, period: 'annually' },
   productLifespan: '10+ years (vs weeks for conventional)',
   circularLoop: 'Community waste → beds → community ownership',

--- a/v2/src/lib/data/content.ts
+++ b/v2/src/lib/data/content.ts
@@ -43,7 +43,7 @@ The answer became Goods: durable, repairable, community-designed "health hardwar
     { year: '2016-2020', event: 'Orange Sky expands to remote communities (now 1/3 of services)' },
     { year: 'Nov 2022', event: 'Goods project kicks off with advisory session' },
     { year: 'Sept 2023', event: 'A Curious Tractor formally founded' },
-    { year: '2024–2025', event: 'Bed deployments reach 400+ across communities; now approaching 500' },
+    { year: '2024+', event: 'Active bed pilots deliver 496 beds across communities' }, // canonical: see asset-canonical.ts
   ],
 
   problem: {
@@ -85,7 +85,7 @@ export const impact = {
   stats: [
     { value: '520+', label: 'Assets tracked in register', icon: 'bed' },
     { value: '107', label: 'Stretch Beds on order', icon: 'demand' },
-    { value: '10', label: 'Communities served', icon: 'community' },
+    { value: '9', label: 'Communities served', icon: 'community' }, // canonical: see asset-canonical.ts
     { value: '$3M/yr', label: 'Washing machines sold → dumps', icon: 'problem', source: 'Alice Springs provider' },
   ],
 };
@@ -1229,7 +1229,7 @@ export const mediaPack = {
   aboutACT: `A Curious Tractor is the organisation behind Goods on Country. Founded in September 2023 by Nicholas Marchesi and Benjamin Knight, ACT exists to design, manufacture, and transfer ownership of essential goods to remote First Nations communities across Australia. The name reflects the approach: curiosity-driven problem solving applied to entrenched disadvantage. ACT is a social enterprise working toward community ownership of manufacturing.`, // NOTE: ACT (A Curious Tractor Pty Ltd) is NOT a registered charity or DGR entity — do not add that claim here.
 
   // Copy-paste-ready press boilerplate
-  pressBoilerplate: `Goods on Country is a social enterprise delivering durable, community-designed essential goods to remote First Nations communities across Australia. The flagship product, the Stretch Bed, is a flat-packable, washable bed made from recycled HDPE plastic, galvanised steel, and heavy-duty Australian canvas. Each bed diverts 20kg of plastic from landfill, assembles in under five minutes with no tools, and supports up to 200kg. With 490+ beds deployed across 10 communities, Goods on Country addresses the environmental health conditions that drive preventable disease, including Rheumatic Heart Disease, by putting health hardware directly into the hands of families who need it. The organisation's long-term goal is to transfer manufacturing capability to community-owned enterprises. Founded in 2023, Goods on Country is a project of A Curious Tractor.`,
+  pressBoilerplate: `Goods on Country is a social enterprise delivering durable, community-designed essential goods to remote First Nations communities across Australia. The flagship product, the Stretch Bed, is a flat-packable, washable bed made from recycled HDPE plastic, galvanised steel, and heavy-duty Australian canvas. Each bed diverts 20kg of plastic from landfill, assembles in under five minutes with no tools, and supports up to 200kg. With 496 beds delivered across 9 communities, Goods on Country addresses the environmental health conditions that drive preventable disease, including Rheumatic Heart Disease, by putting health hardware directly into the hands of families who need it. The organisation's long-term goal is to transfer manufacturing capability to community-owned enterprises. Founded in 2023, Goods on Country is a project of A Curious Tractor.`,
 
   // Brand color palette
   brandColors: [

--- a/v2/src/lib/data/grant-content.ts
+++ b/v2/src/lib/data/grant-content.ts
@@ -102,7 +102,7 @@ export const impactNumbers = {
   washersDeployed: 14, // honest working machines (28 deployed; telemetry/working reconciliation pending)
   communitiesEngaged: 10, // communities represented in asset records
   livesImpacted: '1,000+',
-  plasticDivertedKg: 9920, // modelled: 496 beds x 20kg HDPE
+  plasticDivertedKg: 2660, // canonical: see asset-canonical.ts — Stretch beds only (133 × 20kg HDPE); Basket Beds are not a plastic product
   plasticPerBed: '20kg HDPE',
   verifiedStorytellers: '15+',
   advisoryBoardMembers: 13, // advisory/support network — NOT a fiduciary board
@@ -196,8 +196,8 @@ export const grantAnswers = {
     short: "We don't deliver products to communities. Communities lead the design in community, we support the build, and our goal is to transfer full manufacturing capability so communities own the means of production.",
     medium: `Three things differentiate Goods: (1) Community-led design. Every product decision is shaped in community with the people who use the thing. 500+ minutes of recorded community input drove the evolution from V1 Basket Beds to the V4 Stretch Bed. (2) Local production. Our containerised production facility ($100K invested) is being set up to turn waste plastic into bed components On-Country, creating jobs and a circular economy as it comes online. (3) Ownership pathway. The model is built to transfer capability to communities over time, with full training, capability and documentation, rather than a license.`,
   },
-  whoDoYouWorkWith: 'We work with 10 remote Indigenous communities across QLD, NT, WA, and SA. Core community partners include Oonchiumpa Consultancy, Wilya Janta, and Palm Island Community Company. Health partners include Anyinginyi Health, Miwatj Health, Purple House, and Red Dust.',
-  howDoYouMeasureImpact: 'We track impact through: (1) Asset Register — 558 QR-coded assets with lifecycle monitoring. (2) Telemetry — washing machines report cycle counts, energy usage (coming online). (3) Community feedback — 500+ minutes recorded, 15+ verified storytellers via Empathy Ledger. (4) Environmental metrics — 9,900kg+ plastic diverted (modelled at 20kg HDPE per bed). (5) Health outcomes — tracking with health partners.',
+  whoDoYouWorkWith: 'We work with 9 remote Indigenous communities across QLD, NT, WA, and SA. Core community partners include Oonchiumpa Consultancy, Wilya Janta, and Palm Island Community Company. Health partners include Anyinginyi Health, Miwatj Health, Purple House, and Red Dust.',
+  howDoYouMeasureImpact: 'We track impact through: (1) Asset Register — 558 QR-coded assets with lifecycle monitoring. (2) Telemetry — washing machines report cycle counts, energy usage (coming online). (3) Community feedback — 500+ minutes recorded, 15+ verified storytellers via Empathy Ledger. (4) Environmental metrics — 2,660kg+ plastic diverted (133 Stretch beds × 20kg HDPE; Basket Beds are not a plastic product). (5) Health outcomes — tracking with health partners.',
   whatAreYourFinancials: `~$576K in grant funding verified received (Xero: Snow, Centrecorp, VFFF), with a further ~$202K founder-confirmed and being reconciled (TFN, FRRR, AMP). ~$61K in trade revenue. ~$82,500 in outstanding receivables (Rotary, authorised). $100K invested in the production facility. Demand materially exceeds current production capacity. Figures are Xero management data, not audited.`,
   howWillYouUseThisFunding: {
     beds: 'Each $600–850 funds one Stretch Bed deployed to a remote community, diverting 20kg of plastic and providing a 10+ year sleeping surface.',

--- a/v2/src/lib/data/impact-fetcher.ts
+++ b/v2/src/lib/data/impact-fetcher.ts
@@ -40,14 +40,27 @@ const RHD_SURGICAL_ADMISSION_COST_AUD = 70_000;
 const BEDS_PER_RHD_CASE_PREVENTED = 500; // 1 RHD case prevented per ~500 beds (× household)
 const WASH_CYCLES_PER_RHD_CASE_PREVENTED = 5_000;
 
+/**
+ * Washing machines: the register tracks 28 physically DEPLOYED, but fleet
+ * telemetry confirms ~14 actually reporting/working. Public/funder surfaces
+ * use the honest WORKING number (Ben, 2026-05-30). Not yet auto-derivable
+ * (fleet telemetry unreliable) — wire to fleet KPIs when stable. Never publish
+ * 28 (deployed) or 41 (all rows incl. retired) as the working count.
+ */
+const WASHERS_WORKING = 14;
+
 // ---------------------------------------------------------------------------
 // Individual data fetchers
 // ---------------------------------------------------------------------------
 
 interface AssetStats {
-  totalAssets: number;
-  totalBeds: number;
-  totalWashingMachines: number;
+  totalAssets: number; // deployed units (beds + washers), quantity-summed
+  totalBeds: number; // deployed beds (Stretch + Basket)
+  stretchBedsDeployed: number; // recycled-HDPE beds — the plastic-diversion product
+  basketBedsDeployed: number; // archived prototype — NOT a plastic product
+  totalWashingMachines: number; // public figure = telemetry-working washers (14)
+  washersDeployed: number; // physically deployed washers (28)
+  washersWorking: number; // telemetry-confirmed working (14)
   communitiesServed: number;
   communityBreakdown: { community: string; count: number }[];
 }
@@ -55,21 +68,40 @@ interface AssetStats {
 async function getAssetStats(): Promise<AssetStats> {
   const supabase = await createClient();
 
-  const [
-    { count: totalAssets },
-    { count: totalBeds },
-    { count: totalWashingMachines },
-    { data: communityData },
-  ] = await Promise.all([
-    supabase.from('assets').select('*', { count: 'exact', head: true }),
-    supabase.from('assets').select('*', { count: 'exact', head: true }).ilike('product', '%bed%'),
-    supabase.from('assets').select('*', { count: 'exact', head: true }).ilike('product', '%washing%'),
-    supabase.from('assets').select('community'),
-  ]);
+  // Pull rows and reduce in JS so we can (1) filter to status='deployed',
+  // (2) sum `quantity` (bulk rows exist, e.g. the 108-qty Centrecorp order),
+  // and (3) split beds into Stretch (recycled HDPE — the plastic-diversion
+  // product) vs Basket (archived prototype, NOT plastic). Head-only row counts
+  // with no status filter are what produced the 520 / 41 / 10,400 overclaim.
+  type AssetRow = {
+    product: string | null;
+    status: string | null;
+    quantity: number | null;
+    community: string | null;
+  };
+  const { data: rows } = await supabase
+    .from('assets')
+    .select('product, status, quantity, community');
+  const all = (rows ?? []) as unknown as AssetRow[];
 
-  const communityCounts = (communityData || []).reduce((acc, asset) => {
+  const qty = (r: AssetRow) => r.quantity ?? 1;
+  const sum = (arr: AssetRow[]) => arr.reduce((s, r) => s + qty(r), 0);
+  const isBed = (p: string | null) => /bed/i.test(p ?? '');
+  const isStretch = (p: string | null) => /stretch/i.test(p ?? '');
+  const isWasher = (p: string | null) => /washing|washer/i.test(p ?? '');
+
+  const deployed = all.filter((r) => r.status === 'deployed');
+  const deployedBeds = deployed.filter((r) => isBed(r.product));
+  const totalBeds = sum(deployedBeds);
+  const stretchBedsDeployed = sum(deployedBeds.filter((r) => isStretch(r.product)));
+  const basketBedsDeployed = totalBeds - stretchBedsDeployed;
+  const washersDeployed = sum(deployed.filter((r) => isWasher(r.product)));
+
+  // Community breakdown over DEPLOYED units only (excludes the Centrecorp
+  // `requested` placeholder + allocated-only communities like Mutitjulu).
+  const communityCounts = deployed.reduce((acc, asset) => {
     const community = asset.community || 'Unknown';
-    acc[community] = (acc[community] || 0) + 1;
+    acc[community] = (acc[community] || 0) + qty(asset);
     return acc;
   }, {} as Record<string, number>);
 
@@ -77,11 +109,19 @@ async function getAssetStats(): Promise<AssetStats> {
     .map(([community, count]) => ({ community, count }))
     .sort((a, b) => b.count - a.count);
 
+  const communitiesServed = Object.keys(communityCounts).filter(
+    (c) => c !== 'Unknown' && c !== 'Pending Delivery',
+  ).length;
+
   return {
-    totalAssets: totalAssets || 0,
-    totalBeds: totalBeds || 0,
-    totalWashingMachines: totalWashingMachines || 0,
-    communitiesServed: Object.keys(communityCounts).filter(c => c !== 'Unknown').length,
+    totalAssets: sum(deployed),
+    totalBeds,
+    stretchBedsDeployed,
+    basketBedsDeployed,
+    totalWashingMachines: WASHERS_WORKING,
+    washersDeployed,
+    washersWorking: WASHERS_WORKING,
+    communitiesServed,
     communityBreakdown,
   };
 }
@@ -164,8 +204,9 @@ function computeSleepNights(beds: number): number {
   return Math.round(beds * AVG_HOUSEHOLD_SIZE * NIGHTS_PER_YEAR);
 }
 
-function computePlasticDiverted(beds: number): number {
-  return beds * PLASTIC_KG_PER_BED;
+/** Plastic diverted (kg). STRETCH beds only — recycled HDPE. Basket Beds are not a plastic product. */
+function computePlasticDiverted(stretchBeds: number): number {
+  return stretchBeds * PLASTIC_KG_PER_BED;
 }
 
 function computeEmploymentHours(beds: number): number {
@@ -295,7 +336,7 @@ function populateDimensions(
     'beds-delivered': assetStats.totalBeds,
     'sleep-nights': computeSleepNights(assetStats.totalBeds),
     'wash-cycles': fleetStats.totalWashCycles,
-    'plastic-diverted': computePlasticDiverted(assetStats.totalBeds),
+    'plastic-diverted': computePlasticDiverted(assetStats.stretchBedsDeployed),
     'employment-hours': computeEmploymentHours(assetStats.totalBeds),
     'storytellers-active': storytellerStats.storytellerCount,
     'communities-served': assetStats.communitiesServed,
@@ -329,8 +370,8 @@ export async function fetchImpactData(): Promise<ImpactSnapshot> {
     storytellerStats,
   );
 
-  const plasticDiverted = computePlasticDiverted(assetStats.totalBeds);
-  const livesImpacted = Math.round(assetStats.totalAssets * AVG_HOUSEHOLD_SIZE);
+  const plasticDiverted = computePlasticDiverted(assetStats.stretchBedsDeployed);
+  const livesImpacted = Math.round(assetStats.totalBeds * AVG_HOUSEHOLD_SIZE);
   const employmentHours = computeEmploymentHours(assetStats.totalBeds);
 
   // Composite impact score: simple weighted sum
@@ -361,6 +402,26 @@ export async function fetchImpactData(): Promise<ImpactSnapshot> {
       fleetStats.totalWashCycles,
       fleetStats.machinesOnline,
     ),
+  };
+}
+
+/**
+ * Canonical asset rollup — the single source every surface should read for
+ * deployment counts. Deployed-only, quantity-summed, Basket/Stretch split,
+ * washers = telemetry-working (14). Replaces the per-surface hand-counts that
+ * drift (the 520 / 41 / 10,400 problem). Plastic = Stretch beds only.
+ */
+export async function getCanonicalAssetRollup() {
+  const a = await getAssetStats();
+  return {
+    bedsDeployed: a.totalBeds,
+    stretchBedsDeployed: a.stretchBedsDeployed,
+    basketBedsDeployed: a.basketBedsDeployed,
+    washersDeployed: a.washersDeployed,
+    washersWorking: a.washersWorking,
+    communitiesServed: a.communitiesServed,
+    plasticKg: computePlasticDiverted(a.stretchBedsDeployed),
+    deployedUnits: a.totalAssets,
   };
 }
 

--- a/v2/src/lib/data/outreach-targets.ts
+++ b/v2/src/lib/data/outreach-targets.ts
@@ -199,7 +199,7 @@ export const philanthropyProspects: OutreachTarget[] = [
     id: 'circular-future', name: 'Circular Future Fund / Planet Ark', category: 'philanthropy_prospect', status: 'research', priority: 'medium',
     instrument: 'grant',
     nextAction: 'Research eligibility. Strong circular economy fit.',
-    grantRelevance: 'Environmental angle. ~9,920kg plastic diverted (modelled: 496 beds x 20kg/bed; not audited).',
+    grantRelevance: 'Environmental angle. 2,660kg+ plastic diverted.', // canonical: see asset-canonical.ts (Stretch beds only)
   },
   {
     id: 'self-loan', name: 'SELF (Social Enterprise Loan Fund)', category: 'impact_finance', status: 'research', priority: 'medium',

--- a/v2/src/lib/data/story-atoms.ts
+++ b/v2/src/lib/data/story-atoms.ts
@@ -11,6 +11,7 @@
 // All copy below has been written to obey those rules.
 
 import { STRETCH_BED } from './products';
+import { CANONICAL_ASSETS } from './asset-canonical';
 
 // ─── Atom 1: Goods bed facts (aliased from products.ts) ─────────────────
 // Used by `kind: 'goods-facts'` blocks. Re-using the canonical product
@@ -21,7 +22,7 @@ export const goodsBedStats: { value: string; label: string }[] = [
   { value: STRETCH_BED.specs.loadCapacity, label: 'load capacity, rated' },
   { value: STRETCH_BED.specs.assemblyTime.replace(/^~?/, '~'), label: 'to assemble, no tools' },
   { value: STRETCH_BED.specs.plasticDiverted.split(' ')[0], label: 'of plastic kept out of landfill, per bed' },
-  { value: '400+', label: 'beds in homes since 2023' },
+  { value: String(CANONICAL_ASSETS.bedsDeployed), label: 'beds in homes since 2023' }, // canonical: see asset-canonical.ts
 ];
 
 export const goodsBedStatsLead = 'One bed, in numbers';


### PR DESCRIPTION
## What
Kills the long-standing bed/asset count drift and exposes the canonical numbers as a live feed.

**Root cause:** `impact-fetcher.getAssetStats` counted asset *rows* with no status filter, ignored `quantity`, and applied 20kg HDPE to *all* beds — so /impact and the funder reports rendered **520 beds / 10,400kg / 41 washers**. Basket Beds are not a plastic product, so plastic was overstated ~3.7x.

## Changes
- `getAssetStats`: `status='deployed'` + `SUM(quantity)`, Stretch/Basket split; excludes the 108-qty Centrecorp `requested` placeholder.
- **Plastic = Stretch beds only** (133 x 20 = **2,660kg**, was 10,400).
- Washers = **14 working** (public); communities = **9** deployed.
- New `getCanonicalAssetRollup()` + `asset-canonical.ts` (`CANONICAL_ASSETS`) = single source for static surfaces.
- New `scripts/check-asset-drift.mjs` = live drift guard.
- Repointed ~15 surfaces (impact-stats 389->496, banner/about/stories 520->496, compendium 495->496 + Canberra 1->2, press kit, grant-content plastic->2,660, etc.).
- New **`/api/impact-summary`** — CORS-open, short-cached endpoint returning the canonical numbers so Empathy Ledger's TOC/impact reads current figures instead of a stale copy.

## Canonical (verified live)
496 beds (363 Basket + 133 Stretch) | 28 washers (14 working) | 9 communities | 2,660kg plastic.

## Verification
`npx tsc --noEmit` clean | `node scripts/check-asset-drift.mjs` green vs the live register (cwsyhpiuepvdjtxaozwf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)