### PR TITLE
test(purchase-path): guard suites for product types, cart, and checkout (77 tests)

### DIFF
--- a/v2/package-lock.json
+++ b/v2/package-lock.json
@@ -46,11 +46,13 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.1.4",
+        "jsdom": "^29.1.1",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5",
@@ -89,6 +91,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -339,6 +392,159 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.5.tgz",
+      "integrity": "sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -514,6 +720,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -2630,6 +2854,66 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -2640,6 +2924,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3603,6 +3895,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3895,6 +4198,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -4209,6 +4522,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -4343,6 +4670,20 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -4413,6 +4754,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -4526,6 +4874,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.2.4",
@@ -6000,6 +6356,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -6441,6 +6810,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6646,6 +7022,83 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/jsesc": {
@@ -7115,6 +7568,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7425,6 +7889,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -8548,6 +9019,44 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -8981,6 +9490,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -9150,6 +9669,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -9696,6 +10228,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.4.0.tgz",
@@ -9808,6 +10347,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
+      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.2"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9819,6 +10378,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -10048,6 +10633,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
+      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -10790,6 +11385,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -10798,6 +11406,41 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -10952,6 +11595,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/v2/package.json
+++ b/v2/package.json
@@ -55,11 +55,13 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.1.4",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5",

--- a/v2/src/app/api/checkout/route.guards.test.ts
+++ b/v2/src/app/api/checkout/route.guards.test.ts
@@ -1,0 +1,799 @@
+/**
+ * Tests for the POST handler in src/app/api/checkout/route.ts.
+ *
+ * Behaviour derived directly from the route source — we never invent
+ * behaviour. Specifically:
+ *   - 400 "No items in cart" when items is missing or empty.
+ *   - 500 "Failed to validate products" when Supabase returns an error or
+ *     no rows.
+ *   - 400 "Only the Stretch Bed is available for checkout." when ANY cart
+ *     item fails the (dbProduct present) AND (is_active) AND
+ *     (isPurchasableProductType(product_type)) check.
+ *   - DB price authority: unit_amount in the Stripe line items comes from
+ *     the DB row (dbProduct.price_cents), never from the client request.
+ *   - Currency is lowercased before being passed to Stripe.
+ *   - Sponsorship: the product_name gets " (Sponsorship[ for X])" appended
+ *     and the metadata gets is_sponsorship/sponsored_community/dedication_message
+ *     fields (stringified).
+ *   - Image URL is absolutized — relative paths get the request origin
+ *     (or fall back to https://www.goodsoncountry.com when origin is
+ *     localhost) prepended; already-absolute URLs are passed through.
+ *   - success_url uses the request origin (or localhost fallback); cancel_url
+ *     appends /checkout?canceled=true.
+ *   - customerEmail is only attached when present.
+ *   - shipping_address_collection.allowed_countries is ['AU'].
+ *   - billing_address_collection is 'required'.
+ *   - phone_number_collection.enabled is true.
+ *
+ * The route uses `await createClient()` (the server client, which reads
+ * cookies via next/headers) — we mock the whole module so neither the
+ * cookies() helper nor the real Supabase URL is touched.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock next/headers' cookies() so the supabase/server module's createClient
+// can be called in a non-Next-runtime test environment.
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({
+    getAll: () => [],
+    set: () => {},
+  })),
+}));
+
+// Mock the supabase server client. Tests build a chainable `from().select().in()`
+// query builder, returning a controlled { data, error } object.
+const mockFrom = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  })),
+}));
+
+// Mock the stripe module. getStripe() returns an object with a chainable
+// checkout.sessions.create that resolves with a fake session.
+const mockSessionsCreate = vi.fn();
+vi.mock('@/lib/stripe', () => ({
+  getStripe: vi.fn(() => ({
+    checkout: {
+      sessions: {
+        create: (...args: unknown[]) => mockSessionsCreate(...args),
+      },
+    },
+  })),
+}));
+
+import { POST } from './route';
+import { NextRequest } from 'next/server';
+import { STRETCH_BED, WASHING_MACHINE } from '@/lib/data/products';
+
+// --- Test helpers ----------------------------------------------------------
+
+const STRETCH_BED_DB_ROW = {
+  id: 'db-stretch-bed-1',
+  name: STRETCH_BED.name,
+  price_cents: 75000, // DB-canonical price ($750.00)
+  currency: 'AUD',
+  product_type: STRETCH_BED.productType,
+  is_active: true,
+};
+
+const WASHING_MACHINE_DB_ROW = {
+  id: 'db-washer-1',
+  name: WASHING_MACHINE.name,
+  price_cents: 999,
+  currency: 'AUD',
+  product_type: WASHING_MACHINE.productType,
+  is_active: true,
+};
+
+function makeRequest(
+  body: unknown,
+  origin = 'https://www.goodsoncountry.com'
+): NextRequest {
+  return new NextRequest('https://www.goodsoncountry.com/api/checkout', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupSupabase(rows: unknown[] | null, error: unknown = null) {
+  // Build a chainable query builder: from(table).select(cols).in(col, vals)
+  // returns { data, error }.
+  const inFn = vi.fn().mockResolvedValue({ data: rows, error });
+  const select = vi.fn().mockReturnValue({ in: inFn });
+  const fromFn = vi.fn().mockReturnValue({ select });
+  mockFrom.mockImplementation(fromFn);
+  return { fromFn, select, inFn };
+}
+
+beforeEach(() => {
+  mockFrom.mockReset();
+  mockSessionsCreate.mockReset();
+  // Default: a successful session
+  mockSessionsCreate.mockResolvedValue({
+    id: 'cs_test_123',
+    url: 'https://checkout.stripe.com/c/pay/cs_test_123',
+  });
+});
+
+// --- Guard: empty / malformed cart -----------------------------------------
+
+describe('POST /api/checkout — empty / malformed cart', () => {
+  it('returns 400 "No items in cart" when items is missing', async () => {
+    setupSupabase([]);
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('No items in cart');
+    // We must NOT touch the DB or Stripe if the cart is empty.
+    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockSessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 "No items in cart" when items is an empty array', async () => {
+    setupSupabase([]);
+    const res = await POST(makeRequest({ items: [] }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('No items in cart');
+    expect(mockFrom).not.toHaveBeenCalled();
+    expect(mockSessionsCreate).not.toHaveBeenCalled();
+  });
+});
+
+// --- Guard: non-purchasable product types ----------------------------------
+
+describe('POST /api/checkout — product-type guard', () => {
+  it('rejects a washing_machine line with 400 "Only the Stretch Bed is available for checkout."', async () => {
+    setupSupabase([WASHING_MACHINE_DB_ROW]);
+    const res = await POST(
+      makeRequest({
+        items: [
+          {
+            id: WASHING_MACHINE_DB_ROW.id,
+            slug: WASHING_MACHINE.slug,
+            name: WASHING_MACHINE.name,
+            price_cents: 1, // client claims $0.01 — should not matter
+            currency: 'AUD',
+            product_type: WASHING_MACHINE.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe(
+      'Only the Stretch Bed is available for checkout.'
+    );
+    expect(mockSessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a cart that mixes stretch_bed with a non-purchasable item', async () => {
+    // Both items come back from the DB. The washer row is active and
+    // present, but its product_type fails the isPurchasableProductType
+    // check, so the whole cart is rejected.
+    setupSupabase([STRETCH_BED_DB_ROW, WASHING_MACHINE_DB_ROW]);
+    const res = await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+          {
+            id: WASHING_MACHINE_DB_ROW.id,
+            slug: WASHING_MACHINE.slug,
+            name: WASHING_MACHINE.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: WASHING_MACHINE.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockSessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an item whose id is not present in the products table', async () => {
+    // DB returns nothing for the requested ids — invalidItems picks up the
+    // missing-product condition (dbProduct is undefined).
+    setupSupabase([]);
+    const res = await POST(
+      makeRequest({
+        items: [
+          {
+            id: 'ghost-id-not-in-db',
+            slug: 'ghost',
+            name: 'Ghost',
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockSessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects an item whose DB row is_active = false', async () => {
+    setupSupabase([{ ...STRETCH_BED_DB_ROW, is_active: false }]);
+    const res = await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockSessionsCreate).not.toHaveBeenCalled();
+  });
+});
+
+// --- Guard: Supabase failure -----------------------------------------------
+
+describe('POST /api/checkout — Supabase failure', () => {
+  it('returns 500 "Failed to validate products" when Supabase returns an error', async () => {
+    setupSupabase(null, { message: 'db down' });
+    const res = await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to validate products');
+    expect(mockSessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 "Failed to validate products" when Supabase returns no data', async () => {
+    setupSupabase(null, null);
+    const res = await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+// --- DB-price authority (the headline hardening) ---------------------------
+
+describe('POST /api/checkout — DB price authority', () => {
+  it('uses the database price, ignoring the client-supplied price_cents', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]); // DB says 75000
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1, // client tries to pay $0.01
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    expect(mockSessionsCreate).toHaveBeenCalledTimes(1);
+    const stripeArgs = mockSessionsCreate.mock.calls[0][0];
+    expect(stripeArgs.line_items[0].price_data.unit_amount).toBe(75000);
+  });
+
+  it('rejects a zero-priced client even if the DB has a valid row (DB is the source of truth)', async () => {
+    // Client sets price to 0. DB still has 75000. The line item gets 75000
+    // from the DB. The point of this test: the client price is NEVER read.
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 0,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 3,
+          },
+        ],
+      })
+    );
+    const stripeArgs = mockSessionsCreate.mock.calls[0][0];
+    expect(stripeArgs.line_items[0].price_data.unit_amount).toBe(75000);
+    expect(stripeArgs.line_items[0].quantity).toBe(3); // quantity is client-supplied (no DB column for it)
+  });
+
+  it('uses the DB currency lowercased, not the client currency', async () => {
+    setupSupabase([{ ...STRETCH_BED_DB_ROW, currency: 'AUD' }]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'usd', // client lies about currency
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    const stripeArgs = mockSessionsCreate.mock.calls[0][0];
+    expect(stripeArgs.line_items[0].price_data.currency).toBe('aud');
+  });
+});
+
+// --- Happy path: Stripe session construction -------------------------------
+
+describe('POST /api/checkout — happy path', () => {
+  it('creates a Stripe checkout session and returns { sessionId, url }', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    const res = await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 2,
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({
+      sessionId: 'cs_test_123',
+      url: 'https://checkout.stripe.com/c/pay/cs_test_123',
+    });
+  });
+
+  it('builds a line item with DB price, quantity, product name, and metadata', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 4,
+          },
+        ],
+      })
+    );
+    const args = mockSessionsCreate.mock.calls[0][0];
+    const line = args.line_items[0];
+    expect(line).toMatchObject({
+      price_data: {
+        currency: 'aud',
+        product_data: {
+          name: STRETCH_BED.name,
+          metadata: {
+            product_id: STRETCH_BED_DB_ROW.id,
+            product_type: STRETCH_BED.productType,
+            is_sponsorship: 'false',
+            sponsored_community: '',
+            dedication_message: '',
+          },
+        },
+        unit_amount: 75000,
+      },
+      quantity: 4,
+    });
+  });
+
+  it('sends mode=payment, AU-only shipping, required billing address, phone collection', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    const args = mockSessionsCreate.mock.calls[0][0];
+    expect(args.mode).toBe('payment');
+    expect(args.payment_method_types).toEqual(['card']);
+    expect(args.billing_address_collection).toBe('required');
+    expect(args.phone_number_collection).toEqual({ enabled: true });
+    expect(args.shipping_address_collection).toEqual({
+      allowed_countries: ['AU'],
+    });
+  });
+
+  it('omits customer_email when not provided', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    const args = mockSessionsCreate.mock.calls[0][0];
+    expect(args).not.toHaveProperty('customer_email');
+  });
+
+  it('passes customer_email through when provided', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        customerEmail: 'buyer@example.com',
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    const args = mockSessionsCreate.mock.calls[0][0];
+    expect(args.customer_email).toBe('buyer@example.com');
+  });
+
+  it('builds success_url and cancel_url from the request origin', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest(
+        {
+          items: [
+            {
+              id: STRETCH_BED_DB_ROW.id,
+              slug: STRETCH_BED.slug,
+              name: STRETCH_BED.name,
+              price_cents: 1,
+              currency: 'AUD',
+              product_type: STRETCH_BED.productType,
+              quantity: 1,
+            },
+          ],
+        },
+        'https://shop.goodsoncountry.com'
+      )
+    );
+    const args = mockSessionsCreate.mock.calls[0][0];
+    expect(args.success_url).toBe(
+      'https://shop.goodsoncountry.com/checkout/success?session_id={CHECKOUT_SESSION_ID}'
+    );
+    expect(args.cancel_url).toBe(
+      'https://shop.goodsoncountry.com/checkout?canceled=true'
+    );
+  });
+
+  it('embeds the order metadata (items list, ids, quantities) as a string', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 3,
+          },
+        ],
+      })
+    );
+    const args = mockSessionsCreate.mock.calls[0][0];
+    expect(args.metadata).toBeDefined();
+    expect(typeof args.metadata.items).toBe('string');
+    const parsed = JSON.parse(args.metadata.items);
+    expect(parsed).toEqual([
+      {
+        id: STRETCH_BED_DB_ROW.id,
+        slug: STRETCH_BED.slug,
+        quantity: 3,
+        product_type: STRETCH_BED.productType,
+        is_sponsorship: undefined,
+        sponsored_community: undefined,
+        dedication_message: undefined,
+      },
+    ]);
+  });
+});
+
+// --- Sponsorship: name + metadata passthrough -----------------------------
+
+describe('POST /api/checkout — sponsorship', () => {
+  it('appends " (Sponsorship for <community>)" to the product name', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+            is_sponsorship: true,
+            sponsored_community: 'Utopia',
+            dedication_message: 'In memory of Auntie',
+          },
+        ],
+      })
+    );
+    const line = mockSessionsCreate.mock.calls[0][0].line_items[0];
+    expect(line.price_data.product_data.name).toBe(
+      `${STRETCH_BED.name} (Sponsorship for Utopia)`
+    );
+    expect(line.price_data.product_data.metadata).toMatchObject({
+      is_sponsorship: 'true',
+      sponsored_community: 'Utopia',
+      dedication_message: 'In memory of Auntie',
+    });
+  });
+
+  it('handles the "-sponsor-" id suffix by stripping it for the DB lookup', async () => {
+    // Client sends id "db-stretch-bed-1-sponsor-someCommunity" — the route
+    // splits on "-sponsor-" and looks up "db-stretch-bed-1" in the DB.
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    const res = await POST(
+      makeRequest({
+        items: [
+          {
+            id: `${STRETCH_BED_DB_ROW.id}-sponsor-Utopia`,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+            is_sponsorship: true,
+            sponsored_community: 'Utopia',
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(200);
+    // The .in() call should have been called with the stripped id.
+    const inFn = mockFrom.mock.results[0].value.select.mock.results[0].value.in;
+    expect(inFn).toHaveBeenCalledWith('id', [STRETCH_BED_DB_ROW.id]);
+  });
+});
+
+// --- Image URL absolutization ----------------------------------------------
+
+describe('POST /api/checkout — image URL absolutization', () => {
+  it('prepends the request origin to a relative image path', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+            image: '/images/stretch-bed.png',
+          },
+        ],
+      })
+    );
+    const line = mockSessionsCreate.mock.calls[0][0].line_items[0];
+    expect(line.price_data.product_data.images).toEqual([
+      'https://www.goodsoncountry.com/images/stretch-bed.png',
+    ]);
+  });
+
+  it('passes an already-absolute image URL through unchanged', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+            image: 'https://cdn.example.com/bed.png',
+          },
+        ],
+      })
+    );
+    const line = mockSessionsCreate.mock.calls[0][0].line_items[0];
+    expect(line.price_data.product_data.images).toEqual([
+      'https://cdn.example.com/bed.png',
+    ]);
+  });
+
+  it('omits the images array when the client did not provide an image', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    const line = mockSessionsCreate.mock.calls[0][0].line_items[0];
+    expect(line.price_data.product_data).not.toHaveProperty('images');
+  });
+
+  it('falls back to https://www.goodsoncountry.com when the origin is localhost', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest(
+        {
+          items: [
+            {
+              id: STRETCH_BED_DB_ROW.id,
+              slug: STRETCH_BED.slug,
+              name: STRETCH_BED.name,
+              price_cents: 1,
+              currency: 'AUD',
+              product_type: STRETCH_BED.productType,
+              quantity: 1,
+              image: '/images/bed.png',
+            },
+          ],
+        },
+        'http://localhost:3000'
+      )
+    );
+    const line = mockSessionsCreate.mock.calls[0][0].line_items[0];
+    expect(line.price_data.product_data.images).toEqual([
+      'https://www.goodsoncountry.com/images/bed.png',
+    ]);
+  });
+});
+
+// --- DB query shape -------------------------------------------------------
+
+describe('POST /api/checkout — DB query shape', () => {
+  it('queries products with the expected column projection and id .in() filter', async () => {
+    const { select, inFn } = setupSupabase([STRETCH_BED_DB_ROW]);
+    await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    expect(mockFrom).toHaveBeenCalledWith('products');
+    expect(select).toHaveBeenCalledWith(
+      'id, name, price_cents, currency, product_type, is_active'
+    );
+    expect(inFn).toHaveBeenCalledWith('id', [STRETCH_BED_DB_ROW.id]);
+  });
+});
+
+// --- Catch-all error path -------------------------------------------------
+
+describe('POST /api/checkout — error path', () => {
+  it('returns 500 "Failed to create checkout session" when Stripe throws', async () => {
+    setupSupabase([STRETCH_BED_DB_ROW]);
+    mockSessionsCreate.mockRejectedValueOnce(new Error('stripe down'));
+    const res = await POST(
+      makeRequest({
+        items: [
+          {
+            id: STRETCH_BED_DB_ROW.id,
+            slug: STRETCH_BED.slug,
+            name: STRETCH_BED.name,
+            price_cents: 1,
+            currency: 'AUD',
+            product_type: STRETCH_BED.productType,
+            quantity: 1,
+          },
+        ],
+      })
+    );
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to create checkout session');
+  });
+
+  it('returns 500 when the request body is not valid JSON', async () => {
+    const req = new NextRequest(
+      'https://www.goodsoncountry.com/api/checkout',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{ not valid json',
+      }
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to create checkout session');
+  });
+});

--- a/v2/src/lib/cart/context.test.ts
+++ b/v2/src/lib/cart/context.test.ts
@@ -1,0 +1,431 @@
+// @vitest-environment jsdom
+//
+// Tests for the cart context in src/lib/cart/context.tsx.
+//
+// NOTE on filename: the task spec asked for context.test.tsx, but the
+// locked vitest config (vitest.config.ts) only picks up files matching
+// the .test.ts glob. We ship as .test.ts and use React.createElement
+// instead of JSX so the file is actually runnable under the locked
+// include glob. (Also noted in CALIBRATION-NOTES.md.)
+//
+// Behaviour derived from the source:
+//   - addItem: rejects non-purchasable product types (returns state unchanged).
+//   - addItem: if (id, is_sponsorship, sponsored_community) all match an
+//     existing item, merges by summing quantities; otherwise appends.
+//   - updateQuantity: <= 0 removes the item; > 0 sets the new quantity.
+//   - removeItem: filters by id.
+//   - clearCart: empties items.
+//   - itemCount = sum(quantity). subtotal = sum(price_cents * quantity).
+//   - localStorage persistence: write-through on every items change;
+//     on mount, loads + filters out non-purchasable product types.
+//
+// The provider uses two effects (one for load, one for save). Tests wait
+// for these to settle with act() and a microtask flush.
+import { createElement, type ReactNode } from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { CartProvider, useCart, type CartItem } from './context';
+import { STRETCH_BED, WASHING_MACHINE, BASKET_BED } from '@/lib/data/products';
+
+const CART_STORAGE_KEY = 'goods-cart';
+
+const baseItem = (
+  overrides: Partial<Omit<CartItem, 'quantity'>> = {}
+): Omit<CartItem, 'quantity'> => ({
+  id: 'stretch-bed-uuid-1',
+  slug: STRETCH_BED.slug,
+  name: STRETCH_BED.name,
+  price_cents: 75000, // $750.00
+  currency: 'AUD',
+  product_type: STRETCH_BED.productType,
+  ...overrides,
+});
+
+// Wrap the provider so renderHook can use it as a wrapper.
+// Using createElement (no JSX) so the file is valid `.ts` and matches the
+// locked vitest include glob of `*.test.ts`.
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(CartProvider, null, children);
+}
+
+const setup = () => renderHook(() => useCart(), { wrapper });
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CartProvider — initial state', () => {
+  it('starts with empty items and a closed cart UI', () => {
+    const { result } = setup();
+    expect(result.current.state.items).toEqual([]);
+    expect(result.current.state.isOpen).toBe(false);
+    expect(result.current.itemCount).toBe(0);
+    expect(result.current.subtotal).toBe(0);
+  });
+});
+
+describe('addItem', () => {
+  it('appends a purchasable item (stretch_bed) to the cart', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem());
+    });
+    expect(result.current.state.items).toHaveLength(1);
+    expect(result.current.state.items[0].quantity).toBe(1);
+    expect(result.current.itemCount).toBe(1);
+    expect(result.current.subtotal).toBe(75000);
+  });
+
+  it('uses the provided quantity when adding a new item', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem(), 3);
+    });
+    expect(result.current.state.items[0].quantity).toBe(3);
+    expect(result.current.itemCount).toBe(3);
+    expect(result.current.subtotal).toBe(75000 * 3);
+  });
+
+  it('rejects washing_machine and leaves the cart unchanged', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(
+        baseItem({
+          id: 'wm-1',
+          product_type: WASHING_MACHINE.productType,
+          name: WASHING_MACHINE.name,
+        })
+      );
+    });
+    expect(result.current.state.items).toEqual([]);
+    expect(result.current.itemCount).toBe(0);
+  });
+
+  it('rejects basket_bed and leaves the cart unchanged', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(
+        baseItem({
+          id: 'bb-1',
+          product_type: BASKET_BED.productType,
+          name: BASKET_BED.name,
+        })
+      );
+    });
+    expect(result.current.state.items).toEqual([]);
+  });
+
+  it('rejects weave_bed (discontinued) and leaves the cart unchanged', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem({ product_type: 'weave_bed' }));
+    });
+    expect(result.current.state.items).toEqual([]);
+  });
+
+  it('merges quantity when the same id + sponsorship + community is added again', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem(), 2);
+    });
+    act(() => {
+      result.current.addItem(baseItem(), 3); // same id, default is_sponsorship=undefined
+    });
+    expect(result.current.state.items).toHaveLength(1);
+    expect(result.current.state.items[0].quantity).toBe(5);
+    expect(result.current.itemCount).toBe(5);
+  });
+
+  it('does NOT merge when sponsored_community differs (sponsorship per community)', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(
+        baseItem({ is_sponsorship: true, sponsored_community: 'Utopia' }),
+        1
+      );
+    });
+    act(() => {
+      result.current.addItem(
+        baseItem({ is_sponsorship: true, sponsored_community: 'Ali Curung' }),
+        1
+      );
+    });
+    expect(result.current.state.items).toHaveLength(2);
+  });
+
+  it('does NOT merge when is_sponsorship flips', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem(), 1); // regular purchase
+    });
+    act(() => {
+      result.current.addItem(
+        baseItem({ is_sponsorship: true, sponsored_community: 'Utopia' }),
+        1
+      );
+    });
+    expect(result.current.state.items).toHaveLength(2);
+  });
+
+  it('appends a separate line when id differs', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem({ id: 'a' }), 1);
+    });
+    act(() => {
+      result.current.addItem(baseItem({ id: 'b' }), 1);
+    });
+    expect(result.current.state.items).toHaveLength(2);
+  });
+});
+
+describe('updateQuantity', () => {
+  it('sets the new quantity for the matching id', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem(), 1);
+    });
+    act(() => {
+      result.current.updateQuantity(result.current.state.items[0].id, 4);
+    });
+    expect(result.current.state.items[0].quantity).toBe(4);
+    expect(result.current.subtotal).toBe(75000 * 4);
+  });
+
+  it('removes the item when quantity is set to 0', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem(), 1);
+    });
+    act(() => {
+      result.current.updateQuantity(result.current.state.items[0].id, 0);
+    });
+    expect(result.current.state.items).toEqual([]);
+    expect(result.current.itemCount).toBe(0);
+    expect(result.current.subtotal).toBe(0);
+  });
+
+  it('removes the item when quantity is negative', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem(), 1);
+    });
+    act(() => {
+      result.current.updateQuantity(result.current.state.items[0].id, -1);
+    });
+    expect(result.current.state.items).toEqual([]);
+  });
+
+  it('only updates the matching id, leaves other items alone', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem({ id: 'a' }), 1);
+    });
+    act(() => {
+      result.current.addItem(baseItem({ id: 'b' }), 2);
+    });
+    act(() => {
+      result.current.updateQuantity('a', 5);
+    });
+    const a = result.current.state.items.find((i) => i.id === 'a')!;
+    const b = result.current.state.items.find((i) => i.id === 'b')!;
+    expect(a.quantity).toBe(5);
+    expect(b.quantity).toBe(2);
+  });
+});
+
+describe('removeItem', () => {
+  it('removes the item with the given id', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem({ id: 'a' }), 1);
+    });
+    act(() => {
+      result.current.addItem(baseItem({ id: 'b' }), 1);
+    });
+    act(() => {
+      result.current.removeItem('a');
+    });
+    expect(result.current.state.items).toHaveLength(1);
+    expect(result.current.state.items[0].id).toBe('b');
+  });
+
+  it('is a no-op when the id is not present', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem(), 1);
+    });
+    act(() => {
+      result.current.removeItem('nonexistent');
+    });
+    expect(result.current.state.items).toHaveLength(1);
+  });
+});
+
+describe('clearCart', () => {
+  it('empties all items but keeps the cart UI closed-state intact', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem(), 1);
+    });
+    act(() => {
+      result.current.addItem(baseItem({ id: 'b' }), 1);
+    });
+    act(() => {
+      result.current.clearCart();
+    });
+    expect(result.current.state.items).toEqual([]);
+    expect(result.current.itemCount).toBe(0);
+    expect(result.current.subtotal).toBe(0);
+  });
+});
+
+describe('cart UI (open/close/toggle)', () => {
+  it('toggleCart flips isOpen', () => {
+    const { result } = setup();
+    expect(result.current.state.isOpen).toBe(false);
+    act(() => result.current.toggleCart());
+    expect(result.current.state.isOpen).toBe(true);
+    act(() => result.current.toggleCart());
+    expect(result.current.state.isOpen).toBe(false);
+  });
+
+  it('openCart / closeCart are idempotent', () => {
+    const { result } = setup();
+    act(() => result.current.openCart());
+    act(() => result.current.openCart());
+    expect(result.current.state.isOpen).toBe(true);
+    act(() => result.current.closeCart());
+    act(() => result.current.closeCart());
+    expect(result.current.state.isOpen).toBe(false);
+  });
+});
+
+describe('derived totals', () => {
+  it('subtotal = sum(price_cents * quantity) across items', () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem({ id: 'a', price_cents: 1000 }), 2);
+    });
+    act(() => {
+      result.current.addItem(baseItem({ id: 'b', price_cents: 2500 }), 3);
+    });
+    expect(result.current.subtotal).toBe(1000 * 2 + 2500 * 3);
+    expect(result.current.itemCount).toBe(5);
+  });
+});
+
+describe('useCart', () => {
+  it('throws when used outside a CartProvider', () => {
+    expect(() => renderHook(() => useCart())).toThrow(
+      /useCart must be used within a CartProvider/
+    );
+  });
+});
+
+describe('localStorage persistence', () => {
+  it('writes the cart to localStorage as JSON on every change', async () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem(), 2);
+    });
+    // The save effect runs in a useEffect — wait a microtask for it to fire.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const stored = JSON.parse(localStorage.getItem(CART_STORAGE_KEY) || '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].quantity).toBe(2);
+    expect(stored[0].product_type).toBe(STRETCH_BED.productType);
+  });
+
+  it('clears localStorage when the cart is cleared', async () => {
+    const { result } = setup();
+    act(() => {
+      result.current.addItem(baseItem(), 1);
+    });
+    act(() => {
+      result.current.clearCart();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(JSON.parse(localStorage.getItem(CART_STORAGE_KEY) || '[]')).toEqual([]);
+  });
+
+  it('loads a valid persisted cart on mount', () => {
+    const persisted = [
+      {
+        id: 'persisted-1',
+        slug: STRETCH_BED.slug,
+        name: STRETCH_BED.name,
+        price_cents: 50000,
+        currency: 'AUD',
+        quantity: 2,
+        product_type: STRETCH_BED.productType,
+      },
+    ];
+    localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(persisted));
+    const { result } = setup();
+    expect(result.current.state.items).toHaveLength(1);
+    expect(result.current.state.items[0].id).toBe('persisted-1');
+    expect(result.current.state.items[0].quantity).toBe(2);
+    expect(result.current.subtotal).toBe(50000 * 2);
+  });
+
+  it('filters out non-purchasable product types on load', () => {
+    const persisted = [
+      {
+        id: 'good-1',
+        slug: STRETCH_BED.slug,
+        name: STRETCH_BED.name,
+        price_cents: 75000,
+        currency: 'AUD',
+        quantity: 1,
+        product_type: STRETCH_BED.productType,
+      },
+      {
+        id: 'bad-1',
+        slug: WASHING_MACHINE.slug,
+        name: WASHING_MACHINE.name,
+        price_cents: 999,
+        currency: 'AUD',
+        quantity: 1,
+        product_type: WASHING_MACHINE.productType,
+      },
+      {
+        id: 'bad-2',
+        slug: BASKET_BED.slug,
+        name: BASKET_BED.name,
+        price_cents: 999,
+        currency: 'AUD',
+        quantity: 1,
+        product_type: BASKET_BED.productType,
+      },
+    ];
+    localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(persisted));
+    const { result } = setup();
+    // Only the stretch_bed item survives the filter.
+    expect(result.current.state.items).toHaveLength(1);
+    expect(result.current.state.items[0].id).toBe('good-1');
+  });
+
+  it('swallows malformed JSON in localStorage and starts empty', () => {
+    localStorage.setItem(CART_STORAGE_KEY, 'this is not json{{{');
+    const { result } = setup();
+    expect(result.current.state.items).toEqual([]);
+    // The provider calls console.error on the catch — verify it didn't crash.
+    expect(result.current.subtotal).toBe(0);
+  });
+
+  it('treats an absent stored value as an empty cart', () => {
+    // No key set at all — same as an empty array.
+    const { result } = setup();
+    expect(result.current.state.items).toEqual([]);
+  });
+});

--- a/v2/src/lib/data/products.guards.test.ts
+++ b/v2/src/lib/data/products.guards.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the purchasable-product guard in src/lib/data/products.ts.
+ *
+ * These are canon invariants — they lock the contract that the rest of the
+ * purchase path (cart context, checkout API) depends on. Behaviour derived
+ * directly from the source:
+ *
+ *   - PURCHASABLE_PRODUCT_TYPES = [STRETCH_BED.productType]
+ *   - isPurchasableProductType(x) === (x === STRETCH_BED.productType)
+ *
+ * Expectations are written against the exported constants — if a new
+ * purchasable product is ever added, the "exactly one purchasable type"
+ * invariant and the "equals STRETCH_BED.productType" invariant will both
+ * fail loudly, which is the point.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isPurchasableProductType,
+  PURCHASABLE_PRODUCT_TYPES,
+  STRETCH_BED,
+  WASHING_MACHINE,
+  BASKET_BED,
+} from './products';
+
+describe('isPurchasableProductType', () => {
+  describe('accepts the Stretch Bed product type', () => {
+    it('returns true for STRETCH_BED.productType', () => {
+      expect(isPurchasableProductType(STRETCH_BED.productType)).toBe(true);
+    });
+
+    it('returns true for the raw "stretch_bed" string', () => {
+      expect(isPurchasableProductType('stretch_bed')).toBe(true);
+    });
+  });
+
+  describe('rejects non-purchasable product types', () => {
+    it('rejects washing_machine', () => {
+      expect(isPurchasableProductType(WASHING_MACHINE.productType)).toBe(false);
+      expect(isPurchasableProductType('washing_machine')).toBe(false);
+    });
+
+    it('rejects basket_bed', () => {
+      expect(isPurchasableProductType(BASKET_BED.productType)).toBe(false);
+      expect(isPurchasableProductType('basket_bed')).toBe(false);
+    });
+
+    it('rejects the discontinued weave_bed slug', () => {
+      // The Weave Bed is discontinued (see CLAUDE.md). Both the camelCase
+      // and snake_case variants must be rejected — anything that looks like
+      // a stretch-bed variant but uses an old slug should fail closed.
+      expect(isPurchasableProductType('weave_bed')).toBe(false);
+      expect(isPurchasableProductType('weave-bed')).toBe(false);
+    });
+  });
+
+  describe('rejects arbitrary / non-string inputs', () => {
+    it.each([
+      ['empty string', ''],
+      ['uppercase STRETCH_BED', 'STRETCH_BED'],
+      ['mixed-case Stretch_Bed', 'Stretch_Bed'],
+      ['whitespace-padded stretch_bed', ' stretch_bed'],
+      ['whitespace-padded (trailing)', 'stretch_bed '],
+      ['looks-similar "stretchbed"', 'stretchbed'],
+      ['looks-similar "stretch-bed"', 'stretch-bed'],
+      ['unknown product', 'rocket_ship'],
+      ['sql injection-y', "stretch_bed' OR '1'='1"],
+      ['numeric string', '1'],
+    ])('rejects %s', (_label, value) => {
+      expect(isPurchasableProductType(value)).toBe(false);
+    });
+  });
+
+  describe('rejects null and undefined (the whole point of the guard)', () => {
+    it('rejects null', () => {
+      expect(isPurchasableProductType(null)).toBe(false);
+    });
+
+    it('rejects undefined', () => {
+      expect(isPurchasableProductType(undefined)).toBe(false);
+    });
+  });
+
+  describe('type-narrowing behaviour', () => {
+    it('acts as a type predicate: true branch narrows to PurchasableProductType', () => {
+      // This is a compile-time check — we exercise it at runtime by feeding
+      // the result back through a function that requires PurchasableProductType.
+      const value: string | null = STRETCH_BED.productType;
+      if (isPurchasableProductType(value)) {
+        // value is now PurchasableProductType ('stretch_bed')
+        expect(value).toBe('stretch_bed');
+      } else {
+        throw new Error('expected the type predicate to be true for stretch_bed');
+      }
+    });
+  });
+});
+
+describe('PURCHASABLE_PRODUCT_TYPES (canon invariant)', () => {
+  it('contains exactly one product type', () => {
+    expect(PURCHASABLE_PRODUCT_TYPES).toHaveLength(1);
+  });
+
+  it('the only purchasable product type is stretch_bed', () => {
+    expect(PURCHASABLE_PRODUCT_TYPES[0]).toBe('stretch_bed');
+  });
+
+  it('exactly matches STRETCH_BED.productType', () => {
+    // This is the stronger invariant: the const array and the const object
+    // must agree. If someone changes STRETCH_BED.productType without updating
+    // the array (or vice versa), this test catches the drift.
+    expect(PURCHASABLE_PRODUCT_TYPES).toEqual([STRETCH_BED.productType]);
+  });
+
+  it('isPurchasableProductType is consistent with the array', () => {
+    for (const t of PURCHASABLE_PRODUCT_TYPES) {
+      expect(isPurchasableProductType(t)).toBe(true);
+    }
+  });
+
+  it('isPurchasableProductType rejects every other known product type', () => {
+    const others = [WASHING_MACHINE.productType, BASKET_BED.productType, 'weave_bed'];
+    for (const t of others) {
+      expect(isPurchasableProductType(t)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## What

Guard coverage for the purchase path, the only place real money moves on the site. 77 new tests across three suites; all 188 tests green (incl. the existing cost-model 111); `tsc --noEmit` clean; zero source changes.

| Suite | Tests | Locks |
|---|---|---|
| `products.guards.test.ts` | 23 | Only the Stretch Bed is purchasable; washers / basket beds / `weave_bed` / junk inputs rejected; exactly one purchasable type exists |
| `cart/context.test.ts` | 27 | Add/merge/quantity/remove/clear/totals, UI state, localStorage persistence incl. malformed JSON + non-purchasable filtering on load |
| `checkout/route.guards.test.ts` | 27 | **DB price authority proven**: tampered client `price_cents` is never read, Stripe receives the DB amount. Plus: empty/malformed cart 400s, non-purchasable 400s, sponsorship handling, image URL absolutization, error paths (Stripe + Supabase mocked) |

Adds `@testing-library/react` + `jsdom` devDependencies. Cart tests are `.test.ts` (React.createElement, no JSX) because the vitest include pattern only picks up `.test.ts`.

## Why

PR #72 hardened these guards (DB-price authority, `isPurchasableProductType`); until now nothing would catch a regression in them. These suites make the hardening permanent.

## Source observations (documented, NOT changed)

1. `addItem(item, 0)` adds a zero-quantity line (only `updateQuantity` clamps)
2. Single outer try/catch makes JSON-parse and Stripe errors indistinguishable to clients
3. No quantity cap per line/order (price is DB-authoritative, so cost is correct, but 10,000-bed checkouts are possible)
4. `customerEmail` not format-validated before Stripe
5. Strict `===` type matching now locked; lenient-matching changes will fail loudly

## Provenance

Generated by a sandboxed MiniMax M3 worker (run 2 of the calibrated pool), independently verified: vitest re-run (188/188), tsc re-run, scope audited (zero source modifications), tamper test traced to assertion.

## Test plan

- [x] `npx vitest run` → 188/188
- [x] `npx tsc --noEmit` → clean
- [x] Additive only — no app code touched