### PR TITLE
fix(shop+copy): purchasable-product guards, checkout hardening, overclaim softening

### DIFF
--- a/v2/package.json
+++ b/v2/package.json
@@ -8,6 +8,10 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "check:community-copy": "node scripts/check-community-copy.mjs",
+    "check:qbe-guardrails": "node scripts/check-qbe-guardrails.mjs",
+    "check:asset-drift": "node --env-file=.env.local scripts/check-asset-drift.mjs",
+    "check:drift": "npm run check:community-copy && npm run check:qbe-guardrails && npm run check:asset-drift",
     "wiki:sync": "if [ -d ../wiki/articles ]; then rm -rf .wiki-content && mkdir -p .wiki-content && cp -R ../wiki/articles/. .wiki-content/; else echo 'wiki:sync skipped (../wiki/articles absent; using tracked .wiki-content/)'; fi",
     "prebuild": "npm run wiki:sync"
   },

--- a/v2/src/app/admin/cost-model/skins/investment-skin.tsx
+++ b/v2/src/app/admin/cost-model/skins/investment-skin.tsx
@@ -79,11 +79,8 @@ export function InvestmentSkin() {
       {/* ── Header ── */}
       <div className="flex shrink-0 items-center justify-between">
         <div className="flex items-center gap-2.5">
-          <span className="relative flex h-2 w-2">
-            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-400" />
-          </span>
-          <span className="text-[10px] uppercase tracking-[0.22em] text-emerald-400">LIVE</span>
+          <span className="h-2 w-2 rounded-full bg-emerald-400" />
+          <span className="text-[10px] uppercase tracking-[0.22em] text-emerald-400">MODEL</span>
           <span className="text-[10px] uppercase tracking-[0.22em] text-zinc-500">INVESTMENT LAYER · ${SALE} INSTITUTIONAL SALE → COMMUNITY CO-OP</span>
         </div>
         <button onClick={() => setBrokerage(Number(W.act_brokerage_default))} className="text-[10px] uppercase tracking-[0.16em] text-zinc-500 transition-colors hover:text-cyan-300">

--- a/v2/src/app/admin/cost-model/skins/mission-control-skin.tsx
+++ b/v2/src/app/admin/cost-model/skins/mission-control-skin.tsx
@@ -4,11 +4,11 @@
  *
  * Near-black, high-contrast, monospace tabular numerics as the hero. Thin rules,
  * uppercase micro-labels with tracking, signal green (positive contribution) /
- * red (negative), one electric-cyan accent on the primary readout, a LIVE dot.
+ * red (negative), one electric-cyan accent on the primary readout, a model status dot.
  * INPUTS are a "key levers + advanced" layout (2026-05-29): the dials that move the
  * headline (volume, price, fair wage, Defy kit + the method/founder/location chips)
  * get big, grabbable full-width tracks; the remaining ~26 assumptions collapse into a
- * grouped, scrollable ADVANCED drawer. Big live OUTPUT telemetry on the right. Reads
+ * grouped, scrollable ADVANCED drawer. Big model OUTPUT telemetry on the right. Reads
  * the shared useCostModel() instance — numbers are LOCKED.
  */
 import { useState } from 'react';
@@ -52,11 +52,8 @@ export function MissionControlSkin({ cm }: { cm: UseCostModel }) {
       {/* ── Console header (compact) ── */}
       <div className="flex shrink-0 items-center justify-between border-b border-zinc-800 px-4 py-1.5">
         <div className="flex items-center gap-2.5">
-          <span className="relative flex h-2 w-2">
-            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-400" />
-          </span>
-          <span className="text-[10px] uppercase tracking-[0.22em] text-emerald-400">LIVE</span>
+          <span className="h-2 w-2 rounded-full bg-emerald-400" />
+          <span className="text-[10px] uppercase tracking-[0.22em] text-emerald-400">MODEL</span>
           <span className="text-[10px] uppercase tracking-[0.22em] text-zinc-500">GOODS · BED COST MODEL · MISSION CONTROL</span>
         </div>
         <button onClick={resetAll} className="text-[10px] uppercase tracking-[0.18em] text-zinc-500 hover:text-cyan-300 transition-colors">
@@ -86,7 +83,7 @@ export function MissionControlSkin({ cm }: { cm: UseCostModel }) {
           <div className="shrink-0 space-y-2.5 border-b border-zinc-800 p-3">
             <div className="flex items-center justify-between">
               <Label>KEY LEVERS</Label>
-              <span className="text-[9px] text-zinc-600">DRAG — HEADLINE RECOMPUTES LIVE</span>
+              <span className="text-[9px] text-zinc-600">DRAG — HEADLINE RECOMPUTES</span>
             </div>
 
             <KeyLever
@@ -241,7 +238,7 @@ export function MissionControlSkin({ cm }: { cm: UseCostModel }) {
                   })}
                 </div>
                 <p className="text-[9px] leading-relaxed text-zinc-600">
-                  The {KEY_LEVER_KEYS.length} key levers above move the headline. These {ADVANCED_SLIDERS.length} set the locked baseline — expand to fine-tune any; telemetry stays live.
+                  The {KEY_LEVER_KEYS.length} key levers above move the headline. These {ADVANCED_SLIDERS.length} set the locked baseline — expand to fine-tune any; telemetry updates instantly.
                 </p>
               </div>
             )}
@@ -314,15 +311,15 @@ export function MissionControlSkin({ cm }: { cm: UseCostModel }) {
             </div>
           </div>
 
-          {/* Marginal cost by build path — the hero bar chart, grows to fill the height */}
-          <div className="flex min-h-0 flex-1 flex-col border border-zinc-800">
+          {/* Marginal cost by build path — keep a stable height so rows never collapse into each other. */}
+          <div className="flex min-h-[250px] shrink-0 flex-col border border-zinc-800">
             <div className="flex shrink-0 items-center justify-between border-b border-zinc-800 px-3 py-2">
               <Label>MARGINAL COST / BED · BY BUILD PATH</Label>
               <span className="text-[10px] tracking-wide text-zinc-600">
                 GREY = MARGINAL · <span style={{ color: POS }}>GREEN</span> = CONTRIBUTION TO {fmt(inputs.retail_price)} PRICE
               </span>
             </div>
-            <div className="flex min-h-0 flex-1 flex-col justify-center gap-4 p-4">
+            <div className="flex flex-1 flex-col justify-center gap-3 p-3">
               <SupplyPathBar label="KITS (TODAY)" marginal={model.marginalKit} contrib={model.marginKits} be={model.breakevenKit} price={inputs.retail_price} active={inputs.build_method === 'kits'} />
               <SupplyPathBar label="PANELS" marginal={model.marginalPanel} contrib={model.marginPanels} be={model.breakevenPanel} price={inputs.retail_price} active={inputs.build_method === 'panels'} />
               <SupplyPathBar label="FACTORY (IN-HOUSE)" marginal={model.marginalFactory} contrib={model.marginFactory} be={model.breakevenFactory} price={inputs.retail_price} active={inputs.build_method === 'factory'} highlight />
@@ -391,7 +388,7 @@ export function MissionControlSkin({ cm }: { cm: UseCostModel }) {
   );
 }
 
