### PR TITLE
Cost-story treatment for /process and /stretch-bed

### DIFF
--- a/v2/src/app/process/page.tsx
+++ b/v2/src/app/process/page.tsx
@@ -21,7 +21,7 @@ const STEP_TAG_QUERIES: Record<number, string[]> = {
 };
 
 // Photo folders shown as chips at the top of the swap modal. Driven by
-// what's actually tagged in Empathy Ledger — see the tag-count audit in
+// what's actually tagged in Empathy Ledger. See the tag-count audit in
 // scripts (community:utopia-homelands × 221, event:alice-build × 121,
 // participant:oonchiumpa-young-people × 121, etc.). Add more entries
 // here when new tag groups appear in EL; the chip row scrolls so a
@@ -163,6 +163,39 @@ const PLANT_GALLERY = [
   { src: '/images/process/factory-panorama.jpg', alt: 'Panorama of the on-country production plant' },
 ];
 
+// Site display face (matches the rest of the marketing pages).
+const displayFont = { fontFamily: 'Georgia, serif' } as const;
+
+// A real, consent-cleared community voice to break up the process.
+// Quotes come from the public display-cleared set in curated-quotes.ts;
+// Mykel's "rocking up every day" is cleared and already live on /cost-story.
+function Voice({
+  quote,
+  name,
+  place,
+  tone = 'light',
+}: {
+  quote: string;
+  name: string;
+  place: string;
+  tone?: 'light' | 'dark';
+}) {
+  const sub = tone === 'dark' ? 'text-background/60' : 'text-muted-foreground';
+  return (
+    <figure className="mx-auto max-w-3xl text-center">
+      <blockquote
+        className="text-2xl font-light italic leading-snug md:text-3xl"
+        style={displayFont}
+      >
+        &ldquo;{quote}&rdquo;
+      </blockquote>
+      <figcaption className={`mt-4 text-sm ${sub}`}>
+        <span className="font-medium">{name}</span> &middot; {place}
+      </figcaption>
+    </figure>
+  );
+}
+
 export default async function ProcessPage() {
   // Pull live Alice Springs May 2026 build photos from Empathy Ledger.
   // First photo becomes the step-5 hero behind the video controls; the
@@ -173,7 +206,7 @@ export default async function ProcessPage() {
     4,
   );
 
-  // Admin detection — same pattern as /field-notes/[slug]: any signed-in
+  // Admin detection, same pattern as /field-notes/[slug]: any signed-in
   // user (or anyone on local dev) gets the in-place swap widget overlaid
   // on every media slot. Public visitors see the same photos but no chrome.
   const supabase = await createClient();
@@ -188,7 +221,7 @@ export default async function ProcessPage() {
   const overrides = getStoryOverrides(OVERRIDE_SLUG);
   const steps: Step[] = STEPS.map((s, idx) => {
     let next = s;
-    // 1. EL auto-fill for step 5 (Alice build) — happens first so manual
+    // 1. EL auto-fill for step 5 (Alice build) happens first, so manual
     //    swaps still win over the dynamic fetch below.
     if (s.step === 5 && elBuildPhotos.length > 0) {
       const [hero, ...rest] = elBuildPhotos;
@@ -275,6 +308,41 @@ export default async function ProcessPage() {
             <div>
               <div className="text-3xl font-bold text-accent-foreground">10+ yrs</div>
               <div className="text-sm text-accent-foreground/80 mt-1">Design life</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ============================================================
+         THE LOOP: plastic-journey brand graphic
+         ============================================================ */}
+      <section className="py-16 md:py-24">
+        <div className="container mx-auto px-4">
+          <div className="mx-auto max-w-5xl">
+            <div className="mx-auto max-w-2xl text-center mb-10">
+              <p className="text-xs uppercase tracking-[0.25em] text-accent mb-3">
+                The loop
+              </p>
+              <h2
+                className="text-3xl md:text-4xl font-bold text-foreground mb-4 leading-tight"
+                style={displayFont}
+              >
+                Plastic doesn&rsquo;t leave. It changes shape.
+              </h2>
+              <p className="text-lg text-muted-foreground leading-relaxed">
+                Twenty kilos of plastic that would have gone to landfill becomes the legs
+                of a bed that lasts ten years. Off-cuts go back in the shredder and come out
+                as the next sheet. Same plastic, two or three more presses out of the same batch.
+              </p>
+            </div>
+            <div className="relative aspect-[3/2] w-full overflow-hidden rounded-3xl bg-[#FBFAF5] shadow-sm">
+              <Image
+                src="/goods-plastic-journey.jpg"
+                alt="The recycled-plastic loop: collected waste plastic is shredded into chip, heat-pressed into sheet, cut into Stretch Bed legs, and off-cuts return to the shredder"
+                fill
+                sizes="(max-width: 1024px) 100vw, 1000px"
+                className="object-contain"
+              />
             </div>
           </div>
         </div>
@@ -388,6 +456,19 @@ export default async function ProcessPage() {
       </section>
 
       {/* ============================================================
+         VOICE: the work is the point (Mykel, Alice Springs build)
+         ============================================================ */}
+      <section className="bg-accent py-16 md:py-20">
+        <div className="container mx-auto px-4">
+          <Voice
+            quote="I'll be rocking up every day to make them."
+            name="Mykel"
+            place="who helped build the beds in Alice Springs"
+          />
+        </div>
+      </section>
+
+      {/* ============================================================
          ON-COUNTRY PRODUCTION PLANT
          ============================================================ */}
       <section className="bg-muted/30 py-16 md:py-20">
@@ -407,6 +488,20 @@ export default async function ProcessPage() {
                 their own yard.
               </p>
             </div>
+
+            {/* The ownership path: buy-kit, on-country plant, community-owned. */}
+            <div className="relative aspect-[16/9] w-full overflow-hidden rounded-3xl bg-[#FBFAF5] shadow-sm mb-3">
+              <Image
+                src="/goods-community-ownership-v2.png"
+                alt="The path to community ownership: a buy-the-kit start, an on-country containerised plant, then a community-owned production line"
+                fill
+                sizes="(max-width: 1024px) 100vw, 1000px"
+                className="object-contain"
+              />
+            </div>
+            <p className="text-sm text-muted-foreground text-center mb-10 max-w-2xl mx-auto">
+              The capital buys the path, not just the press. The plant can transfer to community ownership and run from their own yard.
+            </p>
 
             <div className="relative aspect-[16/9] w-full overflow-hidden rounded-3xl bg-muted shadow-sm mb-4">
               <Image
@@ -439,7 +534,7 @@ export default async function ProcessPage() {
       </section>
 
       {/* ============================================================
-         MADE BY COMMUNITY — closing band with full-bleed video
+         MADE BY COMMUNITY closing band with full-bleed video
          ============================================================ */}
       <section className="relative isolate overflow-hidden bg-foreground text-background">
         <video

--- a/v2/src/app/stretch-bed/page.tsx
+++ b/v2/src/app/stretch-bed/page.tsx
@@ -112,7 +112,7 @@ const specs = [
 ];
 
 export default async function StretchBedPage() {
-  // Admin detection — same pattern as /process and /field-notes: any
+  // Admin detection, same pattern as /process and /field-notes: any
   // signed-in user (or local dev) gets the in-place swap widget on every
   // photo slot. Public visitors see the photos with no chrome.
   const supabase = await createClient();
@@ -123,7 +123,7 @@ export default async function StretchBedPage() {
   const heroSrc = overrides['hero'] ?? '/images/product/stretch-bed-hero.jpg';
 
   return (
-    <main className="bg-white text-slate-900">
+    <main className="bg-[#FCFBF7] text-[#2A2620]" data-skin="goods">
       {/* Hero */}
       <section className="relative">
         <div className="relative h-[52vh] min-h-[360px] w-full">
@@ -142,7 +142,7 @@ export default async function StretchBedPage() {
           )}
           <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-slate-900/80 via-slate-900/30 to-transparent" />
           <div className="absolute inset-x-0 bottom-0 mx-auto max-w-5xl px-6 pb-10">
-            <p className="mb-2 text-sm uppercase tracking-[0.18em] text-orange-400">How it works</p>
+            <p className="mb-2 text-sm uppercase tracking-[0.18em] text-[#D99A6A]">How it works</p>
             <h1 style={serif} className="text-4xl font-bold text-white sm:text-5xl">
               The Stretch Bed
             </h1>
@@ -152,7 +152,7 @@ export default async function StretchBedPage() {
             <div className="mt-5 flex flex-wrap gap-3">
               <a
                 href="#build"
-                className="rounded-md bg-orange-500 px-5 py-2.5 font-medium text-white transition hover:bg-orange-600"
+                className="rounded-md bg-[#B0673B] px-5 py-2.5 font-medium text-white transition hover:bg-[#974F2C]"
               >
                 Watch it built
               </a>
@@ -169,15 +169,15 @@ export default async function StretchBedPage() {
 
       {/* Overview diagram (fixed infographic, not swappable) */}
       <section className="mx-auto max-w-6xl px-6 pt-14">
-        <p className="mb-4 text-center text-sm uppercase tracking-[0.18em] text-orange-500">
+        <p className="mb-4 text-center text-sm uppercase tracking-[0.18em] text-[#B0673B]">
           The whole bed, one diagram
         </p>
         <div className="overflow-hidden rounded-xl border border-slate-200 shadow-sm">
           <Image
-            src="/images/product/stretch-bed-overview.png"
-            alt="Stretch Bed X-trestle tension design: the three components, the five-step assembly, and how the tension holds it together"
-            width={1448}
-            height={1086}
+            src="/goods-bed-anatomy.jpg"
+            alt="Anatomy of the Stretch Bed: galvanised steel poles, heavy-duty canvas, and recycled-plastic X-trestle legs, with the cost of each part"
+            width={1264}
+            height={848}
             className="h-auto w-full"
             priority
           />
@@ -214,7 +214,7 @@ export default async function StretchBedPage() {
                   )}
                 </div>
                 <div className="p-5">
-                  <div className="text-xs font-semibold uppercase tracking-wider text-orange-500">
+                  <div className="text-xs font-semibold uppercase tracking-wider text-[#B0673B]">
                     {c.n}× per bed
                   </div>
                   <h3 style={serif} className="mt-1 text-lg font-bold">
@@ -229,7 +229,7 @@ export default async function StretchBedPage() {
       </section>
 
       {/* Video */}
-      <section id="build" className="bg-slate-50 py-16">
+      <section id="build" className="bg-[#F2ECE0] py-16">
         <div className="mx-auto max-w-5xl px-6">
           <h2 style={serif} className="text-3xl font-bold">
             Watch a bed go together
@@ -256,7 +256,19 @@ export default async function StretchBedPage() {
         <h2 style={serif} className="text-3xl font-bold">
           How to build it, step by step
         </h2>
-        <div className="mt-10 space-y-12">
+        <p className="mt-3 max-w-2xl text-slate-600">
+          Lay out the parts, stand the X-legs, thread the poles, pull it tight. About five minutes, no tools.
+        </p>
+        <div className="mt-8 overflow-hidden rounded-xl border border-slate-200 shadow-sm">
+          <Image
+            src="/goods-bed-assembly.jpg"
+            alt="How the Stretch Bed goes together: lay out the parts, stand the X-legs, thread the poles, tension it, done"
+            width={1264}
+            height={848}
+            className="h-auto w-full"
+          />
+        </div>
+        <div className="mt-12 space-y-12">
           {steps.map((s, i) => {
             const src = overrides[`step.${s.n}`] ?? s.img;
             return (
@@ -280,7 +292,7 @@ export default async function StretchBedPage() {
                   )}
                 </div>
                 <div>
-                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-orange-500 text-lg font-bold text-white">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#B0673B] text-lg font-bold text-white">
                     {s.n}
                   </div>
                   <h3 style={serif} className="mt-4 text-2xl font-bold">
@@ -295,16 +307,16 @@ export default async function StretchBedPage() {
       </section>
 
       {/* The clever bit */}
-      <section className="bg-slate-900 py-16 text-white">
+      <section className="bg-[#221E18] py-16 text-white">
         <div className="mx-auto max-w-3xl px-6">
-          <p className="text-sm uppercase tracking-[0.18em] text-orange-400">Why it works</p>
+          <p className="text-sm uppercase tracking-[0.18em] text-[#D99A6A]">Why it works</p>
           <h2 style={serif} className="mt-2 text-3xl font-bold">
             The weight is what holds it together
           </h2>
           <p className="mt-4 text-lg leading-relaxed text-slate-200">
             It is a tension design. Each pole threads through the hole at the top of each X-leg, so
             the poles cannot slip, and the canvas stretched tight between them braces the whole
-            frame. The frame <span className="text-orange-400">will not stand without the canvas</span>:
+            frame. The frame <span className="text-[#D99A6A]">will not stand without the canvas</span>:
             it is the tension that holds everything together. No screws, no tools, just thread the
             poles through and pull it tight.
           </p>
@@ -344,20 +356,20 @@ export default async function StretchBedPage() {
       </section>
 
       {/* CTA */}
-      <section className="bg-orange-500 py-14 text-white">
+      <section className="bg-[#B0673B] py-14 text-white">
         <div className="mx-auto flex max-w-5xl flex-col items-start gap-5 px-6 sm:flex-row sm:items-center sm:justify-between">
           <div>
             <h2 style={serif} className="text-3xl font-bold">
               Put one in a home
             </h2>
-            <p className="mt-1 text-orange-50">
+            <p className="mt-1 text-[#F4E9E1]">
               Every bed diverts {STRETCH_BED.specs.plasticDiverted.replace(' per bed', '')} from
               landfill and is built toward community ownership.
             </p>
           </div>
           <Link
             href="/shop/stretch-bed-single"
-            className="whitespace-nowrap rounded-md bg-white px-6 py-3 font-semibold text-orange-600 transition hover:bg-orange-50"
+            className="whitespace-nowrap rounded-md bg-white px-6 py-3 font-semibold text-[#B0673B] transition hover:bg-[#F4E9E1]"
           >
             Buy or sponsor a bed
           </Link>


### PR DESCRIPTION
Brings the live /cost-story visual language to the two product-story pages.

## /process (How It's Made)
- New **The loop** band leading with the `goods-plastic-journey` brand graphic, framing the six steps as a circular process.
- **Mykel's** consent-cleared voice ("I'll be rocking up every day to make them") after the build steps. Already live on /cost-story.
- Ownership section now leads with the `goods-community-ownership-v2` illustration (buy-kit, on-Country plant, community-owned) before the real container-factory photos.
- Goods cream + terracotta palette via theme tokens. No em dashes.
- Swap widget, Empathy Ledger auto-fill of the Alice build photos, and videos all intact.

## /stretch-bed (How It Works)
- Premium `goods-bed-anatomy` graphic for the overview.
- `goods-bed-assembly` graphic in the build section.
- Shifted from bright orange/white to the Goods cream + terracotta palette.
- No em dashes.

tsc clean, eslint clean, both render 200 locally. No Codex working-tree files included (built in an isolated worktree off main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)