### PR TITLE
Supabase source map + wrong-project guard + CLAUDE.md fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,8 @@
 
 ## CRITICAL — Read First
 
-### Supabase MCP is the WRONG project
-The Supabase MCP server is connected to project `bhwyqqbovcjoefezgfnq` (a DIFFERENT project). The v2 app uses `cwsyhpiuepvdjtxaozwf`. **NEVER use MCP for v2 database operations.** Use `curl` with the service role key from `.env.local`, or `psql` with the connection string. If you catch yourself running `mcp__supabase__execute_sql` for v2 data, STOP — you're querying the wrong database.
+### Supabase MCP can reach EVERY project — always target Goods
+The org has 9 Supabase projects and the Supabase MCP can reach all of them; it takes an explicit `project_id`, so a stray or wrong id silently queries someone else's database. The v2 app DB is the **Goods** project, `cwsyhpiuepvdjtxaozwf`. The one easiest to hit by mistake is `bhwyqqbovcjoefezgfnq` ("ACT Farmhand"), a different project. **NEVER use the Supabase MCP for v2 database operations.** Use `curl` with the service role key from `.env.local`, or `psql` with the connection string. If you catch yourself running `mcp__supabase__execute_sql` for v2 data, STOP — you are likely on the wrong database. Full project map: `wiki/canon/SOURCES.md`.
 
 ### Build, Don't Plan
 Do NOT enter extended planning modes unless explicitly asked. When given a task, start implementing immediately. If clarification is needed, ask a focused question — do not write multi-phase plan documents. If a plan IS requested, keep it to bullet points and ask for approval before continuing.
@@ -152,5 +152,5 @@ cd v2 && npm run lint     # ESLint
 - Do NOT add `use client` to pages unless necessary — prefer Server Components
 - Do NOT put washing machines or basket beds as "for sale" — only the Stretch Bed is purchasable
 - Large videos go in `public/video/`, not Supabase Storage (too big for API)
-- Do NOT use Supabase MCP for v2 data — it's connected to the wrong project (see "CRITICAL" section above)
+- Do NOT use Supabase MCP for v2 data — it can reach all 9 org projects and needs an explicit project_id; target Goods `cwsyhpiuepvdjtxaozwf` only (see "CRITICAL" section above + `wiki/canon/SOURCES.md`)
 - When user says "open" or "show me", they want to see the running app — open browser URLs or launch dev servers, don't continue code walkthroughs

--- a/v2/scripts/check-asset-drift.mjs
+++ b/v2/scripts/check-asset-drift.mjs
@@ -41,6 +41,16 @@ if (!url || !key) {
   console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY (run with --env-file=.env.local).');
   process.exit(2);
 }
+// Wrong-project guard. The Supabase MCP/credentials can reach 9 projects in the
+// org; canon must only ever be validated against the "Goods" project. If the env
+// points anywhere else (e.g. bhwyqqbovcjoefezgfnq = ACT Farmhand), refuse to run.
+// See wiki/canon/SOURCES.md.
+const GOODS_PROJECT_REF = 'cwsyhpiuepvdjtxaozwf';
+if (!url.includes(GOODS_PROJECT_REF)) {
+  console.error(`Wrong-project guard: SUPABASE_URL is ${url}, not the Goods project (${GOODS_PROJECT_REF}).`);
+  console.error('Canon is only valid against the Goods register. Refusing to run. See wiki/canon/SOURCES.md.');
+  process.exit(2);
+}
 const supabase = createClient(url, key);
 
 // Pull all rows (paginate), then reduce in JS exactly like impact-fetcher.ts.

