### PR TITLE
[codex] Add community count drift guard

### DIFF
--- a/v2/package.json
+++ b/v2/package.json
@@ -8,8 +8,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "check:community-count-drift": "node scripts/check-community-count-drift.mjs",
     "wiki:sync": "if [ -d ../wiki/articles ]; then rm -rf .wiki-content && mkdir -p .wiki-content && cp -R ../wiki/articles/. .wiki-content/; else echo 'wiki:sync skipped (../wiki/articles absent; using tracked .wiki-content/)'; fi",
-    "prebuild": "npm run wiki:sync"
+    "prebuild": "npm run wiki:sync && npm run check:community-count-drift"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",

--- a/v2/scripts/check-community-count-drift.mjs
+++ b/v2/scripts/check-community-count-drift.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * READ-ONLY drift guard for public community-count copy.
+ *
+ * Public and funder-facing copy must use the canonical deployed/active count:
+ * 9 communities served. The live register also has 10 distinct communities
+ * when allocated/placeholder locations are included, but that is not the
+ * public "served" metric.
+ *
+ * This scans src/ for the old public-copy phrasing so "10 communities" does
+ * not drift back into pages, shared funder content, metadata, or API copy.
+ *
+ *   node scripts/check-community-count-drift.mjs   (run from v2/)
+ */
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC_DIR = path.join(ROOT_DIR, 'src');
+
+const TEXT_EXTENSIONS = new Set([
+  '.css',
+  '.js',
+  '.jsx',
+  '.json',
+  '.md',
+  '.mdx',
+  '.mjs',
+  '.ts',
+  '.tsx',
+]);
+
+const BANNED_PATTERNS = [
+  {
+    label: '10 communities',
+    pattern: /\b10\s+communities\b/i,
+  },
+  {
+    label: '10 remote communit...',
+    pattern: /\b10\s+remote\s+communit(?:y|ies)\b/i,
+  },
+];
+
+async function* walk(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(fullPath);
+      continue;
+    }
+
+    if (entry.isFile() && TEXT_EXTENSIONS.has(path.extname(entry.name))) {
+      yield fullPath;
+    }
+  }
+}
+
+const violations = [];
+
+for await (const filePath of walk(SRC_DIR)) {
+  const source = await readFile(filePath, 'utf8');
+  const lines = source.split(/\r?\n/);
+
+  lines.forEach((line, index) => {
+    for (const { label, pattern } of BANNED_PATTERNS) {
+      if (pattern.test(line)) {
+        violations.push({
+          filePath: path.relative(ROOT_DIR, filePath),
+          line: index + 1,
+          label,
+          text: line.trim(),
+        });
+      }
+    }
+  });
+}
+
+if (violations.length) {
+  console.error('COMMUNITY COUNT DRIFT DETECTED');
+  console.error('');
+  console.error('Public/funder copy must use 9 communities served.');
+  console.error('Do not reintroduce the old 10-communities public claim.');
+  console.error('');
+
+  for (const violation of violations) {
+    console.error(`${violation.filePath}:${violation.line} (${violation.label})`);
+    console.error(`  ${violation.text}`);
+  }
+
+  process.exit(1);
+}
+
+console.log('OK - no banned 10-communities public-copy drift found in src/.');


### PR DESCRIPTION
## Summary
- Add an env-free `v2/scripts/check-community-count-drift.mjs` guard that scans `v2/src` for banned public-copy drift around `10 communities` / `10 remote communities`.
- Wire the guard into `prebuild` after `wiki:sync`, so local and Vercel builds fail before the 9-vs-10 regression ships again.

## Why
The canonical public/funder metric is 9 communities served. The separate 10 distinct communities figure includes allocated/placeholder locations and should not reappear in public copy.

## Validation
- `npm run check:community-count-drift`
- `npx tsc --noEmit`
- `git diff --check`

## Known state
- `npm run lint` still fails on pre-existing unrelated lint errors in admin/assets/fleet/wiki pages and an older script; this PR does not touch those files.