### PR TITLE
fix(field-notes): derive OG image from masthead block (unblock prod build)

### DIFF
--- a/v2/src/app/field-notes/[slug]/page.tsx
+++ b/v2/src/app/field-notes/[slug]/page.tsx
@@ -53,11 +53,21 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
   // Unpublished stories never get indexed even when admins preview them.
   const indexable = story.published;
+  // TripStory has no top-level image; the hero lives in the masthead block's
+  // declared media.image. (The EL-resolved hero is request-time only, so the
+  // OG card uses the static fallback.)
+  const masthead = story.blocks.find((b) => b.kind === 'masthead');
+  const heroImage = masthead && masthead.kind === 'masthead' ? masthead.media.image : undefined;
   return {
     title: story.title,
     description: story.summary,
     robots: indexable ? undefined : { index: false, follow: false },
-    openGraph: { title: story.title, description: story.summary, type: 'article', images: [story.image] },
+    openGraph: {
+      title: story.title,
+      description: story.summary,
+      type: 'article',
+      ...(heroImage ? { images: [heroImage] } : {}),
+    },
   };
 }
 


### PR DESCRIPTION
## Why
The production build on `main` (PR #93 / `3d2b697`) fails with:

```
v2/src/app/field-notes/[slug]/page.tsx:60
Type error: Property 'image' does not exist on type 'TripStory'.
```

`TripStory` has no top-level `image` field — the hero lives in the masthead block's `media.image`. The failed build froze **www.goodsoncountry.com** at the last-good deploy (PR #90, ~2 days stale).

## Fix
Derive the OG hero from the masthead block's declared `media.image` (the EL-resolved hero is request-time only, unavailable in `generateMetadata`), and omit `images` when there's no masthead.

## Verification
- `npx tsc --noEmit` clean across the whole `v2` app (exit 0).
- One file, +11/-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)