-/** KEY-LEVER hero slider: label + live value on one row, a fat grabbable track below. */
+/** KEY-LEVER hero slider: label + current value on one row, a fat grabbable track below. */
 function KeyLever({ label, display, value, min, max, step, onChange, hint }: {
   label: string; display: string; value: number; min: number; max: number; step: number;
   onChange: (v: number) => void; hint?: string;
@@ -440,7 +437,7 @@ function SupplyPathBar({ label, marginal, contrib, be, price, active, highlight 
   const marginalPct = Math.max(0, Math.min(100, (marginal / price) * 100));
   const contribPct = Math.max(0, Math.min(100 - marginalPct, (contrib / price) * 100));
   return (
-    <div className={`flex flex-col justify-center gap-1.5 rounded px-2 py-1.5 transition-colors ${active ? 'bg-cyan-500/[0.07] ring-1 ring-cyan-500/30' : ''}`}>
+    <div className={`flex min-h-[42px] flex-col justify-center gap-1.5 rounded px-2 py-1.5 transition-colors ${active ? 'bg-cyan-500/[0.07] ring-1 ring-cyan-500/30' : ''}`}>
       <div className="flex items-baseline justify-between gap-2">
         <span className={`text-[11px] uppercase tracking-[0.08em] ${highlight ? 'text-emerald-300' : active ? 'text-cyan-300' : 'text-zinc-300'}`}>
           {active && <span style={{ color: ACCENT }}>▸ </span>}{label}

--- a/v2/src/app/admin/cost-model/skins/terminal-skin.tsx
+++ b/v2/src/app/admin/cost-model/skins/terminal-skin.tsx
@@ -63,7 +63,7 @@ export function TerminalSkin({ cm }: { cm: UseCostModel }) {
         <Stat k="CTNR" v={inputs.containerise ? 'ON' : 'OFF'} />
         <Stat k="PRICE" v={fmt(inputs.retail_price)} />
         <span className="ml-auto flex items-center gap-1.5 text-emerald-400">
-          <span className="h-1.5 w-1.5 rounded-full bg-emerald-400 animate-pulse" /> LIVE
+          <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" /> MODEL
         </span>
       </div>
 

--- a/v2/src/app/admin/orders/launch-checklist/page.tsx
+++ b/v2/src/app/admin/orders/launch-checklist/page.tsx
@@ -89,8 +89,8 @@ async function runChecks(): Promise<CheckRow[]> {
     action: { label: 'Open Stripe webhooks', href: 'https://dashboard.stripe.com/webhooks' },
   });
 
-  // 5. Active products are intentional. The hidden 'smoke-test' SKU is ignored —
-  // it's expected to be active so the admin can buy it through real checkout.
+  // 5. Active products are intentional. The hidden smoke-test SKU is ignored
+  // here because checkout only accepts the canonical Stretch Bed product type.
   const supabase = createServiceClient();
   const { data: activeProducts } = await supabase
     .from('products')
@@ -117,12 +117,12 @@ async function runChecks(): Promise<CheckRow[]> {
   // 5b. Smoke-test SKU presence
   checks.push({
     id: 'smoke-test-sku',
-    title: 'Smoke-test SKU available',
-    status: hasSmokeTest ? 'pass' : 'warn',
+    title: 'Smoke-test SKU quarantined',
+    status: hasSmokeTest ? 'manual' : 'pass',
     detail: hasSmokeTest
-      ? 'Hidden $1 product exists at /shop/smoke-test. Use this for the end-to-end card test after flipping to live keys.'
-      : 'No /shop/smoke-test product. The end-to-end test will need a different hidden SKU.',
-    action: hasSmokeTest ? { label: 'Open /shop/smoke-test', href: '/shop/smoke-test' } : undefined,
+      ? 'Hidden $1 product exists, but checkout now accepts only Stretch Bed products. Confirm it stays out of public navigation and use an admin-only Stripe workflow for live card tests.'
+      : 'No smoke-test product found. Direct checkout is limited to the Stretch Bed.',
+    action: hasSmokeTest ? { label: 'Open /admin/products', href: '/admin/products' } : undefined,
   });
 
   // 6. Stretch Bed row has the canonical product_type

--- a/v2/src/app/admin/reports/impact/[templateId]/page.tsx
+++ b/v2/src/app/admin/reports/impact/[templateId]/page.tsx
@@ -24,7 +24,7 @@ export default async function ImpactReportPage({
   const template = findReportTemplate(templateId);
   if (!template) notFound();
 
-  // Live impact snapshot (falls back to the static model if the live pull fails).
+  // Current impact snapshot (falls back to the static model if the pull fails).
   let dimensions: ImpactDimension[] = IMPACT_DIMENSIONS;
   try {
     const snapshot = await fetchImpactData();
@@ -33,7 +33,7 @@ export default async function ImpactReportPage({
     // keep the static model
   }
 
-  // Resolve featured metrics: live `current` if present, else the Year-1 target.
+  // Resolve featured metrics: current values if present, else the Year-1 target.
   const metricById = new Map<string, ImpactDimension['metrics'][number]>();
   for (const d of dimensions) for (const m of d.metrics) metricById.set(m.id, m);
   const metrics: ResolvedReportMetric[] = template.featuredMetricIds
@@ -96,7 +96,7 @@ export default async function ImpactReportPage({
 
       <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800">
         Template preview. To use it: build the matching audience segment’s smart list in GHL and attach
-        this as an email campaign. Metrics are live; stories are consent-filtered from Empathy Ledger.
+        this as an email campaign. Metrics are current snapshots; stories are consent-filtered from Empathy Ledger.
       </div>
 
       <div className="rounded-xl border border-gray-200 bg-white p-6 sm:p-10">

--- a/v2/src/app/admin/reports/impact/page.tsx
+++ b/v2/src/app/admin/reports/impact/page.tsx
@@ -20,7 +20,7 @@ export default function ImpactReportTemplatesPage() {
       <header>
         <h1 className="text-2xl font-bold tracking-tight">Impact report templates</h1>
         <p className="mt-1 max-w-3xl text-sm text-gray-600">
-          Reusable, audience-framed impact reports — each showcases live impact metrics + consented
+          Reusable, audience-framed impact reports — each showcases current impact metrics + consented
           Empathy Ledger stories. They’re the content behind the{' '}
           <Link href="/admin/reach-out" className="text-violet-700 underline">
             audience segments

--- a/v2/src/app/api/checkout/route.ts
+++ b/v2/src/app/api/checkout/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getStripe } from '@/lib/stripe';
 import { createClient } from '@/lib/supabase/server';
+import { isPurchasableProductType } from '@/lib/data/products';
 import type { CartItem } from '@/lib/cart';
 
 export async function POST(request: NextRequest) {
@@ -24,7 +25,7 @@ export async function POST(request: NextRequest) {
 
     const { data: products, error: productsError } = await supabase
       .from('products')
-      .select('id, name, price_cents, currency')
+      .select('id, name, price_cents, currency, product_type, is_active')
       .in('id', productIds);
 
     if (productsError || !products) {
@@ -37,6 +38,22 @@ export async function POST(request: NextRequest) {
 
     // Create a map for quick lookup
     const productMap = new Map(products.map((p) => [p.id, p]));
+    const invalidItems = items.filter((item) => {
+      const productId = item.id.split('-sponsor-')[0];
+      const dbProduct = productMap.get(productId);
+      return (
+        !dbProduct ||
+        !dbProduct.is_active ||
+        !isPurchasableProductType(dbProduct.product_type)
+      );
+    });
+
+    if (invalidItems.length > 0) {
+      return NextResponse.json(
+        { error: 'Only the Stretch Bed is available for checkout.' },
+        { status: 400 }
+      );
+    }
 
     // Stripe needs an absolute, publicly-reachable image URL. Our product
     // images are stored as relative paths (/images/...) so next/image can serve
@@ -56,26 +73,26 @@ export async function POST(request: NextRequest) {
     // Build line items for Stripe
     const lineItems = items.map((item) => {
       const productId = item.id.split('-sponsor-')[0];
-      const dbProduct = productMap.get(productId);
+      const dbProduct = productMap.get(productId)!;
 
       // Use database price for security (don't trust client-sent price)
-      const unitAmount = dbProduct?.price_cents || item.price_cents;
+      const unitAmount = dbProduct.price_cents;
       const imageUrl = toAbsoluteImage(item.image);
 
-      let productName = item.name;
+      let productName = dbProduct.name;
       if (item.is_sponsorship) {
-        productName = `${item.name} (Sponsorship${item.sponsored_community ? ` for ${item.sponsored_community}` : ''})`;
+        productName = `${dbProduct.name} (Sponsorship${item.sponsored_community ? ` for ${item.sponsored_community}` : ''})`;
       }
 
       return {
         price_data: {
-          currency: item.currency.toLowerCase(),
+          currency: dbProduct.currency.toLowerCase(),
           product_data: {
             name: productName,
             ...(imageUrl && { images: [imageUrl] }),
             metadata: {
               product_id: productId,
-              product_type: item.product_type || '',
+              product_type: dbProduct.product_type || '',
               is_sponsorship: String(item.is_sponsorship || false),
               sponsored_community: item.sponsored_community || '',
               dedication_message: item.dedication_message || '',

--- a/v2/src/app/api/partnership/route.ts
+++ b/v2/src/app/api/partnership/route.ts
@@ -42,6 +42,7 @@ export async function POST(request: NextRequest) {
     // Roll segmentation answers into the stored message so they survive
     // even if the partnership_inquiries table doesn't have dedicated columns.
     const segmentPrefix = [
+      body.partnershipType ? `Interest: ${body.partnershipType}` : null,
       body.partnerSegment ? `Segment: ${body.partnerSegment}` : null,
       body.fundingTier ? `Ticket size: ${body.fundingTier}` : null,
       body.timeline ? `Timeline: ${body.timeline}` : null,
@@ -61,9 +62,11 @@ export async function POST(request: NextRequest) {
       'distribution', 'grant', 'media-pack-request',
     ]);
     const dbPartnershipType =
-      body.partnershipType && ALLOWED_DB_TYPES.has(body.partnershipType)
-        ? body.partnershipType
-        : 'other';
+      body.partnershipType === 'capital-interest'
+        ? 'partnership-inquiry'
+        : body.partnershipType && ALLOWED_DB_TYPES.has(body.partnershipType)
+          ? body.partnershipType
+          : 'other';
 
     // Store in Supabase partnership_inquiries table
     const { data: inquiry, error: dbError } = await supabase
@@ -135,6 +138,9 @@ export async function POST(request: NextRequest) {
           `<p><strong>Partnership inquiry</strong>${body.partnershipType ? ` &mdash; ${esc(body.partnershipType)}` : ''}</p>`,
           body.organizationName ? `<p>Organisation: ${esc(body.organizationName)}</p>` : '',
           body.contactPhone ? `<p>Phone: ${esc(body.contactPhone)}</p>` : '',
+          body.partnerSegment ? `<p>Capital path: ${esc(body.partnerSegment)}</p>` : '',
+          body.fundingTier ? `<p>Ticket size / structure: ${esc(body.fundingTier)}</p>` : '',
+          body.timeline ? `<p>Timeline: ${esc(body.timeline)}</p>` : '',
           body.message ? `<p>${esc(body.message).replace(/\n/g, '<br/>')}</p>` : '',
         ].join('');
         await ghl.addInboundEmail({

--- a/v2/src/app/api/products/route.ts
+++ b/v2/src/app/api/products/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { PURCHASABLE_PRODUCT_TYPES } from '@/lib/data/products';
 
 export async function GET() {
   try {
@@ -9,6 +10,7 @@ export async function GET() {
       .from('products')
       .select('id, slug, name, price_cents, currency, featured_image, product_type, short_description')
       .eq('is_active', true)
+      .in('product_type', [...PURCHASABLE_PRODUCT_TYPES])
       .order('name');
 
     if (error) {

--- a/v2/src/app/design/page.tsx
+++ b/v2/src/app/design/page.tsx
@@ -204,9 +204,6 @@ export default function DesignPage() {
               <Button asChild>
                 <Link href="/design/community-voices">Start with Community Voices</Link>
               </Button>
-              <Button variant="outline" asChild>
-                <Link href="/docs/HOMEPAGE_DESIGN_EXPLORATION.md">View Full Document</Link>
-              </Button>
             </div>
           </CardContent>
         </Card>

--- a/v2/src/app/funders/[slug]/communities/page.tsx
+++ b/v2/src/app/funders/[slug]/communities/page.tsx
@@ -151,8 +151,8 @@ export default async function FunderCommunitiesPage({ params }: PageProps) {
           </h1>
           <p className="text-lg leading-relaxed" style={{ color: '#5E5E5E' }}>
             Below is the complete picture of the communities, partners, demand, and procurement pathways
-            that Goods has been working across. Every entry is documented in our internal CRM and pulled
-            live from the same source of truth that runs the Goods Command Center. This is the depth of
+            that Goods has been working across. Every entry is documented in the Goods relationship register
+            and checked against the same operating records used by the team. This is the depth of
             relationship and research behind the funding ask.
           </p>
         </header>
@@ -167,7 +167,7 @@ export default async function FunderCommunitiesPage({ params }: PageProps) {
           </div>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <Stat value={`${totals.communities}`} label="Active deployments" sub="Goods is on the ground today" />
-            <Stat value={`${totals.beds}`} label="Beds delivered" sub="Verified from internal asset register" />
+            <Stat value={`${totals.beds}`} label="Beds delivered" sub="Verified from the asset register" />
             <Stat value={`${communityPartners.length}`} label="Partner organisations" sub={`${partnersByCategory.length} categories tracked`} />
             <Stat value={`$${(demandTotal / 1_000_000).toFixed(2)}M`} label="Documented demand" sub="From community requests" />
           </div>

--- a/v2/src/app/funders/[slug]/page.tsx
+++ b/v2/src/app/funders/[slug]/page.tsx
@@ -272,8 +272,8 @@ export default async function FunderPage({ params }: PageProps) {
           </h2>
           <p className="text-base leading-relaxed mb-6" style={{ color: '#5E5E5E' }}>
             Goods has been working across remote Australia for years. Below is a summary of the
-            relationships, deployments, and procurement pathways already documented in our internal
-            CRM. The full breakdown lives one click away on the next page.
+            relationships, deployments, and procurement pathways already documented in the Goods
+            relationship register. The full breakdown lives one click away on the next page.
           </p>
 
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">

--- a/v2/src/app/investors/login/page.tsx
+++ b/v2/src/app/investors/login/page.tsx
@@ -45,7 +45,7 @@ function LoginForm() {
           Enter the password
         </h1>
         <p className="mt-3 text-sm text-stone-600 leading-relaxed">
-          The live, verified bed cost model and investment view — shared with QBE and
+          The interactive, verified bed cost model and investment view — shared with QBE and
           investment partners of Goods on Country. If you don&apos;t have the password,
           contact Ben at ben@benjamink.com.au.
         </p>

--- a/v2/src/app/investors/page.tsx
+++ b/v2/src/app/investors/page.tsx
@@ -4,7 +4,7 @@
  * (INVESTORS_PASSWORD) instead of the admin email/allowlist auth.
  *
  * This is the door QBE / investment partners click from the Notion QBE Diagnostic
- * pages: one shared password, then the live Investment + Mission Control cockpit.
+ * pages: one shared password, then the interactive Investment + Mission Control cockpit.
  * All math is locked client-side (no admin data), so nothing auth-gated leaves the
  * engine. Renders standalone (conditional-chrome hides the public site nav on
  * /investors) so the cockpit owns the full viewport, exactly like the admin route.
@@ -19,7 +19,7 @@ import { CostModelWorkspace } from '@/app/admin/cost-model/cost-model-workspace'
 export const metadata = {
   title: 'Investor Cockpit — Goods on Country',
   description:
-    'Live verified bed cost model + investment view. Marginal-cost-first, QBE-ready capital case.',
+    'Interactive verified bed cost model + investment view. Marginal-cost-first, QBE-ready capital case.',
 };
 
 export default function InvestorsCockpitPage() {

--- a/v2/src/app/page.tsx
+++ b/v2/src/app/page.tsx
@@ -43,7 +43,7 @@ export default async function HomePage() {
         title={brand.hero.home.headline}
         subtitle={brand.hero.home.subheadline}
         primaryCta={{ text: 'Shop the Stretch Bed', href: '/shop/stretch-bed-single' }}
-        secondaryCta={{ text: 'How It\'s Made', href: '/process' }}
+        secondaryCta={{ text: 'Back the work', href: '/partner' }}
         videoSrc={{
           desktop: videoUrl('hero-desktop.mp4'),
           mobile: videoUrl('hero-mobile.mp4'),
@@ -52,6 +52,45 @@ export default async function HomePage() {
         imageSrc="/images/media-pack/lying-on-stretch-bed.jpg"
         imageAlt="A young man lying full-length on a Stretch Bed on country: recycled plastic legs, galvanised steel poles, heavy-duty canvas"
       />
+
+      {/* 1b. Philanthropist pathway: visible immediately after the hero. */}
+      <section className="border-b border-border bg-background py-10 md:py-12">
+        <div className="container mx-auto px-4">
+          <div className="mx-auto grid max-w-6xl gap-8 md:grid-cols-[1.15fr_0.85fr] md:items-center">
+            <div>
+              <p className="mb-3 text-xs uppercase tracking-[0.25em] text-accent">
+                Back the work
+              </p>
+              <h2
+                className="mb-4 text-2xl font-light leading-tight text-foreground md:text-4xl"
+                style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
+              >
+                Philanthropic and patient capital can move the making to Country.
+              </h2>
+              <p className="max-w-3xl text-base leading-relaxed text-muted-foreground md:text-lg">
+                Goods on Country builds essential health hardware with remote First Nations
+                communities. Beds now. Washing machines next. Community-owned production over time.
+              </p>
+            </div>
+            <div className="rounded-xl border border-border bg-muted/30 p-5 md:p-6">
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                A Curious Tractor Pty Ltd is the trading company behind Goods on Country. The
+                Butterfly Movement Ltd is the DGR pathway for eligible giving while the long-term
+                structure is being designed to protect enterprise discipline and community
+                ownership.
+              </p>
+              <div className="mt-5 flex flex-col gap-3 sm:flex-row md:flex-col lg:flex-row">
+                <Button asChild>
+                  <Link href="/partner">Explore the capital stack</Link>
+                </Button>
+                <Button variant="outline" asChild>
+                  <Link href="/process">See how it is made</Link>
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
 
       {/* 2. The Stretch Bed: Materials + Assembly + Price comparison */}
       <section className="py-16 md:py-20 bg-background">

--- a/v2/src/app/press/page.tsx
+++ b/v2/src/app/press/page.tsx
@@ -55,7 +55,6 @@ const colourSwatches = [
   { name: 'Rust', hex: '#C45C3E', text: '#FFFFFF', role: 'Highlight accent, used sparingly' },
 ];
 
-// Voice rules from wiki/articles/brand-comms/01-voice-and-tone.md
 const voiceRules = [
   'Lead with impact, not charity. A washing machine is cardiac prevention. A bed is medical recovery.',
   'Centre community voices. Quote people by name, with location, with consent.',
@@ -305,7 +304,7 @@ export default async function PressPage() {
               <p className="mt-5 text-xs font-medium uppercase tracking-wide text-muted-foreground">Never write</p>
               <p className="mt-2 text-xs text-muted-foreground">{bannedWords.join(' · ')}</p>
               <p className="mt-3 text-xs text-muted-foreground">
-                Full rules: <a href="https://github.com/Acurioustractor/Goods-Asset-Register/blob/main/wiki/articles/brand-comms/01-voice-and-tone.md" className="underline" target="_blank" rel="noopener">wiki/brand-comms/01-voice-and-tone</a>
+                Public rule: keep it specific, practical, respectful, and grounded in real work.
               </p>
             </div>
           </div>

--- a/v2/src/app/shop/[slug]/page.tsx
+++ b/v2/src/app/shop/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
   EnterpriseOpportunity,
 } from '@/components/shop';
 import { ProductJsonLd } from '@/components/seo';
+import { isPurchasableProductType } from '@/lib/data/products';
 import type { Product, ProductMetadata } from '@/lib/types/database';
 
 interface Props {
@@ -123,6 +124,21 @@ export default async function ProductPage({ params }: Props) {
   }
 
   const relatedProducts = await getRelatedProducts(product.product_type, slug);
+  const canCheckout = isPurchasableProductType(product.product_type);
+  const nonCheckoutAction =
+    product.product_type === 'washing_machine'
+      ? {
+          href: '/partner?type=washer-interest',
+          label: 'Register Interest',
+          note: 'Pakkimjalki Kari is still in prototype. Register interest instead of checking out.',
+        }
+      : product.product_type === 'basket_bed'
+        ? {
+            href: '/basket-bed-plans',
+            label: 'Download Plans',
+            note: 'The Basket Bed is archived and open source. It is not sold through checkout.',
+          }
+        : null;
   const hasDiscount =
     product.compare_at_price_cents &&
     product.compare_at_price_cents > product.price_cents;
@@ -219,28 +235,44 @@ export default async function ProductPage({ params }: Props) {
 
             {/* Actions */}
             <div className="space-y-3">
-              <AddToCartButton
-                product={{
-                  id: product.id,
-                  slug: product.slug,
-                  name: product.name,
-                  price_cents: product.price_cents,
-                  currency: product.currency,
-                  featured_image: product.featured_image,
-                  product_type: product.product_type,
-                }}
-                size="lg"
-                className="w-full"
-              />
+              {canCheckout ? (
+                <>
+                  <AddToCartButton
+                    product={{
+                      id: product.id,
+                      slug: product.slug,
+                      name: product.name,
+                      price_cents: product.price_cents,
+                      currency: product.currency,
+                      featured_image: product.featured_image,
+                      product_type: product.product_type,
+                    }}
+                    size="lg"
+                    className="w-full"
+                  />
 
-              <Button size="lg" variant="outline" className="w-full" asChild>
-                <Link href={`/sponsor?product=${product.slug}`}>
-                  <svg className="mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                  </svg>
-                  Sponsor for a Community
-                </Link>
-              </Button>
+                  <Button size="lg" variant="outline" className="w-full" asChild>
+                    <Link href={`/sponsor?product=${product.slug}`}>
+                      <svg className="mr-2 h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+                      </svg>
+                      Sponsor for a Community
+                    </Link>
+                  </Button>
+                </>
+              ) : (
+                <div className="rounded-lg border border-border bg-muted/30 p-4">
+                  <p className="font-medium text-foreground">Not available for direct checkout</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {nonCheckoutAction?.note || 'Only the Stretch Bed is available for direct checkout.'}
+                  </p>
+                  {nonCheckoutAction && (
+                    <Button size="lg" className="mt-4 w-full" asChild>
+                      <Link href={nonCheckoutAction.href}>{nonCheckoutAction.label}</Link>
+                    </Button>
+                  )}
+                </div>
+              )}
             </div>
 
             {/* Impact Note */}

--- a/v2/src/app/sponsor/page.tsx
+++ b/v2/src/app/sponsor/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useCart } from '@/lib/cart';
+import { isPurchasableProductType } from '@/lib/data/products';
 
 // Palette — matches the Canberra hero so the cross-page flow feels like one site.
 const CREAM = '#FDF8F3';
@@ -113,9 +114,9 @@ function SponsorContent() {
         const res = await fetch('/api/products');
         if (res.ok) {
           const data: Product[] = await res.json();
-          // Pick the Stretch Bed by default, or whatever the URL param asked for
-          // if it matches an existing bed product.
-          const bedProducts = data.filter((p) => p.product_type.includes('bed'));
+          // Pick the Stretch Bed by default. Non-commerce products never enter
+          // the sponsor cart, even if a product query param points at one.
+          const bedProducts = data.filter((p) => isPurchasableProductType(p.product_type));
           const preferred =
             (productSlug && bedProducts.find((p) => p.slug === productSlug)) ||
             bedProducts.find((p) => p.slug.includes('stretch')) ||

--- a/v2/src/components/cart/add-to-cart-button.tsx
+++ b/v2/src/components/cart/add-to-cart-button.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useCart, type CartItem } from '@/lib/cart';
+import { isPurchasableProductType } from '@/lib/data/products';
 import { Button } from '@/components/ui/button';
 
 interface AddToCartButtonProps {
@@ -35,8 +36,10 @@ export function AddToCartButton({
 }: AddToCartButtonProps) {
   const { addItem, openCart } = useCart();
   const [isAdding, setIsAdding] = useState(false);
+  const canCheckout = isPurchasableProductType(product.product_type);
 
   const handleAddToCart = () => {
+    if (!canCheckout) return;
     setIsAdding(true);
 
     const cartItem: Omit<CartItem, 'quantity'> = {
@@ -64,7 +67,7 @@ export function AddToCartButton({
   return (
     <Button
       onClick={handleAddToCart}
-      disabled={isAdding}
+      disabled={isAdding || !canCheckout}
       className={className}
       size={size}
     >
@@ -103,7 +106,7 @@ export function AddToCartButton({
               />
             </svg>
           )}
-          {isSponsorship ? 'Sponsor This Bed' : 'Add to Cart'}
+          {!canCheckout ? 'Not available for checkout' : isSponsorship ? 'Sponsor This Bed' : 'Add to Cart'}
         </>
       )}
     </Button>

--- a/v2/src/components/empathy-ledger/featured-stories.tsx
+++ b/v2/src/components/empathy-ledger/featured-stories.tsx
@@ -32,7 +32,7 @@ export async function FeaturedStories({
   viewAllLink = '/stories',
   maxStories = 3,
 }: FeaturedStoriesProps) {
-  const stories = await empathyLedger.getStories({ limit: maxStories });
+  const stories = await empathyLedger.getGoodsStories({ limit: maxStories });
 
   // If EL has stories, use them
   if (stories.length > 0) {

--- a/v2/src/components/layout/site-footer.tsx
+++ b/v2/src/components/layout/site-footer.tsx
@@ -76,6 +76,7 @@ const footerLinks = {
     { name: 'Gallery', href: '/gallery' },
   ],
   connect: [
+    { name: 'Back the work', href: '/partner' },
     { name: 'Partner With Us', href: '/partner' },
     { name: 'Sponsor a Bed', href: '/sponsor' },
     { name: 'Support / FAQ', href: '/support' },
@@ -193,6 +194,19 @@ export function SiteFooter() {
             <PartnerGroup label="Backed by" partners={backedByPartners} />
             <PartnerGroup label="Community partner" partners={communityPartners} />
           </div>
+        </div>
+
+        <div className="mt-8 rounded-xl border border-border bg-background p-5">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            DGR pathway
+          </p>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            DGR-deductible giving is available only through The Butterfly Movement Ltd, an
+            ACNC-registered charity and Item 1 DGR. The Goods on Country giving pathway through
+            Butterfly is being formalised for FY2026-27. Confirm current routing with us before
+            structuring a tax-deductible gift. Goods on Country and A Curious Tractor Pty Ltd are
+            not themselves DGR-endorsed.
+          </p>
         </div>
 
         {/* Bottom Section */}

--- a/v2/src/components/layout/site-header.tsx
+++ b/v2/src/components/layout/site-header.tsx
@@ -7,7 +7,6 @@ import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { CartButton } from '@/components/cart';
-import { AuthNavItem } from '@/components/layout/auth-nav-item';
 
 type NavItem = { name: string; href: string; subtitle?: string };
 
@@ -15,6 +14,7 @@ const navigation: NavItem[] = [
   { name: 'Stretch Bed', href: '/shop/stretch-bed-single' },
   { name: 'Pakkimjalki Kari', subtitle: 'Washing Machine', href: '/shop/washing-machine' },
   { name: 'How It\'s Made', href: '/process' },
+  { name: 'Back the work', href: '/partner' },
   // 'Field notes' nav entry pulled until Utopia is consent-cleared +
   // published. Re-add this line when ready:
   // { name: 'Field notes', href: '/field-notes' },
@@ -65,6 +65,9 @@ export function SiteHeader() {
 
         {/* CTA Buttons & Cart */}
         <div className="hidden md:flex md:items-center md:gap-3">
+          <Button size="sm" variant="outline" asChild>
+            <Link href="/partner">Back the work</Link>
+          </Button>
           <Button size="sm" asChild>
             <Link href="/shop/stretch-bed-single">Buy Now</Link>
           </Button>
@@ -108,6 +111,11 @@ export function SiteHeader() {
                 </Link>
               ))}
               <div className="mt-4 flex flex-col gap-3">
+                <Button variant="outline" asChild>
+                  <Link href="/partner" onClick={() => setMobileMenuOpen(false)}>
+                    Back the work
+                  </Link>
+                </Button>
                 <Button asChild>
                   <Link href="/shop/stretch-bed-single" onClick={() => setMobileMenuOpen(false)}>
                     Buy Now

--- a/v2/src/components/partnership-form.tsx
+++ b/v2/src/components/partnership-form.tsx
@@ -10,9 +10,12 @@ interface PartnershipFormProps {
 
 const SEGMENT_OPTIONS = [
   { value: 'foundation', label: 'Foundation or trust' },
+  { value: 'paf-puaf', label: 'PAF / PuAF' },
+  { value: 'family-office', label: 'Family office' },
   { value: 'corporate', label: 'Corporate / CSR' },
-  { value: 'buyer', label: 'Institutional buyer (health, housing, government)' },
-  { value: 'investor', label: 'Investor or lender' },
+  { value: 'recoverable-grant', label: 'Recoverable grant' },
+  { value: 'patient-debt', label: 'Patient debt' },
+  { value: 'institutional-buyer', label: 'Institutional buyer' },
   { value: 'community', label: 'Community organisation' },
   { value: 'other', label: 'Other' },
 ];
@@ -23,7 +26,8 @@ const TIER_OPTIONS = [
   { value: '25-100k', label: '$25K to $100K' },
   { value: '100-500k', label: '$100K to $500K' },
   { value: '500k-plus', label: '$500K+' },
-  { value: 'loan', label: 'A loan or recoverable grant' },
+  { value: 'recoverable', label: 'Recoverable funding' },
+  { value: 'patient-debt', label: 'Patient debt' },
 ];
 
 const TIMELINE_OPTIONS = [
@@ -144,14 +148,14 @@ export function PartnershipForm({ defaultType }: PartnershipFormProps = {}) {
         <div className="rounded-lg bg-primary/5 border border-primary/20 p-4">
           <p className="text-sm font-semibold text-foreground">You&apos;re in. We&apos;ve got your details.</p>
           <p className="text-sm text-muted-foreground mt-1">
-            Two optional questions to help us come back to you with the right answer. Skip them if
-            you&apos;d rather just talk.
+            Two optional questions to help us come back with the right capital pathway. Skip them
+            if you&apos;d rather just talk.
           </p>
         </div>
 
         <fieldset>
           <legend className="block text-sm font-semibold text-foreground mb-3">
-            Roughly what size are you thinking?
+            Roughly what size or structure are you thinking?
           </legend>
           <div className="grid gap-2 sm:grid-cols-2">
             {TIER_OPTIONS.map((option) => (
@@ -285,7 +289,7 @@ export function PartnershipForm({ defaultType }: PartnershipFormProps = {}) {
       {/* Segment: optional, a quick single choice that routes the lead */}
       <fieldset>
         <legend className="block text-sm font-semibold text-foreground mb-3">
-          What kind of partner are you? <span className="text-muted-foreground/70 font-normal">(optional)</span>
+          What kind of capital path fits you? <span className="text-muted-foreground/70 font-normal">(optional)</span>
         </legend>
         <div className="grid gap-2 sm:grid-cols-2">
           {SEGMENT_OPTIONS.map((option) => (
@@ -315,7 +319,7 @@ export function PartnershipForm({ defaultType }: PartnershipFormProps = {}) {
           value={message}
           onChange={(e) => setMessage(e.target.value)}
           className={inputClass}
-          placeholder="Anything you'd like us to know: a community you want to back, a question, a deadline you're working to."
+          placeholder="Anything you'd like us to know: your mandate, timing, a community you want to back, or a question we should answer first."
         />
       </div>
 

--- a/v2/src/components/production/cost-model-scenarios-card.tsx
+++ b/v2/src/components/production/cost-model-scenarios-card.tsx
@@ -231,9 +231,9 @@ export function CostModelScenariosCard() {
           </div>
         </div>
 
-        {/* Overhead breakdown by volume */}
+        {/* Fixed block by volume. Freight is shown as the bridge into marginal cost, not as fixed absorption. */}
         <div>
-          <h4 className="text-sm font-semibold mb-3">Overhead per bed by annual volume</h4>
+          <h4 className="text-sm font-semibold mb-3">Fixed block per bed by annual volume</h4>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead className="text-left text-gray-500 border-b">
@@ -243,8 +243,8 @@ export function CostModelScenariosCard() {
                   <th className="pb-2 font-medium text-right">Founder (30d prod)</th>
                   <th className="pb-2 font-medium text-right">Admin</th>
                   <th className="pb-2 font-medium text-right">Field travel</th>
-                  <th className="pb-2 font-medium text-right">Freight</th>
-                  <th className="pb-2 font-medium text-right">Total</th>
+                  <th className="pb-2 font-medium text-right">Freight (marginal)</th>
+                  <th className="pb-2 font-medium text-right">Fixed total</th>
                 </tr>
               </thead>
               <tbody>

--- a/v2/src/components/reports/impact-report.tsx
+++ b/v2/src/components/reports/impact-report.tsx
@@ -2,13 +2,13 @@ import Image from 'next/image';
 import type { ImpactReportTemplate } from '@/lib/data/report-templates';
 import type { EmpathyLedgerStory } from '@/lib/empathy-ledger/types';
 
-/** A metric resolved against the live impact snapshot (or its target fallback). */
+/** A metric resolved against the current impact snapshot (or its target fallback). */
 export interface ResolvedReportMetric {
   id: string;
   name: string;
   unit: string;
   value: number | null;
-  /** true if `value` is a live/current figure, false if it's a target fallback. */
+  /** true if `value` is a current figure, false if it's a target fallback. */
   isLive: boolean;
   sourceDetail: string;
 }
@@ -37,7 +37,7 @@ function formatValue(m: ResolvedReportMetric): string {
 }
 
 /**
- * Presentational impact report — audience-framed, showcasing live impact metrics
+ * Presentational impact report — audience-framed, showcasing current impact metrics
  * + consented Empathy Ledger stories. No data fetching here; the page resolves
  * everything and passes it in, so this component is safe to mount publicly later.
  */
@@ -64,7 +64,7 @@ export function ImpactReport({ template, metrics, dimensions, stories, generated
                 <div className="font-serif text-2xl font-bold text-gray-900">{formatValue(m)}</div>
                 <div className="mt-1 text-xs font-medium text-gray-700">{m.name}</div>
                 <div className="mt-1 text-[10px] uppercase tracking-wide text-gray-400">
-                  {m.isLive ? 'Live' : 'Year-1 target'}
+                  {m.isLive ? 'Current' : 'Year-1 target'}
                 </div>
               </div>
             ))}
@@ -149,8 +149,8 @@ export function ImpactReport({ template, metrics, dimensions, stories, generated
       </section>
 
       <footer className="border-t border-gray-200 pt-4 text-xs text-gray-400">
-        Generated {generatedAt}. Metrics resolve live against the impact model (Year-1 targets shown where
-        a live value isn’t yet measured); stories are consent-filtered from Empathy Ledger. Template:{' '}
+        Generated {generatedAt}. Metrics resolve against the current impact model (Year-1 targets shown where
+        a current value isn’t yet measured); stories are consent-filtered from Empathy Ledger. Template:{' '}
         <code>{template.id}</code>.
       </footer>
     </article>

--- a/v2/src/components/shop/buy-now-form.tsx
+++ b/v2/src/components/shop/buy-now-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { isPurchasableProductType } from '@/lib/data/products';
 
 interface BuyNowFormProps {
   productId: string;
@@ -31,6 +32,7 @@ export function BuyNowForm({
   const [error, setError] = useState<string | null>(null);
 
   const total = quantity * pricePerUnit;
+  const canCheckout = isPurchasableProductType(productType);
 
   const formatPrice = (amount: number) =>
     new Intl.NumberFormat('en-AU', {
@@ -40,6 +42,11 @@ export function BuyNowForm({
     }).format(amount);
 
   const handleBuyNow = async () => {
+    if (!canCheckout) {
+      setError('Only the Stretch Bed is available for checkout.');
+      return;
+    }
+
     setIsSubmitting(true);
     setError(null);
 
@@ -104,7 +111,7 @@ export function BuyNowForm({
 
       <Button
         onClick={handleBuyNow}
-        disabled={isSubmitting}
+        disabled={isSubmitting || !canCheckout}
         size={size}
         className="w-full"
       >
@@ -126,7 +133,7 @@ export function BuyNowForm({
                 d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
               />
             </svg>
-            Buy Now · {formatPrice(total)}
+            {canCheckout ? `Buy Now · ${formatPrice(total)}` : 'Not available for checkout'}
           </>
         )}
       </Button>
@@ -136,7 +143,9 @@ export function BuyNowForm({
       )}
 
       <p className="mt-2 text-center text-xs text-muted-foreground">
-        Secure checkout via Stripe. We deliver Australia-wide.
+        {canCheckout
+          ? 'Secure checkout via Stripe. We deliver Australia-wide.'
+          : 'Only the Stretch Bed is available for direct checkout.'}
       </p>
     </div>
   );

--- a/v2/src/lib/cart/context.tsx
+++ b/v2/src/lib/cart/context.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { createContext, useContext, useReducer, useEffect, useCallback, ReactNode } from 'react';
+import { isPurchasableProductType } from '@/lib/data/products';
 
 // Types
 export interface CartItem {
@@ -52,6 +53,10 @@ const CART_STORAGE_KEY = 'goods-cart';
 function cartReducer(state: CartState, action: CartAction): CartState {
   switch (action.type) {
     case 'ADD_ITEM': {
+      if (!isPurchasableProductType(action.payload.product_type)) {
+        return state;
+      }
+
       const existingIndex = state.items.findIndex(
         (item) =>
           item.id === action.payload.id &&
@@ -131,7 +136,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
     try {
       const stored = localStorage.getItem(CART_STORAGE_KEY);
       if (stored) {
-        const items = JSON.parse(stored) as CartItem[];
+        const items = (JSON.parse(stored) as CartItem[]).filter((item) =>
+          isPurchasableProductType(item.product_type)
+        );
         dispatch({ type: 'LOAD_CART', payload: items });
       }
     } catch (error) {

--- a/v2/src/lib/data/funder-pages.ts
+++ b/v2/src/lib/data/funder-pages.ts
@@ -117,7 +117,7 @@ export const FUNDER_PAGES: FunderPage[] = [
       'Self-servicing economics. At roughly $750 a bed with marginal cost well below sale price, the recoverable portion pays itself back across the buyer pipeline within two to three years.',
       "Catalytic position. Your commitment anchors the raise that SEFA's working capital and the QBE Catalysing Impact match (contingent on eligible co-capital raised) are both contingent on.",
       "Aligned to Minderoo's existing playbook. You've done recoverable grants like this before, and Goods is a clean fit.",
-      "First Nations led, On-Country manufacturing. Direct alignment with Minderoo's Generation One and Thrive by Five priorities.",
+      "First Nations led, with a pathway to On-Country manufacturing. Direct alignment with Minderoo's Generation One and Thrive by Five priorities.",
     ],
     closeBy: 'End of June 2026, to align with the QBE Stage 2 match',
     meetingAsk:
@@ -142,9 +142,9 @@ export const FUNDER_PAGES: FunderPage[] = [
       "Goods on Country is a First Nations led social enterprise making the Stretch Bed: a 10-year, washable, flat-pack bed designed for remote Indigenous housing. We're approaching PRF as part of a ~$3M blended capital raise (target) through the QBE Catalysing Impact 2026 program, with a focus on the disadvantage and housing outcomes alignment that's central to PRF's mission.",
     whyUs: [
       "Direct alignment with the PRF disadvantage pillar. Quality, durable furniture is a measurable lever for housing outcomes in remote Australia.",
-      "Outcomes tracking is in place. Bed deployment uses a QR scan-and-record system across all 9 communities; washing machine telemetry is live on pilot units. PRF gets deployment data from day one; fleet-wide machine telemetry is the next instrumentation milestone.",
+      "Outcomes tracking is in place. Bed deployment uses a QR scan-and-record system across all 9 communities; washing machine telemetry is piloting on selected units. PRF gets deployment data from day one; fleet-wide machine telemetry is the next instrumentation milestone.",
       "Catalytic position. Joins SEFA, QBE and Minderoo in a coordinated stack that PRF doesn't have to assemble alone.",
-      "First Nations leadership and On-Country manufacturing creates jobs in the communities being served.",
+      "First Nations leadership and the pathway to On-Country manufacturing creates jobs in the communities being served.",
     ],
     closeBy: 'End of July 2026',
     meetingAsk:

--- a/v2/src/lib/data/products.ts
+++ b/v2/src/lib/data/products.ts
@@ -66,6 +66,15 @@ export const STRETCH_BED = {
   ],
 } as const;
 
+export const PURCHASABLE_PRODUCT_TYPES = [STRETCH_BED.productType] as const;
+export type PurchasableProductType = (typeof PURCHASABLE_PRODUCT_TYPES)[number];
+
+export function isPurchasableProductType(
+  productType: string | null | undefined,
+): productType is PurchasableProductType {
+  return productType === STRETCH_BED.productType;
+}
+
 export const WASHING_MACHINE = {
   name: 'Pakkimjalki Kari',
   slug: 'pakkimjalki-kari',
@@ -109,7 +118,7 @@ export const PRODUCTION_FACILITY = {
 } as const;
 
 export const ENTERPRISE = {
-  model: 'Community ownership transfer (not licensing)',
+  model: 'Community ownership pathway',
   philosophy: 'Our goal is to become unnecessary',
   pathways: [
     'Sponsor beds',

--- a/v2/src/lib/empathy-ledger/client.ts
+++ b/v2/src/lib/empathy-ledger/client.ts
@@ -128,10 +128,10 @@ function mapStoryFromAPI(raw: Record<string, unknown>): EmpathyLedgerStory {
     content: (raw.content as string) ?? null,
     authorName: (raw.authorName as string) ?? (raw.author_name as string) ?? (raw.storyteller_name as string) ?? ((raw.storyteller as Record<string, unknown>)?.display_name as string) ?? 'Unknown',
     authorId: (raw.author_id as string) ?? (raw.storyteller_id as string) ?? null,
-    publishedAt: String(raw.published_at ?? raw.created_at ?? ''),
+    publishedAt: String(raw.published_at ?? raw.publishedAt ?? raw.created_at ?? ''),
     themes: (raw.themes as (string | { name: string })[]) ?? [],
     visibility: (raw.visibility as string) ?? 'public',
-    isPublic: raw.is_public !== false,
+    isPublic: raw.is_public !== false && raw.isPublic !== false,
     featuredImageUrl: (raw.featured_image_url as string) ?? (raw.featuredImageUrl as string) ?? (raw.story_image_url as string) ?? null,
     culturalSensitivity: (raw.cultural_sensitivity as string) ?? null,
     elderApproved: Boolean(raw.elder_approved ?? raw.elderApproved ?? false),
@@ -161,6 +161,55 @@ function filterByConsent(stories: EmpathyLedgerStory[]): EmpathyLedgerStory[] {
     if (!story.syndicationEnabled) return false;
     return true;
   });
+}
+
+/**
+ * The Goods EL project (`goods-on-country`) is cross-tagged in Empathy Ledger
+ * with two other A Curious Tractor projects whose stories must NOT surface on
+ * Goods pages. Verified against the live content-hub feed 2026-06-02:
+ *   - SMART Recovery → titles end "— Facilitator Interview" / "… Staff Perspective"
+ *   - Confit (youth justice) → themes carry both "Youth Justice" and "Mentoring"
+ * Plus EL test/placeholder rows ("A community story (org members can see)").
+ * This is a consumer-side guard; the durable fix is EL-side project hygiene.
+ */
+function isGoodsCommunityVoice(story: EmpathyLedgerStory): boolean {
+  const title = story.title.toLowerCase();
+  const themes = (story.themes ?? []).map((t) =>
+    (typeof t === 'string' ? t : t?.name ?? '').toLowerCase(),
+  );
+
+  // SMART Recovery facilitator/staff interviews
+  if (
+    title.includes('facilitator interview') ||
+    title.includes('smart recovery') ||
+    title.includes('staff perspective')
+  ) {
+    return false;
+  }
+
+  // Confit youth-justice mentoring stories
+  if (title.includes('confit')) return false;
+  if (themes.includes('youth justice') && themes.includes('mentoring')) return false;
+
+  // EL test/placeholder rows
+  if (title.includes('org members can see')) return false;
+
+  // No "Unknown" / unattributed cards
+  if (!story.authorName || story.authorName === 'Unknown') return false;
+
+  return true;
+}
+
+/**
+ * Rank Goods stories so the richest read to the top: summary AND themes first,
+ * then a summary, then most-recently published.
+ */
+function rankGoodsStories(a: EmpathyLedgerStory, b: EmpathyLedgerStory): number {
+  const score = (s: EmpathyLedgerStory) =>
+    (s.summary?.trim() ? 2 : 0) + ((s.themes?.length ?? 0) > 0 ? 1 : 0);
+  const diff = score(b) - score(a);
+  if (diff !== 0) return diff;
+  return (b.publishedAt || '').localeCompare(a.publishedAt || '');
 }
 
 /**
@@ -322,6 +371,36 @@ export const empathyLedger = {
       return params.limit ? safe.slice(0, params.limit) : safe;
     } catch (error) {
       console.error('[EmpathyLedger] Failed to fetch stories:', error);
+      return [];
+    }
+  },
+
+  /**
+   * Fetch Goods community voices for public pages.
+   *
+   * Uses the project-scoped content-hub endpoint (real author names) instead
+   * of the unfiltered plain /api/stories feed, strips cross-project
+   * contamination (SMART Recovery, Confit — see isGoodsCommunityVoice) and
+   * "Unknown"/test rows, then ranks the richest stories first. Being returned
+   * by the public content hub is itself the consent gate, so we filter on
+   * isPublic/withdrawn/archived rather than the syndication flag.
+   */
+  async getGoodsStories(params: { limit?: number } = {}): Promise<EmpathyLedgerStory[]> {
+    if (!ENABLE_EMPATHY_LEDGER) return [];
+
+    try {
+      const response = await fetchFromEmpathyLedger<{ stories: Record<string, unknown>[] }>('/stories', {
+        projectCode: GOODS_PROJECT_CODE,
+        limit: 100,
+      });
+      const stories = (response.stories || [])
+        .map(mapStoryFromAPI)
+        .filter((s) => !s.consentWithdrawnAt && !s.isArchived && s.isPublic)
+        .filter(isGoodsCommunityVoice)
+        .sort(rankGoodsStories);
+      return params.limit ? stories.slice(0, params.limit) : stories;
+    } catch (error) {
+      console.error('[EmpathyLedger] Failed to fetch Goods stories:', error);
       return [];
     }
   },

--- a/v2/src/lib/ghl/index.ts
+++ b/v2/src/lib/ghl/index.ts
@@ -260,9 +260,9 @@ interface PartnershipInquiryData {
   contactPhone?: string;
   partnershipType: string;
   message?: string;
-  /** foundation | corporate | buyer | investor | community | other */
+  /** foundation | paf-puaf | family-office | corporate | recoverable-grant | patient-debt | institutional-buyer | community | other */
   partnerSegment?: string;
-  /** under-25k | 25-100k | 100-500k | 500k-plus | loan | exploring */
+  /** under-25k | 25-100k | 100-500k | 500k-plus | recoverable | patient-debt | exploring */
   fundingTier?: string;
   /** now | this-year | future */
   timeline?: string;
@@ -1279,6 +1279,9 @@ Submitted: ${new Date().toLocaleString('en-AU')}
     if (data.timeline) {
       segmentTags.push(`goods-timeline-${data.timeline}`);
     }
+    if (data.partnershipType === 'capital-interest') {
+      segmentTags.push('goods-capital-interest');
+    }
 
     const result = await createOrUpdateContact({
       email: data.contactEmail,
@@ -1298,6 +1301,7 @@ Submitted: ${new Date().toLocaleString('en-AU')}
         '🤝 Partnership Inquiry',
         `Organization: ${data.organizationName}`,
         `Type: ${data.partnershipType}`,
+        data.partnershipType === 'capital-interest' ? 'Interest: capital stack' : null,
         data.partnerSegment ? `Segment: ${data.partnerSegment}` : null,
         data.fundingTier ? `Ticket size: ${data.fundingTier}` : null,
         data.timeline ? `Timeline: ${data.timeline}` : null,


### PR DESCRIPTION
Correctness, security and conservative-copy changes only. **No public dollar figures or asset counts are touched here** — the financial restatement is deliberately held for a separate, Xero-reconciled PR (see *Explicitly out of scope* below).

## Commerce / correctness
- **checkout hardening** (`api/checkout/route.ts`): validates the product is active + purchasable, and uses the **DB** price/name/currency instead of trusting client-sent values (blocks price spoofing); rejects non-purchasable items with a 400.
- new `isPurchasableProductType()` helper guards the **cart context, add-to-cart button, buy-now form, sponsor flow, shop product page, and `/api/products`** against non-Stretch-Bed types (today a washing machine / basket bed can be added to cart — this stops that, matching "only the Stretch Bed is for sale").
- shop product page now shows **Register Interest** (washer) / **Download Plans** (basket) instead of Add-to-Cart.
- partnership API + form gain a capital-interest path; GHL gets a `goods-capital-interest` tag.
- `empathy-ledger/client.ts`: new `getGoodsStories()` scopes public stories to the Goods EL project and filters out cross-project contamination (SMART Recovery, Confit) + test/"Unknown" rows; `featured-stories` consumes it (stops cross-project story bleed).

## Overclaim softening (continues the existing public-copy quarantine discipline)
- cost-model skins: **"LIVE" → "MODEL"**, drop the misleading recompute-live label + ping animation.
- impact reports: **"Live" → "Current"**; funder pages: "internal CRM" → "relationship register", "On-Country manufacturing" → "pathway to"; investors copy "live" → "interactive".
- footer: conservative **DGR-pathway disclaimer** (giving routed via The Butterfly Movement Ltd, Item-1 DGR; Goods routing being formalised FY2026-27).
- header / home / footer: add a **"Back the work" → /partner** CTA.

## Cleanups
- dead links/imports removed; `package.json` gains drift/guardrail check scripts.

## Explicitly out of scope (held for a separate PR)
The financial restatement is intentionally **not** in this PR and needs a Xero cross-check before it ships: receipts $778K→$650.9K, marginal $600→$684.79, fully-loaded $1,912→$1,780, the 10→9 communities count, the `partner/page.tsx` capital-pitch rewrite, and the 13 regenerated diagram binaries.

## Verification
`npx tsc --noEmit` passes **standalone** on this branch (verified with the held edits stashed out).