--- a/wiki/canon/SOURCES.md
+++ b/wiki/canon/SOURCES.md
@@ -1,0 +1,45 @@
+# Goods data sources (the map behind the canon)
+
+Last verified 2026-06-08. This is the reference for which Supabase project holds
+what, so the alignment engine always reads the right database. If you are about
+to query "Goods data", check here first.
+
+## The one rule
+
+The v2 app database is the **Goods** project, ref `cwsyhpiuepvdjtxaozwf`. For any
+v2 data operation use the `.env.local` credentials (curl or psql), NOT the
+Supabase MCP. The MCP can see every project in the org and needs an explicit
+project_id; pass the wrong one and you silently query someone else's database.
+
+## Projects (Supabase org `zennczhyghoomusnvcpg`)
+
+| Env var (in v2/.env.local) | Project ref | Supabase dashboard name | What lives here | Kept current by |
+|---|---|---|---|---|
+| `NEXT_PUBLIC_SUPABASE_URL` | `cwsyhpiuepvdjtxaozwf` | **Goods** | v2 app: assets register, products, recipients, bed records | `check-asset-drift.mjs` re-derives canon vs live; daily CI once secrets set |
+| `EMPATHY_LEDGER_SUPABASE_URL` | `yvnuayzslukamizrlhwb` | Empathy Ledger Enhanced | EL storytellers, stories, media | manual; `el-*` scripts |
+| `ACT_INFRA_SUPABASE_URL` | `tednluwflfhxyucgwigh` | Empathy Ledger (NOT a project called "ACT infra") | Goods Xero mirror (`xero_invoices`), the money figures | manual reconcile (`/reconcile` + accountant); `check-canon-drift.mjs` flags staleness |
+
+## The wrong-project trap
+
+`bhwyqqbovcjoefezgfnq` is **ACT Farmhand**, a different project. It is the one the
+CLAUDE.md warning is about. It is NOT Goods. Never query it for Goods data.
+
+Other projects the MCP can see but Goods does not use: Palm Island On Country
+Server (`uaxhjzqrdotoahjnxmbj`), Barkly Backbone (`gkwzdnzwpfpkvgpcbeeq`), SMART
+Connect (`gokmsihcbejttzimbrlw`), Knight Finances (`qolqnrxdqkctidjeilqt`).
+
+## Footguns
+
+1. **MCP sees all 9 projects.** It requires an explicit project_id. `check-asset-drift.mjs` now refuses to run unless `SUPABASE_URL` is the Goods ref, so the canon can never be validated against the wrong database.
+2. **Name mismatch.** `ACT_INFRA_SUPABASE_URL` points at the project Supabase calls "Empathy Ledger"; `EMPATHY_LEDGER_SUPABASE_URL` points at "Empathy Ledger Enhanced". Do not assume the dashboard name matches the env var.
+3. **Region.** Goods runs in `ap-northeast-1` (Tokyo); the rest of the org is in Australia. Cosmetic, but note it if you compare hosts.
+4. **Money is manual.** The Xero mirror (ACT infra project) is not auto-pulled into canon. That is the standing reconciliation P0 (one accountant-reviewed Goods-only figure).
+
+## How each canon domain stays up to date
+
+- **assets** (beds, washers, communities, plastic): `cwsyhpiuepvdjtxaozwf`, AUTO. `check-asset-drift.mjs` fails on drift. Local now; daily and on every main push once the `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` repo secrets are set.
+- **money** (received, receivables, the cuts): `tednluwflfhxyucgwigh` Xero mirror, MANUAL. `check-canon-drift.mjs` enforces cross-file lockstep and flags staleness; the live re-pull is human (`/reconcile`).
+- **story / consent** (cleared voices, EL published): `yvnuayzslukamizrlhwb`, MANUAL.
+
+See `canon.ts` for the per-fact `source` and `asAt`, and `needs-signoff.md` /
+`artifact-review.md` for the live review queues the loops generate.


### PR DESCRIPTION
Documents the 9-project Supabase landscape (wiki/canon/SOURCES.md: which project holds app/EL/Xero data, the wrong-project trap, env-var name mismatch). Adds a wrong-project guard to check-asset-drift.mjs (refuses to run unless SUPABASE_URL is the Goods ref). Corrects the CLAUDE.md MCP wording (reaches all projects, needs explicit project_id, target Goods).