### PR TITLE
fix(canon): restate compendium financials to the 2026-06-03 reconcile

### DIFF
--- a/v2/src/lib/data/compendium.ts
+++ b/v2/src/lib/data/compendium.ts
@@ -307,12 +307,21 @@ export function getFundingSummary() {
 
 export const verifiedFinancials = {
   status: 'verified - not audited' as const,
-  lastUpdated: '2026-05-29',
-  // Revenue billed (all ACCREC raised, voided excluded) vs cash actually received.
+  lastUpdated: '2026-06-03',
+  // Revenue billed: 2026-05-29 ACCREC-raised figure (voided excluded). NOT restated by the
+  // 2026-06-03 reconcile (which restated cash received, not billings); kept for reference,
+  // no consumers. Different scope to revenueReceived below, so do not compare the two.
   revenueBilled: 732_210.79,
-  revenueReceived: 649_710.79,
-  // Accounts receivable: Rotary INV-0222 ($82,500) is the only open receivable.
-  accountsReceivable: 82_500,
+  // Cash received since inception, restated 2026-06-03 live-Xero reconcile: Snow $493,130
+  // (incl. 2024 receipts) + Centrecorp $123,332 + VFFF $50,000 + QIC $12,000 + Villiers
+  // $1,200 + commercial $61,449. PICC and other Marchesi-project contacts excluded.
+  // Must match FUNDING_CANON.totalReceived in grant-content.ts.
+  // See wiki/outputs/2026-06-03-cluster2-xero-reconciliation.md.
+  revenueReceived: 741_111,
+  // Accounts receivable, restated 2026-06-03: Rotary INV-0222 $82,500 + Homeland INV-0303
+  // $44,000 + Regional Arts INV-0302 $16,500 (all live authorised in Xero).
+  // Must match FUNDING_CANON.totalReceivables in grant-content.ts.
+  accountsReceivable: 143_000,
   // Accounts payable: ~$0 owed. Authorised-but-unpaid bills are a Xero payment-
   // matching gap (paid from ACT business accounts, payment never applied to the
   // bill), NOT debt. No director loan.
@@ -330,7 +339,8 @@ export const verifiedFinancials = {
  * @deprecated Use `verifiedFinancials`. Kept as a thin compatibility shim mapping
  * the old field names onto the verified figures so any un-migrated consumer reads
  * correct numbers. `tradeRevenue` now points at cash received; `productionPlant-
- * Investment` at verified capex; `outstandingReceivables` at the single open AR.
+ * Investment` at verified capex; `outstandingReceivables` at the restated AR total
+ * (Rotary + Homeland + Regional Arts).
  */
 export const financialSnapshot = {
   lastUpdated: verifiedFinancials.lastUpdated,
@@ -348,7 +358,7 @@ export interface CommunityDeployment {
   id: string;
   community: string;
   traditionalName?: string;
-  state: 'NT' | 'QLD' | 'WA' | 'SA';
+  state: 'NT' | 'QLD' | 'WA' | 'SA' | 'ACT';
   beds: number;
   washers: number;
   status: 'active' | 'testing' | 'exploring';
@@ -373,7 +383,7 @@ export const deployments: CommunityDeployment[] = [
   { id: 'utopia', community: 'Utopia Homelands', state: 'NT', beds: 147, washers: 0, status: 'active', partner: 'Oonchiumpa' },
   { id: 'mt-isa', community: 'Mt Isa', traditionalName: 'Kalkadoon', state: 'QLD', beds: 2, washers: 0, status: 'testing', partner: 'BG Fit & Men\'s Shed' },
   { id: 'darwin', community: 'Darwin', state: 'NT', beds: 1, washers: 1, status: 'testing', partner: 'Red Dust' },
-  { id: 'canberra', community: 'Canberra', state: 'NT', beds: 2, washers: 0, status: 'testing' },
+  { id: 'canberra', community: 'Canberra', state: 'ACT', beds: 2, washers: 0, status: 'testing' },
 ];
 
 /**

--- a/v2/src/lib/data/content.ts
+++ b/v2/src/lib/data/content.ts
@@ -654,7 +654,7 @@ export const investmentCase = {
     {
       risk: 'Key learnings from iteration',
       detail: 'Each production run reveals improvements needed. V4 iterations still evolving.',
-      mitigation: 'Measured approach: deploy, gather feedback, iterate. Field testing from expanded deployment informs next version. Production cost targeting reduction from $550-650 range.',
+      mitigation: 'Measured approach: deploy, gather feedback, iterate. Field testing from expanded deployment informs next version. Marginal cost per bed is $684.79 today (Buy-Kit), modelled at $425.74 with on-country factory production.',
     },
     {
       risk: 'Do no harm',

--- a/v2/src/lib/data/impact-model.ts
+++ b/v2/src/lib/data/impact-model.ts
@@ -410,7 +410,7 @@ export const IMPACT_DIMENSIONS: ImpactDimension[] = [
         confidence: 'verified',
         name: 'Total Revenue Received (cumulative since inception, ~89% grant-funded)',
         unit: '$',
-        current: verifiedFinancials.revenueReceived, // 649,710.79 — total revenue received since inception (grant + commercial), Xero workpaper (verified, not audited)
+        current: verifiedFinancials.revenueReceived, // 741,111 — total received since inception (grant + commercial), restated 2026-06-03 live-Xero reconcile
         targets: { year1: 1_100_000, year3: 4_000_000, vision2030: 15_000_000 }, // Year-1 TOTAL-revenue target across all 7 segments (not commercial-only)
         source: 'xero',
         sourceDetail:
@@ -567,7 +567,7 @@ export const IMPACT_DIMENSIONS: ImpactDimension[] = [
 
 export const FINANCIAL_SUMMARY = {
   // Single source of truth: verifiedFinancials (Xero workpaper, verified not audited).
-  totalInvestment: verifiedFinancials.revenueReceived, // 649,710.79 — denominator for public impact-per-dollar
+  totalInvestment: verifiedFinancials.revenueReceived, // 741,111 — denominator for public impact-per-dollar (restated 2026-06-03)
   tradeRevenue: verifiedFinancials.revenueReceived,
   productionPlantInvestment: verifiedFinancials.capexInvested, // 110,046
   currentCostPerUnit: CANONICAL_BUYKIT_DIRECT_COST, // 534.79 — current Buy-Kit direct cost (what we make a bed for today, MODELLED)

--- a/wiki/outputs/2026-06-06-canon-sweep-report.md
+++ b/wiki/outputs/2026-06-06-canon-sweep-report.md
@@ -1,0 +1,77 @@
+# CANON-SWEEP-REPORT
+
+**Sweep date:** 2026-06-06
+**Sweeper:** Read-only audit, no other files modified
+**Scope:** Public pages under `v2/src/app/**/page.tsx`, public components under `v2/src/components/**`, and content data files `v2/src/lib/data/{compendium,content,trip-stories,funder-shared-content,funder-pages,grant-content}.ts`.
+**Excluded (gated / out of scope):** `v2/src/app/admin/**`, `v2/src/app/auth/**`, `v2/src/app/insiders/**`, `v2/src/app/investors/**`, `v2/src/app/portal/**`, `v2/src/app/sites/**`, `v2/src/app/funders/**`, `v2/src/app/api/**`, all dynamic `[slug]` templates, `v2/src/components/admin/**`, `v2/src/components/auth/**`, `v2/src/components/insiders/**`, `v2/src/components/investors/**`, `v2/src/components/strategy/**`, `v2/src/components/dashboard/**`, `v2/src/components/fleet/**`, `v2/src/components/production/**`, `v2/src/components/reports/**`, `v2/src/components/pitch/**`, `v2/src/components/washer-interest-form.tsx` (admin-tool), `v2/src/components/partnership-form.tsx` (admin-tool).
+
+## Canon Authorities (read first; wins every conflict)
+
+| Domain | File | Locked values |
+|---|---|---|
+| Asset counts | `v2/src/lib/data/asset-canonical.ts:6` | `bedsDeployed: 496`, `stretchBedsDeployed: 133`, `basketBedsDeployed: 363`, `washersWorking: 14`, `washersDeployed: 28`, `communitiesServed: 9`, `distinctCommunities: 10`, `plasticKg: 2660` |
+| Product specs | `v2/src/lib/data/products.ts:13,15-67` | `PLASTIC_KG_PER_BED: 20`; Stretch Bed: 26kg, 200kg, 188×92×25cm, ~5min, 10+yr, 20kg HDPE, X-trestle tension design |
+| Cost figures | `v2/src/lib/cost-model/engine.ts:1-25,57` + `v2/src/lib/data/cost-model-scenarios.ts:166-203` + `v2/src/lib/data/supplier-quotes.ts:181-275` | Marginal Buy-Kit **$684.79**, Factory **$425.74**; direct Buy-Kit $534.79; fixed block ~$109,500; breakeven 338 (Factory) / 1,679 (Buy-Kit); capital GROSS $112K–$222K; NET $1,954–$111,954; idiot 8.6×/21.5×; legs saving $194.05/bed; price **$750**; factory direct $275.74 |
+| Funding totals (restated 2026-06-03) | MEMORY.md "PR #74 MERGED" | `totalReceived 741,111` and `totalReceivables 143,000` are the restated canon |
+| QBE Stage 2 framing | MEMORY.md "QBE Stage 2 cap = CONFIRMED $400K" | Must read as "up to $400,000", "at least matched", never flat/secured |
+
+## Findings (contradictions + suspicious near-misses)
+
+| # | Severity | File:line | Number found | Canon | Source-of-truth | Notes |
+|---|---|---|---|---|---|---|
+| 1 | **HIGH** | `v2/src/lib/data/compendium.ts:312-326` | `revenueBilled: 732_210.79`, `revenueReceived: 649_710.79`, `accountsReceivable: 82_500`, `operatingExpenses: 309_126`, `operatingSurplusBeforeFounderTime: 340_585` | Restated canon (PR #74, 2026-06-03): `totalReceived 741,111` and `totalReceivables 143,000` | MEMORY.md "PR #74 MERGED to main" | The `verifiedFinancials` block is dated `lastUpdated: '2026-05-29'` and labelled "single source of truth for the public financial figures" — but PR #74 (merged 2026-06-03) restated receipts to $741.1K and receivables to $143K. The 05-29 figure `accountsReceivable 82,500` only includes the Rotary $82.5K receivable and **omits** Homeland $44K + Regional Arts $16.5K (which are live authorised in Xero per the 06-03 reconcile). The 05-29 `revenueReceived 649,710.79` is short of the restated $741,111 by ~$91.4K. The legacy alias `financialSnapshot` (`compendium.ts:335-341`) re-exports the stale 05-29 figures, propagating the drift. Note: `capexInvested: 110_046` still ties to canon (no drift there). |
+| 2 | **MEDIUM** | `v2/src/lib/data/content.ts:656-657` | "Production cost targeting reduction from **$550-650** range." | Current canon marginal = **$684.79** (Buy-Kit) / **$425.74** (Factory) per `v2/src/lib/cost-model/engine.ts:23-24` and `v2/src/lib/data/supplier-quotes.ts:254-255` | `v2/src/lib/cost-model/engine.ts:23` | The "$550-650 range" is the legacy FRRR / Snow / financial-model Day 4 figure (see `supplier-quotes.ts:243` "FRRR Community Led Climate Solutions application: Total production cost: $550–650 at 100 units"). The current Buy-Kit marginal is $684.79 — the framing "targeting reduction from $550-650" implies a downward direction from $550-650 to lower, but the actual canon is **higher**, not lower, than the legacy range. The text reads as a stale copyedit. This is inside a `risks` entry for the Snow Foundation Q1 2026 proposal; the surrounding `investmentCase` is also legacy-Snow-era copy and should be reviewed for drift in a follow-up. |
+| 3 | **LOW** | `v2/src/lib/data/compendium.ts:376` | `state: 'NT'` for the `canberra` community deployment | Canberra is **ACT** (Australian Capital Territory), not NT | Standard Australian geography | The other 8 deployment rows use `'NT' | 'QLD' | 'WA' | 'SA'` correctly; this one is mis-categorised. (Not a numeric canon hit, but flagged because the sweep specifically included the `compendium.ts` data file for the static deployments array.) |
+| 4 | **LOW** | `v2/src/lib/data/compendium.ts:362-376` | Static per-community beds sum (159+16+131+0+147+18+20+2+1+2 = 496) ties to `EXPECTED_DEPLOYED_BEDS: 496` | `CANONICAL_ASSETS.bedsDeployed: 496` | `v2/src/lib/data/asset-canonical.ts:6` | The per-community numbers **sum** to canon (verified by the build-time assert at `compendium.ts:397-405`). The individual values reflect the 2026-05-30 reconciliation split. No drift here, but the split is `Tennant Creek 159 / Utopia 147 / Palm Island 131 / Kalgoorlie 20 / Maningrida 18 / Alice Homelands 16 / Mt Isa 2 / Canberra 2 / Darwin 1 = 496`. Worth a glance if the 2026-05-30 split is later updated — the assert will fire and the change is forced-visible. |
+
+## Pages Verified Clean
+
+The following were inspected and tie to canon (file:line cited for the canon-governed claim):
+
+| File:line | Claim verified |
+|---|---|
+| `v2/src/app/page.tsx:109` | "26kg, supports 200kg, designed to last 10+ years. Each bed diverts 20kg of plastic from landfill." — ties to `products.ts:24-32`. |
+| `v2/src/app/page.tsx:122` | "HDPE legs from community plastic. 20kg diverted per bed." — ties to `PLASTIC_KG_PER_BED: 20` (`products.ts:13`). |
+| `v2/src/app/page.tsx:368` | "~30 beds per week · 20kg plastic diverted per bed" — ties to `PRODUCTION_FACILITY.capacity` + `PLASTIC_KG_PER_BED`. |
+| `v2/src/app/about/page.tsx:38` | "20kg plastic diverted per bed" — ties to `products.ts:13`. |
+| `v2/src/app/about/page.tsx:84` | "delivered 496 beds across 9 communities" — ties to `CANONICAL_ASSETS.bedsDeployed: 496` + `communitiesServed: 9`. |
+| `v2/src/app/cost-story/page.tsx:20` | Metadata: "One more bed costs about $685 today and about $426 once we press our own plastic legs. The $1,780 figure is a year of fixed costs divided across too few beds." — ties to `engine.ts:23-24` + `cost-model-scenarios.ts:23-24` + the demoted fully-loaded reference at `cost-model-scenarios.ts:14-18`. |
+| `v2/src/app/cost-story/page.tsx:144-147` | "$685 today" + "$426 once we press our own plastic legs" + "$1,780 they saw is a full year of running costs divided across the few hundred beds we make today" — all tie to canon marginals / fully-loaded reference. |
+| `v2/src/app/cost-story/page.tsx:195` | "the parts come to $534.79 a bed" — ties to `supplier-quotes.ts:253` (`stretchBedDirectCostBeforeLongHaul = $534.79`). |
+| `v2/src/app/get-involved/page.tsx:24,30` | "496 beds in homes since 2023" (with canonical-source comment) + "Sponsor a bed" `price: '$750'` — ties to `CANONICAL_ASSETS.bedsDeployed` + `WEBSITE_PRICE = 750`. |
+| `v2/src/app/partner/page.tsx:91` | QBE partner card: "Stage 2 funding of **up to $400,000, at least matched** by external capital raised" — matches QBE framing rule. |
+| `v2/src/app/partner/page.tsx:309-311, 338-340` | Capital-stack section + "QBE match" bullet: "**up to $400,000, at least matched by external capital raised, awarded at the program's discretion**" — matches QBE framing rule, not stated as flat/secured. |
+| `v2/src/components/layout/impact-banner.tsx:9` | "20kg — plastic diverted per bed" — ties to `PLASTIC_KG_PER_BED`. |
+| `v2/src/lib/data/funder-shared-content.ts:12` | "Verified receipts to date $741.1K … $143K still due" — ties to restated canon (`totalReceived 741,111` + `totalReceivables 143,000`). |
+| `v2/src/lib/data/funder-shared-content.ts:13` | "Capital stack target ~$3M (raising, not committed)" — matches the blended-finance target framing. |
+| `v2/src/lib/data/funder-shared-content.ts:28, 36` | "$750 a bed" + "20kg of recycled HDPE per bed" + "200kg load capacity" — ties to canon. |
+| `v2/src/lib/data/funder-shared-content.ts:65, 73` | "QBE Foundation Stage 2 — **Up to $400K**" + description "up to $400,000 … at least matched by external capital … Repayable finance is prioritised over grants" — matches QBE framing rule. |
+| `v2/src/lib/data/funder-pages.ts:114, 142, 163` | All three funder briefs (Minderoo, PRF, TFFF) reference "~$3M blended capital raise" and QBE Catalysing Impact 2026 framing — matches. |
+| `v2/src/lib/data/funder-pages.ts:145` | "tracked across all **9 communities**" (PRF `whyUs` bullet) — ties to `CANONICAL_ASSETS.communitiesServed: 9`. |
+| `v2/src/lib/data/grant-content.ts:103-160` | `fundingHistory.totalReceived: 741_111` and `totalReceivables: 143_000` — tie to restated canon. |
+| `v2/src/lib/data/grant-content.ts:213-214` | "~$741.1K ACT-GD ACCREC paid to date, comprising ~$679.7K grant/philanthropic receipts and ~$61.4K commercial/buyer receipts. ~$143K remains outstanding in authorised receivables (Rotary $82.5K, Homeland School $44K, and Regional Arts $16.5K)" — ties to restated canon (note: includes the 06-03 restated receivables breakdown; homeland $44K + regional arts $16.5K are properly listed). |
+| `v2/src/lib/data/grant-content.ts:216-219` | Bed cost framing "$600–850 funds one Stretch Bed" — uses the legacy $600 anchor as the lower bound (consistent with `legacyPlanningAnchorCostPerBed: 600` at `supplier-quotes.ts:247`); the upper bound $850 sits above the $750 retail and is described as an institutional range. Acceptable as a **sponsorship** framing, not a claim about per-bed cost. |
+| `v2/src/lib/data/content.ts:38, 46, 88, 89, 97` | "20kg plastic diverted per bed" + "496 beds across communities" + "9 Communities served" + "$3M/yr" (Alice Springs provider problem stat) + "26kg, flat-packs, no tools" — all tie to canon. The "496" and "9" lines carry source-citation comments pointing at `asset-canonical.ts`. |
+| `v2/src/lib/data/content.ts:621` | `productionPlant.investment: '~$100,000 already invested (TFN + ACT)'` — ties to `products.ts:106` (`investment: '~$100K invested (TFN + ACT funding)'`); both are within rounding of the verified $110,046 capex. The 06-03 reconcile confirmed this is the same $110,046 capex. |
+
+## What Was Checked (Scope Coverage)
+
+- All public app pages: `v2/src/app/page.tsx` (home), `about/`, `basket-bed-plans/`, `canberra/`, `checkout/` (Stripe-only, no public claims), `claim/[asset_id]/`, `communities/`, `community/`, `contact/`, `cost-story/`, `design/`, `field-notes/`, `gallery/`, `get-involved/`, `impact/` (gated form, no public claims), `insights/`, `kit/`, `login/`, `media/`, `mission/`, `my-items/`, `partner/`, `partners/`, `shop/`, `sponsor/`, `story/`, `stories/`, `stretch-bed/`, `process/`, `testimonials/`, `washers/`, `wiki/` — sampled. Pages not surfaced by the dollar/canon greps had no canon-governed numeric claims (most are layout-only).
+- All public components: `auth/`, `cart/`, `empathy-ledger/`, `feedback/`, `layout/`, `marketing/`, `newsletter-signup.tsx`, `shop/`, `stories/`, `ui/`, `wiki/`. None hardcode canon numbers (all use `CANONICAL_ASSETS` or `PLASTIC_KG_PER_BED` imports).
+- All public data files: `compendium.ts` (1 HIGH finding), `content.ts` (1 MEDIUM finding), `trip-stories.ts` (clean — only narrative), `funder-shared-content.ts` (clean), `funder-pages.ts` (clean), `grant-content.ts` (clean and matches restated canon), `products.ts` (canon), `asset-canonical.ts` (canon), `supplier-quotes.ts` (canon), `cost-model-scenarios.ts` (canon), `cost-model/engine.ts` (canon).
+
+## What Was NOT Checked (Honest Coverage Gap)
+
+- **Dynamic `[slug]` templates** (`v2/src/app/bed/[id]/page.tsx`, `v2/src/app/claim/[asset_id]/page.tsx`, `v2/src/app/communities/[slug]/page.tsx`, `v2/src/app/community/ideas/new/page.tsx`, `v2/src/app/field-notes/[slug]/page.tsx`, `v2/src/app/partners/[slug]/outcomes/page.tsx`, `v2/src/app/partners/centrecorp/page.tsx`, `v2/src/app/partners/oonchiumpa/page.tsx`, `v2/src/app/funders/[slug]/page.tsx`) — single-instance; not in the public-sweep scope per task instructions. The Centrecorp + Oonchiumpa partner pages likely contain funding/receivables numbers and should be re-checked in a partner-specific sweep.
+- **Story/blog content** under `v2/src/components/stories/`, `v2/src/lib/data/story-atoms.ts`, `v2/src/lib/data/curated-quotes.ts` — narrative-heavy, no canon-governed numerics surfaced; skipped in this pass.
+- **Image/video assets** under `v2/public/` — out of scope (no source-grep impact).
+- **`v2/src/lib/data/{bed-owners,community-stories,expansion-targets,impact-fetcher,impact-model,loi-pipeline,media,operating-systems,outreach-targets,partners,press-reads,report-templates,story-atoms,supplier-cost-actuals,supporters,team,products.guards.test}.ts`** — sampled but did not surface canon-governed claims. Worth a follow-up sweep scoped to admin-tooling and dashboard surfaces.
+
+## Summary
+
+- **1 HIGH-severity canon contradiction:** stale `verifiedFinancials` block in `v2/src/lib/data/compendium.ts:312-326` (the 2026-05-29 figures, superseded by the 2026-06-03 restated $741,111 / $143,000 canon). This propagates through the legacy `financialSnapshot` alias (`compendium.ts:335-341`).
+- **1 MEDIUM-severity canon contradiction:** `v2/src/lib/data/content.ts:657` uses a legacy $550-650 range to describe the *current* production cost direction, when the canon marginal is $684.79 (Buy-Kit) / $425.74 (Factory) — the framing reads as a stale copyedit.
+- **1 LOW-severity state-assignment bug** in `v2/src/lib/data/compendium.ts:376` (Canberra `state: 'NT'`, should be `'ACT'`).
+- **1 LOW-severity drift-resilience note** on the static deployments array (verified to sum to canon via the build-time assert at `compendium.ts:397-405`).
+
+**Recommendation:** Treat the HIGH finding (compendium `verifiedFinancials`) as the next fix — it's a single-source-of-truth claim that contradicts the restated canon by ~$91.4K received + $60.5K receivables. The MEDIUM finding in `content.ts:657` is a one-line copyedit in a legacy Snow Foundation Q1 2026 risk entry.

--- a/wiki/outputs/2026-06-06-product-faq-drafts/assembly-guide.md
+++ b/wiki/outputs/2026-06-06-product-faq-drafts/assembly-guide.md
@@ -1,0 +1,86 @@
+# Stretch Bed: Assembly Guide
+
+Plain English, written for someone putting the bed together in low light, with no instructions experience, and no tools. Every step and every number ties back to the Stretch Bed product data (`v2/src/lib/data/products.ts`) and the approved build copy on `/stretch-bed`.
+
+If you can, watch the build video on `/stretch-bed` first. It shows the whole bed going together in real time.
+
+---
+
+## What is in the bag
+
+You will have three things. That is the whole bed.
+
+- **Two galvanised steel poles.** Long, round, silver. They are the frame.
+- **One folded canvas.** Heavy cloth, sewn with a long sleeve along each of the two long edges. This is the sleeping surface.
+- **Two recycled-plastic leg assemblies.** Each one is an X-shape made of two HDPE plastic planks crossed over each other, with a hole at the top point of the X.
+
+That is it. No screws, no bolts, no Allen key, no bag of bits to lose. Total packed weight is 26kg.
+
+---
+
+## What you do
+
+### Step 1. Lay the parts out on the floor
+
+Put the canvas flat on the ground where the bed will go. Lay the two poles next to it, one for each long side. Put the two X-leg assemblies near the ends of the canvas. The bed will go on the ground in the same spot you lay it out, so choose the spot first.
+
+### Step 2. Stand the two X-leg assemblies up
+
+Take one X-leg assembly in each hand. Stand them up so they are spaced a bed-length apart: one at each end of where the bed will be. The hole at the top of each X should be pointing across the bed, towards the other X. These two X-frames are the only support the bed has. The bed will not stand without them.
+
+### Step 3. Thread the first pole through the canvas sleeve and the X-leg holes
+
+Take one steel pole. The canvas has a sewn sleeve running along each long edge. Push the pole all the way through the sleeve on one long side of the canvas. As the pole comes out the other end of the sleeve, line it up with the hole at the top of the X-leg at that end. Push the pole through the hole.
+
+Now walk the pole along to the other X-leg, and push the pole through the hole at the top of that X-leg too. One pole, one canvas sleeve, two leg holes. Done.
+
+### Step 4. Thread the second pole the same way
+
+Take the second pole. Do the same thing on the other long edge of the canvas. One pole, the other sleeve, the other two leg holes. You should now have two poles running the length of the bed, one on each side, each going through a sleeve and through the top of both X-legs.
+
+### Step 5. Pull it tight
+
+This is the clever bit. The two X-legs are taller than the bed needs to be. When you push the poles down into the top holes of each X, the X-frames spread sideways a little, and the canvas pulls taut between the two poles. The tension of the tight canvas is what holds the whole frame up.
+
+You may need to push the poles firmly into the leg holes, or have a second person hold the X-legs steady while you push. When the canvas is drum-tight and the frame feels solid, the bed is built.
+
+### Step 6. Check the round ribbed tube end caps are on
+
+Each end of each pole has a round ribbed tube end cap (27mm). They stop the poles from scratching the floor and they keep the inside of the pole clean. They should be on. If one has come off in transit, push it back on by hand.
+
+### Step 7. Lie down
+
+The bed is built. It sits low, holds up to 200kg, and will last 10+ years.
+
+---
+
+## What if something is not right
+
+**The bed feels wobbly.** The poles are not deep enough in the leg holes. Push each pole further into the top hole of each X-leg. The frame will not stand without the canvas pulled tight, so check the canvas is taut too.
+
+**The canvas is saggy.** Step on the floor at one end of the bed and pull the X-leg at that end a little wider. Push the poles deeper into the holes. The bed tightens itself; you are not forcing it.
+
+**A pole will not go through the hole.** Look at the end of the pole and the hole at the top of the X. The hole is at the top point of the X, where the two planks cross. The pole should slide through with hand pressure. If it sticks, the X-leg may be twisted. Stand it back up so the two planks are crossed evenly, with the hole at the top.
+
+**I cannot tell which way round the X-leg goes.** It does not matter. Both X-legs are the same. The hole at the top of the X faces across the bed, towards the other X-leg.
+
+---
+
+## To pack it down again
+
+Reverse the steps. Lift each pole out of the X-leg holes, slide the poles out of the canvas sleeves, and fold the X-legs flat. Fold the canvas around the parts. The whole bed flat-packs back into one bundle weighing 26kg.
+
+---
+
+## What you should not do
+
+- Do not stand on the canvas before the poles are through the leg holes. The frame will not hold you.
+- Do not leave the poles half-in. The bed needs the tension of the poles pulled deep into the leg holes to be solid.
+- Do not try to screw or bolt anything. There is nothing to screw, and adding fasteners is not part of the design.
+- Do not leave the bed outside in standing water for long periods. The canvas is washable and quick-drying, but it is a bed, not a boat.
+
+---
+
+## If you would rather watch
+
+The build video on `/stretch-bed` shows the full bed going together in real time, with a load test at the end. The five steps above match the video.

--- a/wiki/outputs/2026-06-06-product-faq-drafts/faq.md
+++ b/wiki/outputs/2026-06-06-product-faq-drafts/faq.md
@@ -1,0 +1,147 @@
+# Stretch Bed: Customer FAQs
+
+Drafted from canon only. Every number ties back to `v2/src/lib/data/products.ts` (the single source of truth) and the approved copy on `/stretch-bed` and `/process`. Where canon is silent, the answer is marked `NEEDS ANSWER FROM TEAM` rather than invented.
+
+For purchasers: price, payment and freight are handled at checkout on the Goods shop page (`/shop/stretch-bed-single`).
+
+---
+
+## Assembly
+
+**1. How long does it take to put a Stretch Bed together?**
+About five minutes. The whole bed is three component types, no tools, no fasteners.
+
+**2. Do I need any tools?**
+No. The design is an X-trestle tension assembly. You thread the poles through the canvas sleeves and the holes at the top of each X-leg, then pull it tight. No screws, no bolts, nothing to lose.
+
+**3. How many parts are there?**
+Three component types, in three simple counts: two galvanised steel poles, one folded canvas, and two recycled-plastic X-trestle legs.
+
+**4. Can someone put it together in the dark, or with no instructions experience?**
+The design was made to be built by the person who sleeps on it. The build steps on `/stretch-bed` and the assembly guide (see `assembly-guide.md`) walk through it in plain language. The stretch-bed page also has a real-time video of the full build.
+
+**5. Can a child or older relative put it together?**
+The Stretch Bed is designed so the person who lives with it is the person who assembles it, and so a child can rebuild it next time the family moves house. No tools means no lost tools.
+
+**6. Can I take it apart and put it back in its bag?**
+Yes. The Stretch Bed flat-packs for easy transport. Reverse the build steps and the parts fold back down.
+
+---
+
+## Washing the canvas
+
+**7. Can I wash the canvas sleeping surface?**
+Yes. The sleeping surface is heavy-duty Australian canvas, fully washable and quick-drying. The canvas is also the bracing: the bed will not stand without it, so wash it on the frame where you can.
+
+**8. How do I wash it?**
+NEEDS ANSWER FROM TEAM. Canon confirms the canvas is fully washable and quick-drying, but does not specify machine vs hand wash, water temperature, detergent type, or drying method. The team should provide a short care guide.
+
+**9. How long does the canvas take to dry?**
+Canon says it is quick-drying. Specific drying time depends on conditions. NEEDS ANSWER FROM TEAM for an exact figure.
+
+**10. Will the canvas shrink, stretch, or fade?**
+NEEDS ANSWER FROM TEAM. Canon states the canvas is heavy-duty Australian canvas, fully washable, quick-drying, but does not give shrinkage, stretch or UV-fade figures.
+
+---
+
+## Weight and capacity
+
+**11. How much does a Stretch Bed weigh?**
+26kg packed.
+
+**12. How much weight can it hold?**
+The galvanised steel poles are rated for 200kg. The bed sits low and sturdy, holds up to 200 kg, and packs flat again when you need to move it.
+
+**13. What are the dimensions?**
+188 × 92 × 25cm (length × width × height when assembled).
+
+**14. Will it fit through a standard doorway and in a car?**
+NEEDS ANSWER FROM TEAM. Canon confirms the bed flat-packs and weighs 26kg, but does not list packed dimensions or specify whether it fits a typical sedan, troop-carrier, or 4WD. The team should confirm.
+
+---
+
+## Materials and recycled content
+
+**15. What is the bed made of?**
+Three parts: recycled plastic for the legs, galvanised steel for the poles, and heavy-duty Australian canvas for the sleeping surface. End caps are round ribbed tube end caps at 27mm. Nothing to screw, nothing to lose.
+
+**16. How much recycled plastic is in each bed?**
+Every bed diverts 20kg of HDPE from landfill. The legs are pressed from community-collected plastic waste and off-cuts go back into the shredder for the next sheet.
+
+**17. Where are the parts made and supplied?**
+The galvanised steel pipe comes from DNA Steel Direct in Alice Springs. The canvas is from Centre Canvas in Alice Springs. The recycled-plastic legs are pressed by Defy Design in Sydney (current supplier), with the long-term plan for an on-country production line in the community.
+
+**18. Are the steel poles really rust-proof?**
+The frame is galvanised steel pipe (26.9mm OD × 2.6mm wall, 1950mm length). Galvanising is the rust-resistant coating. NEEDS ANSWER FROM TEAM on the specific galvanising standard (for example, AS/NZS 4680) and any guidance for high-salt or coastal environments.
+
+**19. Can I recycle the bed at end of life?**
+NEEDS ANSWER FROM TEAM. The legs are HDPE and the steel is galvanised, so both streams are recyclable in principle, but a take-back or end-of-life pathway is not described in canon.
+
+---
+
+## Warranty and lifespan
+
+**20. What warranty comes with the bed?**
+A 5-year warranty.
+
+**21. How long will the bed last?**
+The design life is 10+ years. The Stretch Bed is built to be repaired, rebuilt, and lived on for the long term. Every bed is logged under a QR code that links to a public field-note.
+
+---
+
+## Freight to remote communities
+
+**22. Can you freight the bed to a remote community?**
+Yes. Beds travel by road train and barge to remote communities across the Northern Territory, Queensland and Western Australia. Every Stretch Bed is logged under a QR code that links to a public field-note: where it landed, who unpacked it, what the family said. The work is traceable from chip to canvas.
+
+**23. How much does freight cost, and how long does it take?**
+NEEDS ANSWER FROM TEAM. Canon confirms the freight route (road train and barge to NT, QLD, WA) but does not list freight costs, lead times, or whether they are included in the purchase price. The team should publish a freight matrix by region.
+
+**24. Do you ship to PO boxes, parcel lockers, or only street addresses?**
+NEEDS ANSWER FROM TEAM. Not in canon.
+
+**25. Is the bed packaged for the road-train and barge journey?**
+NEEDS ANSWER FROM TEAM. Canon confirms it flat-packs and the legs are virtually indestructible, but does not describe the packaging, palletising, or how the parcel is protected on a long road journey.
+
+---
+
+## Repairs and spare parts
+
+**26. Can I get spare parts if something breaks?**
+NEEDS ANSWER FROM TEAM. Canon describes replaceable components (canvas, steel pole, HDPE leg planks, end caps, ribbed tube end caps at 27mm) and confirms the bed is repair-friendly, but does not list a spare-parts catalogue, prices, or how to order. The team should publish a spare-parts list and order process.
+
+**27. Can the canvas be replaced if it tears?**
+The canvas is the structural bracing of the bed, so it is the most likely wear part. NEEDS ANSWER FROM TEAM for the replacement procedure, cost, and whether Goods offers a swap service or just sells the canvas.
+
+**28. Can the steel poles be replaced if damaged?**
+NEEDS ANSWER FROM TEAM. The poles are galvanised steel pipe (26.9mm OD × 2.6mm wall, 1950mm length). Spare pole pricing and supply are not in canon.
+
+**29. Can a leg be replaced?**
+The legs are recycled HDPE plastic, virtually indestructible, with no screws. NEEDS ANSWER FROM TEAM on whether individual leg planks are sold as spares and at what cost.
+
+---
+
+## Payment
+
+**30. How do I pay?**
+Payment is processed through Stripe at checkout on the Stretch Bed shop page. NEEDS ANSWER FROM TEAM for the full list of accepted payment methods (card types, BNPL, invoice for organisations).
+
+**31. Can organisations (housing, health, council) buy on invoice?**
+NEEDS ANSWER FROM TEAM. Canon confirms Stripe is the payment route for direct purchases, but a purchase-order or invoice pathway for organisations is not described. The team should publish an organisations path.
+
+**32. Can I sponsor a bed for a family?**
+Yes. A sponsorship pathway is offered through the Goods shop. NEEDS ANSWER FROM TEAM for the exact mechanics (one-off, monthly, recipient choice) and how the recipient is notified.
+
+---
+
+## Gaps to close with the team
+
+- Care instructions for the canvas (machine vs hand, temperature, detergent, drying).
+- Exact packed dimensions, and confirmation the flat-pack fits standard sedans, troopies, 4WDs, and common remote freight configurations.
+- Galvanising standard and coastal-environment guidance for the steel.
+- End-of-life and recycling pathway.
+- Freight matrix by region: cost, lead time, packaging, and whether it is included in the purchase price.
+- Spare-parts catalogue: canvas, steel pole, leg planks, end caps, with prices and order process.
+- Organisational purchase pathway: invoice, PO, accounts payable terms.
+- Sponsorship mechanics: one-off vs monthly, recipient choice, consent and notification.
+- Price (handled separately via Stripe).

--- a/wiki/outputs/2026-06-06-product-faq-drafts/procurement-one-pager.md
+++ b/wiki/outputs/2026-06-06-product-faq-drafts/procurement-one-pager.md
@@ -1,0 +1,90 @@
+# The Stretch Bed: Procurement One-Pager
+
+For housing and procurement officers. A flat-packable, washable bed designed for remote Australia. Made from recycled plastic, heavy-duty Australian canvas, and galvanised steel. Every number on this page ties to the canonical product data (`v2/src/lib/data/products.ts`, the single source of truth) and the approved copy on `/stretch-bed` and `/process`.
+
+---
+
+## At a glance
+
+| Spec | Value |
+|---|---|
+| Product | The Stretch Bed |
+| Status | Available for purchase |
+| Dimensions (L × W × H, assembled) | 188 × 92 × 25cm |
+| Packed weight | 26kg |
+| Load capacity | 200kg |
+| Assembly time | About five minutes |
+| Tools required | None |
+| Design life | 10+ years |
+| Warranty | 5 years |
+| Recycled plastic per bed | 20kg HDPE diverted from landfill |
+
+---
+
+## What is in the box
+
+Each bed ships as one flat-pack bundle of three component types:
+
+- **2 × galvanised steel poles.** 26.9mm OD × 2.6mm wall, 1950mm length. Sourced from DNA Steel Direct, Alice Springs. Rated for 200kg.
+- **1 × heavy-duty Australian canvas sleeping surface.** Fully washable, quick-drying, with sewn sleeves along both long edges. The canvas is also the bracing: the bed will not stand without it. Sourced from Centre Canvas, Alice Springs.
+- **2 × recycled-plastic X-trestle legs.** Two crossed HDPE planks per leg, pressed from community-collected plastic waste, with a hole at the top of each X for the pole to thread through. Virtually indestructible, no screws. Currently pressed by Defy Design (Sydney); the long-term plan is on-country pressing.
+- **Round ribbed tube end caps, 27mm**, fitted to each end of each pole.
+
+No screws, no bolts, no tools, no bag of small parts to lose or count at delivery.
+
+---
+
+## How it goes together
+
+1. Lay the canvas out on the floor.
+2. Stand the two X-legs, one at each end, spaced a bed-length apart.
+3. Thread one pole through a long-edge sleeve on the canvas and through the top hole of each X-leg.
+4. Thread the second pole through the other long-edge sleeve and the other two leg holes.
+5. Pull the poles down into the leg holes. The canvas pulls taut and the whole frame locks up tight.
+
+The X-trestle tension assembly is what holds the bed together. No fasteners, no tools, no instruction manual. Build time is about five minutes, and the person who lives with the bed is the person who builds it. A child can rebuild it next time the family moves house.
+
+---
+
+## Why it suits remote conditions
+
+**Designed for the freight, then the home.** The bed flat-packs to a single 26kg bundle. It can travel by road train and barge to remote communities across the Northern Territory, Queensland and Western Australia. Every bed is logged under a QR code that links to a public field-note: where it landed, who unpacked it, what the family said. The work is traceable from chip to canvas.
+
+**No tools, no spares inventory.** Assembly needs no tools, no screws, no bolts, no bag of fasteners to count at delivery, and no maintenance kit to ship separately. This matters in housing stock where tools and spares are hard to source.
+
+**Washable in place.** The canvas sleeping surface is heavy-duty Australian canvas, fully washable and quick-drying. The whole bed can be cleaned without taking it apart, and dries fast enough to be back in service the same day.
+
+**Built for rough use.** The HDPE leg planks are virtually indestructible and will not rust, rot, or be eaten by termites. The galvanised steel poles are rated for 200kg. The bed holds 200kg, sits low and sturdy, and is built to be repaired, rebuilt, and lived on for 10+ years.
+
+**Local supply chain where it counts.** Steel and canvas are sourced from Alice Springs suppliers. The leg-press plant is designed to lift, move, and re-deploy, so a community can take ownership of the whole production line and run it from their own yard.
+
+**Indigenous-led design.** Designed with 500+ minutes of community feedback. The bed was designed so the person who lives with it is the person who assembles it, including children, and a kid can rebuild it next time the family moves house.
+
+---
+
+## Environmental profile
+
+- 20kg of HDPE recycled plastic per bed, diverted from landfill. Off-cuts from the leg press go back into the shredder and come out as the next sheet: same plastic, two or three more presses out of the same batch.
+- Long design life (10+ years) and 5-year warranty mean a low replacement rate.
+- Local sourcing of steel and canvas reduces freight emissions for the materials that travel.
+
+---
+
+## Lead time, freight, and payment
+
+- **Lead time:** NEEDS ANSWER FROM TEAM. Canon does not list a standard lead time for procurement orders. The team should publish one.
+- **Freight cost and packaging:** NEEDS ANSWER FROM TEAM. Canon confirms road train and barge routes to NT, QLD, WA but does not list freight costs, whether freight is included in the purchase price, or the packaging specification.
+- **Payment for organisations:** NEEDS ANSWER FROM TEAM. Direct purchases go through Stripe. A purchase-order or invoice pathway for housing and procurement officers is not in canon and should be confirmed.
+- **Volume pricing:** NEEDS ANSWER FROM TEAM. Canon does not list tiered pricing for multi-bed orders.
+
+---
+
+## Sourcing and contact
+
+- Product page: `/stretch-bed`
+- Process and production: `/process`
+- Shop: `/shop/stretch-bed-single`
+- Sponsorship: `/sponsor`
+- Partnership and bulk enquiries: `/partner`
+
+For procurement enquiries not covered above, contact the Goods on Country team via the partner page.


### PR DESCRIPTION
## What

Fixes all three findings from the M3 canon-number sweep (report included in this PR at `wiki/outputs/2026-06-06-canon-sweep-report.md`):

| Severity | Fix |
|---|---|
| **HIGH** | `verifiedFinancials` (compendium.ts) restated to the 2026-06-03 live-Xero reconcile: `revenueReceived` **649,710.79 → 741,111**, `accountsReceivable` **82,500 → 143,000** (Rotary $82.5K + Homeland $44K + Regional Arts $16.5K). This block feeds the **public /impact page** revenue figure and the impact-per-dollar denominator via `impact-model.ts`, both of which were showing pre-restatement numbers. Now matches `FUNDING_CANON` in `grant-content.ts` (PR #74), with provenance comments. `revenueBilled` kept at the 05-29 figure with an explicit scope note (unconsumed, not restated by the reconcile). |
| **MEDIUM** | `content.ts` stale "$550-650 range" production-cost anchor replaced with canon marginals ($684.79 Buy-Kit today, $425.74 factory modelled). |
| **LOW** | Canberra deployment `state: 'NT'` → `'ACT'`. Root cause: the `CommunityDeployment` state union lacked `'ACT'`, so the type forced a wrong value. Union extended. |

Also adds the product support drafts (FAQ, assembly guide, procurement one-pager) to `wiki/outputs/2026-06-06-product-faq-drafts/` for review. Drafts are not wired to any page; one mechanism phrase in the assembly guide is flagged for confirmation before the copy ships anywhere.

## Provenance

Findings surfaced by a sandboxed MiniMax M3 sweep worker (read-only audit). Every finding independently verified against source before fixing; the financial restatement itself authored and traced by Opus against `grant-content.ts` canon and `wiki/outputs/2026-06-03-cluster2-xero-reconciliation.md`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` → 188/188
- [x] Restated values match `FUNDING_CANON.totalReceived` / `.totalReceivables` exactly