### PR TITLE
fix(qbe): accurate Stage 2 funding terms, restore capital stack, gate /sites/qbe

### DIFF
--- a/v2/src/app/partner/page.tsx
+++ b/v2/src/app/partner/page.tsx
@@ -88,7 +88,7 @@ const backedByPartners = [
     width: 800,
     height: 220,
     href: 'https://www.qbe.com/sustainability/qbe-foundation',
-    role: 'Catalysing Impact 2026 cohort, with Stage 2 match up to a $400K cap subject to eligible capital raised first.',
+    role: 'Catalysing Impact 2026 cohort, with Stage 2 funding of up to $400,000, at least matched by external capital raised.',
   },
 ];
 
@@ -306,8 +306,8 @@ export default async function PartnerPage({
                 The right capital is blended, patient and honest about what is proven.
               </h2>
               <p className="text-lg leading-relaxed text-background/75">
-                QBE Catalysing Impact 2026 creates a timely match opportunity up to a $400K cap,
-                conditional on eligible non-QBE capital being raised first. The practical ask is to
+                QBE Catalysing Impact 2026 creates a timely match opportunity of up to $400,000,
+                at least matched by external capital we raise first. The practical ask is to
                 explore which layer fits your mandate.
               </p>
             </div>
@@ -335,8 +335,9 @@ export default async function PartnerPage({
                 </div>
                 <ul className="space-y-3 text-sm text-background/75">
                   <li>
-                    <span className="font-semibold text-background">QBE match:</span> up to a $400K
-                    cap, conditional on eligible non-QBE capital being raised first.
+                    <span className="font-semibold text-background">QBE match:</span> up to
+                    $400,000, at least matched by external capital raised, awarded at the
+                    program&apos;s discretion.
                   </li>
                   <li>
                     <span className="font-semibold text-background">Debt:</span> only where orders,

--- a/v2/src/app/sites/qbe/qbe-site-workspace.tsx
+++ b/v2/src/app/sites/qbe/qbe-site-workspace.tsx
@@ -147,13 +147,13 @@ const evidenceRows: Array<{
   },
   {
     claim: 'QBE Stage 2 match cap',
-    value: '$400K cap',
+    value: 'Up to $400K (program cap)',
     status: 'Guardrail',
     source: MATCH_TARGET.note,
   },
   {
     claim: 'Catalytic ask to close',
-    value: '$400,000 signed match-eligible capital',
+    value: '~$400K signed match-eligible capital',
     status: 'Open',
     source: 'signed commitments required before this can be described as closed',
   },
@@ -707,8 +707,8 @@ export function QbeSiteWorkspace() {
             <div className="grid gap-3 sm:grid-cols-3">
               <div className="rounded-lg border border-white/10 bg-white/5 p-4">
                 <p className="text-xs uppercase tracking-[0.2em] text-[#BBA255]">Catalytic ask</p>
-                <p className="mt-2 text-2xl font-semibold">$400k</p>
-                <p className="mt-1 text-xs text-[#E6DFD1]">QBE match cap, conditional on eligible capital raised first.</p>
+                <p className="mt-2 text-2xl font-semibold">~$400k</p>
+                <p className="mt-1 text-xs text-[#E6DFD1]">Signed match-eligible capital to close. QBE Stage 2 funds up to $400K, at least matched, not secured until awarded.</p>
               </div>
               <div className="rounded-lg border border-white/10 bg-white/5 p-4">
                 <p className="text-xs uppercase tracking-[0.2em] text-[#BBA255]">Cost unlock</p>
@@ -755,7 +755,7 @@ export function QbeSiteWorkspace() {
               </div>
             </div>
             <div className="rounded-lg border border-white/10 bg-white/5 p-4 text-sm leading-6 text-[#E6DFD1]">
-              <span className="font-semibold text-[#FDF8F3]">Verified frame:</span> $750 price, $684.79 current marginal cost, $425.74 factory marginal cost. QBE Stage 2 is a dollar-for-dollar match up to a $400K cap, contingent on eligible capital raised first.
+              <span className="font-semibold text-[#FDF8F3]">Verified frame:</span> $750 price, $684.79 current marginal cost, $425.74 factory marginal cost. QBE Stage 2 funding is up to $400,000, at least matched by external capital raised first, awarded at Steering Committee discretion.
             </div>
           </div>
         </div>
@@ -783,8 +783,8 @@ export function QbeSiteWorkspace() {
           />
           <Metric
             label="Match target"
-            value="$400K cap"
-            sub="QBE Stage 2 match cap. Eligible external capital must be raised first."
+            value="Up to $400K"
+            sub="QBE Stage 2 program cap. Must be at least matched by signed external capital raised first."
             icon={ShieldAlert}
           />
         </div>

--- a/v2/src/lib/data/funder-shared-content.ts
+++ b/v2/src/lib/data/funder-shared-content.ts
@@ -60,14 +60,17 @@ export const BUYER_PIPELINE = [
 ];
 
 export const CAPITAL_STACK = [
-  { layer: 'Match grant', source: 'QBE Foundation Stage 2', amount: '$400K cap', status: 'Conditional on eligible raise', highlight: true },
+  { layer: 'Catalytic blended', source: 'Minderoo (this ask)', amount: '$1.5M', status: 'In conversation', highlight: true },
+  { layer: 'Subordinated debt', source: 'SEFA working capital (BOLD agreement)', amount: '$300K', status: 'In outreach' },
+  { layer: 'Match grant', source: 'QBE Foundation Stage 2', amount: 'Up to $400K', status: 'Conditional on matched raise' },
   { layer: 'To be raised', source: 'Additional philanthropic and community partners', amount: '$1M', status: 'Pipeline' },
+  { layer: 'Guarantee', source: 'Snow Foundation letter of support', amount: '·', status: 'In conversation' },
 ];
 
 export const QBE_PROGRAM = {
   title: 'QBE Catalysing Impact 2026',
   description:
-    "Goods is in the QBE Foundation's blended finance accelerator, run by Social Impact Hub. We were selected on alignment with climate resilience and inclusion. Stage 2 includes a dollar-for-dollar match up to a $400K cap against eligible capital we raise from elsewhere.",
+    "Goods is in the QBE Foundation's blended finance accelerator, run by Social Impact Hub. We were selected on alignment with climate resilience and inclusion. Stage 2 includes funding of up to $400,000 from a $1M pool, which must be at least matched by external capital we raise from elsewhere. Repayable finance is prioritised over grants.",
   contacts: [
     'Lauren at QBE Foundation (climate and inclusion)',
     'Alex at QBE Ventures ($5 to $15M check sizes)',

--- a/v2/src/lib/data/loi-pipeline.ts
+++ b/v2/src/lib/data/loi-pipeline.ts
@@ -90,12 +90,16 @@ export const STAGE_TO_RUNG: Record<string, LoiRung> = {
 };
 
 /**
- * QBE Stage-2 match. CONTINGENT on raising eligible non-QBE capital FIRST.
- * Do not present the match as secured until eligible commitments are signed.
+ * QBE Stage-2 funding. Program cap CONFIRMED at $400K by the Catalysing Impact
+ * 2026 induction deck (31 Mar 2026): up to $400,000 from a $1M shared pool,
+ * must be AT LEAST matched by external capital secured (legally binding
+ * commitments), repayable finance prioritised over grants. Awarded at Steering
+ * Committee discretion — application Sept 2026, outcomes Nov 2026.
+ * Do not present the funding as secured until awarded.
  */
 export const MATCH_TARGET = {
   cap: 400_000,
-  note: 'QBE Stage-2 match is capped at $400K and remains contingent on eligible non-QBE capital being raised first. Keep the raise lanes explicit and do not present match funding as secured until commitments are signed.',
+  note: 'QBE Stage-2 funding is up to $400K (program cap, $1M shared pool) and must be at least matched by signed external commitments raised first. Application Sept 2026, outcomes Nov 2026, Steering Committee discretion. Do not present as secured until awarded.',
 };
 
 /**

--- a/v2/src/lib/data/story-atoms.ts
+++ b/v2/src/lib/data/story-atoms.ts
@@ -49,7 +49,7 @@ export const healthFramings: Record<string, HealthFraming> = {
     ],
     pull: {
       quote: '"Something as simple as a good bed makes a huge difference. It improves their health, helps with mobility, and gives them dignity."',
-      src: 'Chloe · Support worker, Kalgoorlie · cleared voice',
+      src: 'Chloe · Support worker, Kalgoorlie',
     },
   },
   'sleep-and-skin': {

--- a/v2/src/proxy.ts
+++ b/v2/src/proxy.ts
@@ -50,8 +50,12 @@ export async function proxy(request: NextRequest) {
   // Investor cockpit — shared password gate (QBE / investment partners).
   // Same lightweight cookie pattern as /insiders: one shared password, then the
   // live cost-model + investment cockpit. The login page and auth route stay public.
+  // Also covers /sites/qbe (investor-facing capital workspace with unit economics).
   if (
-    (pathname === '/investors' || pathname.startsWith('/investors/')) &&
+    (pathname === '/investors' ||
+      pathname.startsWith('/investors/') ||
+      pathname === '/sites/qbe' ||
+      pathname.startsWith('/sites/qbe/')) &&
     pathname !== '/investors/login' &&
     pathname !== '/api/investors/auth'
   ) {


### PR DESCRIPTION
## Why

Review of the Codex QBE-site PRs (#78–84) surfaced three issues; the Catalysing Impact 2026 induction deck (31 Mar 2026) settled the cap question.

## Changes

**1. Accurate QBE Stage 2 funding terms** (confirmed by the induction deck):
- Up to $400,000 from a $1M shared pool, must be **at least matched** by signed legally-binding external commitments, repayable finance prioritised, Steering Committee discretion, application Sept 2026 / outcomes Nov 2026
- Copy now reads "up to $400,000, at least matched, not secured until awarded" on `/partner`, `funder-shared-content.ts`, `loi-pipeline.ts` (`MATCH_TARGET.cap = 400_000` + program-terms note) and the QBE workspace, replacing flat secured-sounding "$400K cap" phrasing

**2. Capital stack restored** in `funder-shared-content.ts`: Minderoo $1.5M (lead ask), SEFA $300K, Snow guarantee rows were dropped in #84's cleanup; restored alongside the QBE and pipeline rows

**3. `/sites/qbe` gated**: added to the existing investors password gate in `src/proxy.ts` (login at `/investors/login`, cookie shared with `/investors`). The workspace carries detailed unit economics and supplier pricing, so noindex alone wasn't enough

**4. Public-copy cleanup**: dropped the internal "cleared voice" label from Chloe's quote attribution in `story-atoms.ts`

## Verification
- `tsc --noEmit` clean
- No remaining "cap TBC" / "$400K cap" inconsistencies (swept `v2/src`)
- No em dashes introduced in copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)