### PR TITLE
fix(stories): whitespace-robust curated-quote lookup (getCuratedQuotes helper)

### DIFF
--- a/v2/src/app/admin/stories/page.tsx
+++ b/v2/src/app/admin/stories/page.tsx
@@ -1,5 +1,5 @@
 import { empathyLedger } from '@/lib/empathy-ledger/client';
-import { curatedQuotes } from '@/lib/data/curated-quotes';
+import { getCuratedQuotes } from '@/lib/data/curated-quotes';
 import { StoriesDashboard } from './stories-dashboard';
 import type { SyndicationStoryteller } from '@/lib/empathy-ledger/types';
 
@@ -38,7 +38,7 @@ export default async function StoriesPage() {
   const storytellers = enriched
     .filter(isRealStoryteller)
     .map((st) => {
-      const curated = curatedQuotes[st.name];
+      const curated = getCuratedQuotes(st.name);
       if (!curated || curated.length === 0) return st;
       return {
         ...st,

--- a/v2/src/lib/data/curated-quotes.ts
+++ b/v2/src/lib/data/curated-quotes.ts
@@ -317,3 +317,18 @@ export const curatedQuotes: Record<string, CuratedQuote[]> = {
     },
   ],
 };
+
+// EL display_names sometimes carry double-spaces ("Alfred  Johnson") and other
+// whitespace variants, so a raw curatedQuotes[name] index can miss. Look quotes
+// up through getCuratedQuotes() instead, which falls back to a whitespace-
+// normalised key. Keeps admin and public story paths resolving identically.
+const normaliseName = (name: string) => name.replace(/\s+/g, ' ').trim();
+
+const curatedQuotesByNormalisedName: Record<string, CuratedQuote[]> = {};
+for (const [key, value] of Object.entries(curatedQuotes)) {
+  curatedQuotesByNormalisedName[normaliseName(key)] = value;
+}
+
+export function getCuratedQuotes(name: string): CuratedQuote[] | undefined {
+  return curatedQuotes[name] ?? curatedQuotesByNormalisedName[normaliseName(name)];
+}


### PR DESCRIPTION
Small data-hygiene fix from the storyteller-triage list.

## Context
EL `display_name`s sometimes carry double-spaces ("Alfred  Johnson"), so curated-quote keys and the names they're matched against can differ by whitespace. The **public** stories grid already tolerated this via an inline `normaliseName` fallback — so public cards were not actually broken. The gap was the **admin** stories grid, which indexed `curatedQuotes[st.name]` raw with no fallback and could miss those rows.

## Change
- Add a colocated `getCuratedQuotes(name)` helper in `curated-quotes.ts`: direct hit first, then a whitespace-normalised fallback.
- Use it on `admin/stories/page.tsx` so admin and public paths resolve identically. Reusable for future call sites.

## Deliberately not done
- **Keys left as-is.** The file's rule is "key by EL `display_name` as it appears in EL," and EL itself sometimes carries double-spaces, so the keys may intentionally mirror EL. The helper makes their exact spacing irrelevant, so cleaning them would be cosmetic risk for no gain.
- **Shane/Shayne Bloomfield untouched.** The repo uses "Shayne" consistently, but which spelling matches EL's `display_name` is a real person's name — an EL-curation/source-of-truth decision, not a code guess.

## Verification
`npx tsc --noEmit` passes; no remaining raw `curatedQuotes[...]` index access in the admin page.