### PR TITLE
[DRAFT — gated on GHL prereqs] Goods canonical GHL tags (P3c: R8–R11)

### DIFF
--- a/v2/src/app/api/bed/[id]/story/route.ts
+++ b/v2/src/app/api/bed/[id]/story/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServiceClient } from '@/lib/supabase/server';
 import { ghl, tagForAsset } from '@/lib/ghl';
+import { bedStoryCanonicalTags } from '@/lib/ghl/canonical-tags';
 
 const EL_SUPABASE_URL = process.env.EMPATHY_LEDGER_SUPABASE_URL || '';
 const EL_SUPABASE_KEY = process.env.EMPATHY_LEDGER_SUPABASE_KEY || '';
@@ -230,6 +231,15 @@ export async function POST(
   if (contact) {
     try {
       const isEmail = contact.includes('@');
+      // P3c R9 (OCAP) + R11: a storyteller is a community-line person.
+      // role:storyteller + lane:community (+ place:community:<slug> when known).
+      // NO comms: EVER. R11: `consent_to_contact` means "ok to reply about THIS
+      // story", NOT marketing — it is deliberately NOT promoted to any comms:
+      // tag; it stays as the existing goods-consent-to-contact note marker only.
+      const canonicalTags = bedStoryCanonicalTags({
+        community: asset.community,
+        consentToContact,
+      });
       const result = await ghl.createInquiryContact(
         isEmail ? contact : '',
         name || undefined,
@@ -238,6 +248,7 @@ export async function POST(
           consentToContact ? 'goods-consent-to-contact' : 'goods-no-contact',
           // Per-asset tag = bidirectional bed↔contact link in GHL
           tagForAsset(asset.unique_id),
+          ...canonicalTags,
         ],
         { source: 'Bed Story Submission' },
       );

--- a/v2/src/app/api/contact/route.ts
+++ b/v2/src/app/api/contact/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ghl } from '@/lib/ghl';
+import { contactCanonicalTags } from '@/lib/ghl/canonical-tags';
 
 interface ContactFormData {
   name: string;
@@ -62,13 +63,22 @@ export async function POST(request: NextRequest) {
         body.message,
       ].join('\n');
 
-      ghlResult = await ghl.createInquiryContact(body.email, body.name, [subjectTag], {
+      // P3c additive canonical tags: role:supporter + source:website +
+      // interest:<subject>. R8 — comms is granted ONLY when subscribe is an
+      // explicit opt-in (handled below via addToNewsletter, which also stamps
+      // newsletter_consent=Yes). Without subscribe, no comms: tag is added here.
+      const canonicalTags = contactCanonicalTags({ subject: body.subject, subscribe: false });
+
+      ghlResult = await ghl.createInquiryContact(body.email, body.name, [subjectTag, ...canonicalTags], {
         phone: body.phone,
         companyName: body.organisation,
         message: inquiryDetails,
         source: `Website Contact: ${body.subject || 'General Inquiry'}`,
       });
 
+      // R8: the /contact form does not currently render a subscribe control, so
+      // this branch is dormant in practice. If a subscribe opt-in IS sent, the
+      // newsletter path grants comms:goods-newsletter + newsletter_consent=Yes.
       if (body.subscribe) {
         await ghl.addToNewsletter(body.email, body.name, 'contact-form');
       }

--- a/v2/src/app/api/feedback/route.ts
+++ b/v2/src/app/api/feedback/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ghl } from '@/lib/ghl';
+import { feedbackCanonicalTags } from '@/lib/ghl/canonical-tags';
 
 interface FeedbackPayload {
   page: string;
@@ -10,7 +11,8 @@ interface FeedbackPayload {
 async function syncFeedbackToGhl(page: string, email: string, message: string) {
   if (!email || email === 'Anonymous' || !email.includes('@')) return;
   try {
-    const result = await ghl.createInquiryContact(email, undefined, ['goods-feedback'], {
+    // P3c additive canonical tags: source:website. NO comms: (feedback is not a subscribe).
+    const result = await ghl.createInquiryContact(email, undefined, ['goods-feedback', ...feedbackCanonicalTags()], {
       source: 'Website Feedback',
     });
     if (result.success && result.contact?.id) {

--- a/v2/src/app/api/partnership/route.ts
+++ b/v2/src/app/api/partnership/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServiceClient } from '@/lib/supabase/server';
 import { ghl } from '@/lib/ghl';
+import { partnershipCanonicalTags } from '@/lib/ghl/canonical-tags';
 
 interface PartnershipFormData {
   organizationName: string;
@@ -95,10 +96,13 @@ export async function POST(request: NextRequest) {
     const isWasherInterest = body.partnershipType === 'washer-interest';
     let ghlResult;
     if (isWasherInterest) {
+      // P3c additive canonical tags: role:buyer + interest:washer +
+      // source:website. NO comms: (registering interest is not consent).
+      const canonicalTags = partnershipCanonicalTags({ partnershipType: 'washer-interest' });
       ghlResult = await ghl.createInquiryContact(
         body.contactEmail,
         body.contactName,
-        ['goods-washer-interest'],
+        ['goods-washer-interest', ...canonicalTags],
         { source: 'Washing Machine Interest' },
       );
       if (ghlResult.success && ghlResult.contact?.id) {

--- a/v2/src/lib/ghl/canonical-tags.test.ts
+++ b/v2/src/lib/ghl/canonical-tags.test.ts
@@ -1,0 +1,362 @@
+/**
+ * P3c — Goods → ACT canonical GHL tag/field contract.
+ *
+ * These tests pin the EXACT canonical tag set + custom fields each Goods entry
+ * point must emit, per the ACT CRM taxonomy (wiki/concepts/ghl-crm-taxonomy.md
+ * §3) and the locked P3c rulings (R8 consent / R9 OCAP lane / R10 capital_tier
+ * / R11 story-contact). The contract is ADDITIVE: canonical tags sit ALONGSIDE
+ * the existing flat `goods-*` tags (which the live Smart Router still branches
+ * on) — the flat tags are NOT removed here.
+ *
+ * What is asserted, the load-bearing invariants:
+ *   (a) EVERY write carries `project:act-gd` (injected + deduped at the
+ *       chokepoint).
+ *   (b) claim / support / bed-story carry `lane:community` and NEVER any
+ *       `comms:*` tag (OCAP — R9).
+ *   (c) `comms:goods-newsletter` is granted ONLY where there is an explicit
+ *       opt-in, and always paired with `newsletter_consent=Yes` (R8).
+ *   (d) the partnership ticket-size becomes a `capital_tier` custom field, not
+ *       a belonging-ladder `tier:` tag (R10).
+ *
+ * Tags are computed by pure builders so we can assert the exact set without
+ * touching the GHL API. The chokepoint helpers in index.ts call these same
+ * builders, so the unit contract here == the live emit.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  injectProjectTag,
+  contactCanonicalTags,
+  partnershipCanonicalTags,
+  partnershipCanonicalFields,
+  newsletterCanonicalTags,
+  newsletterCanonicalFields,
+  orderCanonicalTags,
+  supportCanonicalTags,
+  claimCanonicalTags,
+  bedStoryCanonicalTags,
+  feedbackCanonicalTags,
+  GOODS_PROJECT_TAG,
+  COMMS_NEWSLETTER_TAG,
+  LANE_COMMUNITY_TAG,
+} from './canonical-tags';
+
+const COMMS_PREFIX = 'comms:';
+
+// --- (a) chokepoint: project tag injection + dedupe ------------------------
+
+describe('injectProjectTag — chokepoint invariant', () => {
+  it('always appends project:act-gd', () => {
+    expect(injectProjectTag([])).toContain(GOODS_PROJECT_TAG);
+    expect(injectProjectTag(['goods-customer'])).toContain(GOODS_PROJECT_TAG);
+  });
+
+  it('dedupes the final tag array', () => {
+    const out = injectProjectTag([
+      'goods-customer',
+      'goods-customer',
+      GOODS_PROJECT_TAG,
+      'role:buyer',
+      'role:buyer',
+    ]);
+    expect(out.filter((t) => t === 'goods-customer')).toHaveLength(1);
+    expect(out.filter((t) => t === GOODS_PROJECT_TAG)).toHaveLength(1);
+    expect(out.filter((t) => t === 'role:buyer')).toHaveLength(1);
+  });
+
+  it('preserves the pre-existing flat tags (additive, never replaces)', () => {
+    const out = injectProjectTag(['goods-recipient', 'goods-asset-gb0-1']);
+    expect(out).toContain('goods-recipient');
+    expect(out).toContain('goods-asset-gb0-1');
+  });
+
+  it('drops empty / falsy tag values', () => {
+    const out = injectProjectTag(['goods-customer', '', undefined as unknown as string]);
+    expect(out).not.toContain('');
+    expect(out).toContain('goods-customer');
+    expect(out).toContain(GOODS_PROJECT_TAG);
+  });
+});
+
+// --- Contact form (R8) ------------------------------------------------------
+
+describe('contactCanonicalTags', () => {
+  it('general inquiry → role:supporter + source:website, NO comms:', () => {
+    const tags = contactCanonicalTags({ subject: 'General Inquiry', subscribe: false });
+    expect(tags).toContain('role:supporter');
+    expect(tags).toContain('source:website');
+    expect(tags).toContain('interest:general');
+    expect(tags.some((t) => t.startsWith(COMMS_PREFIX))).toBe(false);
+  });
+
+  it('media/press subject → role:media (not role:supporter)', () => {
+    const tags = contactCanonicalTags({ subject: 'Media Pack Request', subscribe: false });
+    expect(tags).toContain('role:media');
+    expect(tags).not.toContain('role:supporter');
+    expect(tags).toContain('source:website');
+  });
+
+  it('subscribe = true (explicit opt-in) → grants comms:goods-newsletter', () => {
+    const tags = contactCanonicalTags({ subject: 'General Inquiry', subscribe: true });
+    expect(tags).toContain(COMMS_NEWSLETTER_TAG);
+  });
+
+  it('subscribe absent/false → NO comms: (inquiry is not consent)', () => {
+    expect(
+      contactCanonicalTags({ subject: 'General Inquiry' }).some((t) => t.startsWith(COMMS_PREFIX)),
+    ).toBe(false);
+  });
+
+  it('carries an interest tag derived from the subject', () => {
+    expect(contactCanonicalTags({ subject: 'Bulk Order Inquiry' })).toContain(
+      'interest:bulk-order',
+    );
+  });
+});
+
+// --- Partnership form (R10) -------------------------------------------------
+
+describe('partnershipCanonicalTags', () => {
+  it('foundation/trust segment → role:funder + source:website, NO comms:', () => {
+    const tags = partnershipCanonicalTags({ partnershipType: 'capital-interest', partnerSegment: 'foundation' });
+    expect(tags).toContain('role:funder');
+    expect(tags).toContain('source:website');
+    expect(tags.some((t) => t.startsWith(COMMS_PREFIX))).toBe(false);
+  });
+
+  it('institutional-buyer segment → role:buyer', () => {
+    const tags = partnershipCanonicalTags({ partnershipType: 'capital-interest', partnerSegment: 'institutional-buyer' });
+    expect(tags).toContain('role:buyer');
+  });
+
+  it('washer-interest → role:buyer + interest:washer', () => {
+    const tags = partnershipCanonicalTags({ partnershipType: 'washer-interest' });
+    expect(tags).toContain('role:buyer');
+    expect(tags).toContain('interest:washer');
+  });
+
+  it('community segment → role:partner', () => {
+    const tags = partnershipCanonicalTags({ partnershipType: 'capital-interest', partnerSegment: 'community' });
+    expect(tags).toContain('role:partner');
+  });
+
+  it('NEVER emits a belonging-ladder tier: tag (R10 — ticket size is a field, not a tag input)', () => {
+    // The builder takes NO fundingTier input by design — ticket size can only
+    // ever land as the capital_tier custom field, never as a tier: tag.
+    const tags = partnershipCanonicalTags({
+      partnershipType: 'capital-interest',
+      partnerSegment: 'foundation',
+    });
+    expect(tags.some((t) => t.startsWith('tier:'))).toBe(false);
+  });
+
+  it('NEVER emits comms: from the partnership form', () => {
+    const tags = partnershipCanonicalTags({ partnershipType: 'sponsor', partnerSegment: 'corporate' });
+    expect(tags.some((t) => t.startsWith(COMMS_PREFIX))).toBe(false);
+  });
+});
+
+describe('partnershipCanonicalFields — R10 capital_tier', () => {
+  it('maps fundingTier into a capital_tier field keyed by the configured field id', () => {
+    const fields = partnershipCanonicalFields('500k-plus', 'CF_CAPITAL_TIER');
+    expect(fields).toEqual({ CF_CAPITAL_TIER: '500k-plus' });
+  });
+
+  it('returns {} when there is no fundingTier (do not write an empty field)', () => {
+    expect(partnershipCanonicalFields(undefined, 'CF_CAPITAL_TIER')).toEqual({});
+  });
+
+  it('returns {} when the field id is not configured (cannot write without a key)', () => {
+    expect(partnershipCanonicalFields('500k-plus', '')).toEqual({});
+  });
+});
+
+// --- Newsletter / sponsor-interest / canberra (R8) --------------------------
+
+describe('newsletterCanonicalTags', () => {
+  it('generic newsletter signup → comms:goods-newsletter + source:website (explicit subscribe form)', () => {
+    const tags = newsletterCanonicalTags(undefined);
+    expect(tags).toContain(COMMS_NEWSLETTER_TAG);
+    expect(tags).toContain('source:website');
+  });
+
+  it('sponsor-interest tag → comms: + interest:beds + source:website', () => {
+    const tags = newsletterCanonicalTags('sponsor-interest');
+    expect(tags).toContain(COMMS_NEWSLETTER_TAG);
+    expect(tags).toContain('interest:beds');
+    expect(tags).toContain('source:website');
+  });
+
+  it('canberra-airport-2026 tag → comms: + source:event:canberra-airport-2026 + place:act', () => {
+    const tags = newsletterCanonicalTags('canberra-airport-2026');
+    expect(tags).toContain(COMMS_NEWSLETTER_TAG);
+    expect(tags).toContain('source:event:canberra-airport-2026');
+    expect(tags).toContain('place:act');
+  });
+
+  it('parliament-house event tag → comms: + source:event:parliament-house', () => {
+    const tags = newsletterCanonicalTags('parliament-house');
+    expect(tags).toContain(COMMS_NEWSLETTER_TAG);
+    expect(tags).toContain('source:event:parliament-house');
+  });
+});
+
+describe('newsletterCanonicalFields — R8 consent capture', () => {
+  it('stamps newsletter_consent=Yes whenever comms is granted', () => {
+    expect(newsletterCanonicalFields('CF_CONSENT')).toEqual({ CF_CONSENT: 'Yes' });
+  });
+
+  it('returns {} when the consent field id is not configured', () => {
+    expect(newsletterCanonicalFields('')).toEqual({});
+  });
+});
+
+// --- Order / Stripe (transactional, NO comms) -------------------------------
+
+describe('orderCanonicalTags', () => {
+  it('retail bed order → role:buyer + interest:beds + source:website, NO comms:', () => {
+    const tags = orderCanonicalTags({ productTypes: ['stretch_bed'], isSponsorship: false });
+    expect(tags).toContain('role:buyer');
+    expect(tags).toContain('interest:beds');
+    expect(tags).toContain('source:website');
+    expect(tags.some((t) => t.startsWith(COMMS_PREFIX))).toBe(false);
+  });
+
+  it('washing machine order → interest:washer', () => {
+    const tags = orderCanonicalTags({ productTypes: ['washing_machine'], isSponsorship: false });
+    expect(tags).toContain('interest:washer');
+  });
+
+  it('sponsorship → role:supporter (not role:buyer), still NO comms:', () => {
+    const tags = orderCanonicalTags({ productTypes: ['stretch_bed'], isSponsorship: true });
+    expect(tags).toContain('role:supporter');
+    expect(tags).not.toContain('role:buyer');
+    expect(tags.some((t) => t.startsWith(COMMS_PREFIX))).toBe(false);
+  });
+});
+
+// --- Support ticket (R9 OCAP) -----------------------------------------------
+
+describe('supportCanonicalTags — OCAP lane', () => {
+  it('→ role:community + lane:community + source:website', () => {
+    const tags = supportCanonicalTags({ community: undefined });
+    expect(tags).toContain('role:community');
+    expect(tags).toContain(LANE_COMMUNITY_TAG);
+    expect(tags).toContain('source:website');
+  });
+
+  it('NEVER emits comms: (OCAP — community line)', () => {
+    expect(supportCanonicalTags({ community: 'Utopia' }).some((t) => t.startsWith(COMMS_PREFIX))).toBe(
+      false,
+    );
+  });
+
+  it('emits place:community:<slug> when the community is known', () => {
+    expect(supportCanonicalTags({ community: 'Mparntwe / Alice Springs' })).toContain(
+      'place:community:mparntwe-alice-springs',
+    );
+  });
+
+  it('omits place:community: when the community is unknown (no invented value)', () => {
+    expect(supportCanonicalTags({ community: undefined }).some((t) => t.startsWith('place:community:'))).toBe(
+      false,
+    );
+  });
+});
+
+// --- Recipient claim (R9 OCAP — highest priority) ---------------------------
+
+describe('claimCanonicalTags — OCAP lane (highest priority)', () => {
+  it('→ role:community + lane:community + interest:beds for a bed claim', () => {
+    const tags = claimCanonicalTags({ productType: 'stretch_bed', community: undefined });
+    expect(tags).toContain('role:community');
+    expect(tags).toContain(LANE_COMMUNITY_TAG);
+    expect(tags).toContain('interest:beds');
+  });
+
+  it('washing machine claim → interest:washer', () => {
+    const tags = claimCanonicalTags({ productType: 'washing machine', community: undefined });
+    expect(tags).toContain('interest:washer');
+  });
+
+  it('NEVER emits comms: EVER (OCAP — community recipient)', () => {
+    expect(
+      claimCanonicalTags({ productType: 'stretch_bed', community: 'Utopia' }).some((t) =>
+        t.startsWith(COMMS_PREFIX),
+      ),
+    ).toBe(false);
+  });
+
+  it('emits place:community:<slug> when known', () => {
+    expect(claimCanonicalTags({ productType: 'bed', community: 'Utopia' })).toContain(
+      'place:community:utopia',
+    );
+  });
+});
+
+// --- Bed-story (R9 OCAP + R11) ----------------------------------------------
+
+describe('bedStoryCanonicalTags — OCAP lane + R11', () => {
+  it('→ role:storyteller + lane:community', () => {
+    const tags = bedStoryCanonicalTags({ community: undefined });
+    expect(tags).toContain('role:storyteller');
+    expect(tags).toContain(LANE_COMMUNITY_TAG);
+  });
+
+  it('NEVER emits comms: EVER (storyteller = community line; consent_to_contact is NOT marketing)', () => {
+    expect(
+      bedStoryCanonicalTags({ community: 'Utopia', consentToContact: true }).some((t) =>
+        t.startsWith(COMMS_PREFIX),
+      ),
+    ).toBe(false);
+  });
+
+  it('consent_to_contact=true does NOT promote to any comms: tag (R11)', () => {
+    const withConsent = bedStoryCanonicalTags({ community: undefined, consentToContact: true });
+    const withoutConsent = bedStoryCanonicalTags({ community: undefined, consentToContact: false });
+    expect(withConsent.some((t) => t.startsWith(COMMS_PREFIX))).toBe(false);
+    expect(withoutConsent.some((t) => t.startsWith(COMMS_PREFIX))).toBe(false);
+  });
+
+  it('emits place:community:<slug> when known', () => {
+    expect(bedStoryCanonicalTags({ community: 'Utopia' })).toContain('place:community:utopia');
+  });
+});
+
+// --- Feedback ---------------------------------------------------------------
+
+describe('feedbackCanonicalTags', () => {
+  it('→ source:website, NO comms:', () => {
+    const tags = feedbackCanonicalTags();
+    expect(tags).toContain('source:website');
+    expect(tags.some((t) => t.startsWith(COMMS_PREFIX))).toBe(false);
+  });
+});
+
+// --- Cross-cutting: every path carries project:act-gd after injection -------
+
+describe('every entry point carries project:act-gd once injected', () => {
+  const paths: Array<[string, string[]]> = [
+    ['contact', contactCanonicalTags({ subject: 'General Inquiry' })],
+    ['partnership', partnershipCanonicalTags({ partnershipType: 'capital-interest', partnerSegment: 'foundation' })],
+    ['newsletter', newsletterCanonicalTags('sponsor-interest')],
+    ['order', orderCanonicalTags({ productTypes: ['stretch_bed'], isSponsorship: false })],
+    ['support', supportCanonicalTags({ community: 'Utopia' })],
+    ['claim', claimCanonicalTags({ productType: 'bed', community: 'Utopia' })],
+    ['bed-story', bedStoryCanonicalTags({ community: 'Utopia' })],
+    ['feedback', feedbackCanonicalTags()],
+  ];
+
+  it.each(paths)('%s → injectProjectTag adds project:act-gd', (_label, tags) => {
+    expect(injectProjectTag(tags)).toContain(GOODS_PROJECT_TAG);
+  });
+
+  it('community-line paths (support/claim/bed-story) never gain comms: after injection', () => {
+    for (const tags of [
+      supportCanonicalTags({ community: 'Utopia' }),
+      claimCanonicalTags({ productType: 'bed', community: 'Utopia' }),
+      bedStoryCanonicalTags({ community: 'Utopia', consentToContact: true }),
+    ]) {
+      expect(injectProjectTag(tags).some((t) => t.startsWith(COMMS_PREFIX))).toBe(false);
+    }
+  });
+});

--- a/v2/src/lib/ghl/canonical-tags.ts
+++ b/v2/src/lib/ghl/canonical-tags.ts
@@ -21,8 +21,10 @@
  *   interest:<x>    — beds | washer | general | bulk-order | ...
  *   place:<x>       — state (qld/nt/act) OR community:<slug>
  *   source:<x>      — website | event:<slug> | inbound
- *   lane:community  — OCAP guard. The Smart Router MUST exclude this from all
- *                     drips (GHL-side, pending).
+ *   lane:community  — OCAP guard (agency model). Never AUTO-enrolled into
+ *                     comms:* and never an automation segment; an explicit
+ *                     consent-evidenced opt-in is honored. GHL-side: don't
+ *                     auto-add comms: to a lane:community contact.
  */
 
 export const GOODS_PROJECT_TAG = 'project:act-gd';
@@ -210,8 +212,8 @@ export function orderCanonicalTags(opts: { productTypes: string[]; isSponsorship
 // ---------------------------------------------------------------------------
 export function supportCanonicalTags(opts: { community?: string | null }): string[] {
   // OCAP: the submitter is a community recipient. lane:community is the
-  // protective marker — the GHL Smart Router MUST exclude lane:community from
-  // all drips (GHL-side, pending). NEVER any comms: here.
+  // protective marker — this path grants NO comms:. GHL-side: never AUTO-enrol
+  // lane:community into comms:* drips (an explicit opt-in is honored separately).
   const tags: string[] = ['role:community', LANE_COMMUNITY_TAG, 'source:website'];
   const place = communityPlaceTag(opts.community);
   if (place) tags.push(place);

--- a/v2/src/lib/ghl/canonical-tags.ts
+++ b/v2/src/lib/ghl/canonical-tags.ts
@@ -1,0 +1,255 @@
+/**
+ * P3c — Goods → ACT canonical GHL tag/field contract (pure builders).
+ *
+ * This module is the single source of truth for the CANONICAL, namespaced tags
+ * each Goods entry point adds to a GHL contact, per the ACT CRM taxonomy
+ * (wiki/concepts/ghl-crm-taxonomy.md §3). The chokepoint + per-feature helpers
+ * in ./index.ts call these builders so the unit contract here equals the live
+ * emit.
+ *
+ * ADDITIVE rule: these canonical tags sit ALONGSIDE the existing flat `goods-*`
+ * tags (which the live GHL Smart Router still branches on). The flat tags are
+ * NOT removed here — they retire later in a separate GHL-side migration.
+ *
+ * Canonical namespaces used:
+ *   project:act-gd  — Goods router tag (injected + deduped at the chokepoint)
+ *   role:<x>        — funder | partner | buyer | supporter | storyteller |
+ *                     community | media
+ *   comms:goods-newsletter — newsletter SEND trigger. ONLY granted with an
+ *                     EXPLICIT opt-in (R8). A contact tagged lane:community
+ *                     gets ZERO comms:* (R9).
+ *   interest:<x>    — beds | washer | general | bulk-order | ...
+ *   place:<x>       — state (qld/nt/act) OR community:<slug>
+ *   source:<x>      — website | event:<slug> | inbound
+ *   lane:community  — OCAP guard. The Smart Router MUST exclude this from all
+ *                     drips (GHL-side, pending).
+ */
+
+export const GOODS_PROJECT_TAG = 'project:act-gd';
+export const COMMS_NEWSLETTER_TAG = 'comms:goods-newsletter';
+export const LANE_COMMUNITY_TAG = 'lane:community';
+
+/**
+ * Chokepoint invariant: every GHL write from Goods carries `project:act-gd`,
+ * and the final tag array is deduped (and stripped of empties). Called once,
+ * inside createOrUpdateContact, so NO path can omit the router tag and no
+ * duplicate tag is ever sent.
+ */
+export function injectProjectTag(tags: ReadonlyArray<string | undefined | null>): string[] {
+  const all = [...tags, GOODS_PROJECT_TAG]
+    .map((t) => (t == null ? '' : String(t).trim()))
+    .filter((t) => t.length > 0);
+  return Array.from(new Set(all));
+}
+
+/**
+ * community label → place:community:<slug>. Lowercase, hyphen-safe, collapsed.
+ * Returns undefined for empty/unknown so callers never invent a place tag.
+ */
+export function communityPlaceTag(community?: string | null): string | undefined {
+  const slug = String(community || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug ? `place:community:${slug}` : undefined;
+}
+
+/** Subject string → interest slug (e.g. "Bulk Order Inquiry" → "bulk-order"). */
+function subjectInterestSlug(subject?: string): string {
+  const s = String(subject || '')
+    .trim()
+    .toLowerCase()
+    .replace(/\binquiry\b/g, '')
+    .replace(/\brequest\b/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return s || 'general';
+}
+
+function isMediaSubject(subject?: string): boolean {
+  const s = String(subject || '').toLowerCase();
+  return s.includes('media') || s.includes('press');
+}
+
+/** Product-type string(s) → interest tag(s) (beds / washer). */
+function productInterestTags(productTypes: string[]): string[] {
+  const tags = new Set<string>();
+  for (const pt of productTypes) {
+    const p = String(pt || '').toLowerCase();
+    if (p.includes('bed')) tags.add('interest:beds');
+    if (p.includes('wash') || p.includes('machine')) tags.add('interest:washer');
+  }
+  return [...tags];
+}
+
+// ---------------------------------------------------------------------------
+// Contact form — /api/contact  (R8)
+// ---------------------------------------------------------------------------
+export function contactCanonicalTags(opts: { subject?: string; subscribe?: boolean }): string[] {
+  const tags: string[] = [];
+  // media/press → role:media, otherwise the default supporter role.
+  tags.push(isMediaSubject(opts.subject) ? 'role:media' : 'role:supporter');
+  tags.push('source:website');
+  tags.push(`interest:${subjectInterestSlug(opts.subject)}`);
+  // R8: comms ONLY with an explicit opt-in (the subscribe checkbox). An inquiry
+  // is NOT consent — without subscribe=true, no comms: tag is granted.
+  if (opts.subscribe === true) tags.push(COMMS_NEWSLETTER_TAG);
+  return tags;
+}
+
+// ---------------------------------------------------------------------------
+// Partnership / capital form — /api/partnership  (R10)
+// ---------------------------------------------------------------------------
+const PARTNER_SEGMENT_ROLE: Record<string, 'role:funder' | 'role:partner' | 'role:buyer'> = {
+  foundation: 'role:funder',
+  'paf-puaf': 'role:funder',
+  'family-office': 'role:funder',
+  corporate: 'role:funder',
+  'recoverable-grant': 'role:funder',
+  'patient-debt': 'role:funder',
+  'institutional-buyer': 'role:buyer',
+  community: 'role:partner',
+};
+
+/**
+ * Partnership canonical tags. role: derived from segment (capital givers →
+ * funder, institutional buyer → buyer, community org → partner). washer-interest
+ * is a prospective buyer of the machine. NO comms: (an inquiry is not consent),
+ * and NO belonging-ladder tier: tag (ticket size is a custom field — R10).
+ */
+export function partnershipCanonicalTags(opts: {
+  partnershipType?: string;
+  partnerSegment?: string;
+}): string[] {
+  const tags: string[] = [];
+  tags.push('source:website');
+
+  if (opts.partnershipType === 'washer-interest') {
+    tags.push('role:buyer');
+    tags.push('interest:washer');
+    return tags;
+  }
+
+  const segRole = opts.partnerSegment ? PARTNER_SEGMENT_ROLE[opts.partnerSegment] : undefined;
+  if (segRole) {
+    tags.push(segRole);
+  } else if (opts.partnershipType === 'sponsor') {
+    tags.push('role:supporter');
+  } else {
+    // Distribution / license / grant / other capital paths default to funder
+    // (a capital/partnership inquiry). Never default to a community role here.
+    tags.push('role:funder');
+  }
+  return tags;
+}
+
+/**
+ * R10: the partnership ticket-size (fundingTier) is written as a `capital_tier`
+ * CUSTOM FIELD, never as a `tier:` tag (which is reserved for the belonging
+ * ladder). Returns {} when there is no value OR no configured field id.
+ */
+export function partnershipCanonicalFields(
+  fundingTier: string | undefined,
+  capitalTierFieldId: string,
+): Record<string, string> {
+  if (!fundingTier || !capitalTierFieldId) return {};
+  return { [capitalTierFieldId]: fundingTier };
+}
+
+// ---------------------------------------------------------------------------
+// Newsletter / sponsor-interest / canberra — /api/newsletter  (R8)
+// ---------------------------------------------------------------------------
+// All three callers (generic signup, sponsor "Stay in the loop", canberra
+// "Stay close to the story") are framed as explicit subscribe/follow forms, so
+// each is a genuine opt-in → comms:goods-newsletter is granted. Event/source
+// extras are keyed off the source tag the form passes.
+const NEWSLETTER_SOURCE_EXTRAS: Record<string, string[]> = {
+  'sponsor-interest': ['interest:beds', 'source:website'],
+  'canberra-airport-2026': ['source:event:canberra-airport-2026', 'place:act'],
+  'parliament-house': ['source:event:parliament-house'],
+  'parliament-house-demo': ['source:event:parliament-house'],
+};
+
+export function newsletterCanonicalTags(sourceTag?: string): string[] {
+  const tags: string[] = [COMMS_NEWSLETTER_TAG];
+  const extras = sourceTag ? NEWSLETTER_SOURCE_EXTRAS[sourceTag] : undefined;
+  if (extras) {
+    tags.push(...extras);
+  } else {
+    // Generic newsletter signup (footer / get-involved / checkout success).
+    tags.push('source:website');
+  }
+  return Array.from(new Set(tags));
+}
+
+/**
+ * R8: whenever comms:goods-newsletter is granted, stamp newsletter_consent=Yes.
+ * Returns {} when the field id is not configured.
+ */
+export function newsletterCanonicalFields(consentFieldId: string): Record<string, string> {
+  if (!consentFieldId) return {};
+  return { [consentFieldId]: 'Yes' };
+}
+
+// ---------------------------------------------------------------------------
+// Order / Stripe checkout — transactional, NO comms
+// ---------------------------------------------------------------------------
+export function orderCanonicalTags(opts: { productTypes: string[]; isSponsorship: boolean }): string[] {
+  const tags: string[] = [];
+  // A sponsor is a supporter; a retail purchaser is a buyer.
+  tags.push(opts.isSponsorship ? 'role:supporter' : 'role:buyer');
+  tags.push(...productInterestTags(opts.productTypes));
+  tags.push('source:website');
+  // No comms: — a transactional order receipt is not marketing consent.
+  return Array.from(new Set(tags));
+}
+
+// ---------------------------------------------------------------------------
+// Support ticket — /api/support  (R9 OCAP)
+// ---------------------------------------------------------------------------
+export function supportCanonicalTags(opts: { community?: string | null }): string[] {
+  // OCAP: the submitter is a community recipient. lane:community is the
+  // protective marker — the GHL Smart Router MUST exclude lane:community from
+  // all drips (GHL-side, pending). NEVER any comms: here.
+  const tags: string[] = ['role:community', LANE_COMMUNITY_TAG, 'source:website'];
+  const place = communityPlaceTag(opts.community);
+  if (place) tags.push(place);
+  return tags;
+}
+
+// ---------------------------------------------------------------------------
+// Recipient claim — /api/claim/[asset_id]  (R9 OCAP — highest priority)
+// ---------------------------------------------------------------------------
+export function claimCanonicalTags(opts: { productType?: string; community?: string | null }): string[] {
+  // OCAP: a goods recipient. lane:community + NO comms: EVER.
+  const tags: string[] = ['role:community', LANE_COMMUNITY_TAG];
+  tags.push(...productInterestTags([opts.productType || '']));
+  const place = communityPlaceTag(opts.community);
+  if (place) tags.push(place);
+  return Array.from(new Set(tags));
+}
+
+// ---------------------------------------------------------------------------
+// Bed-story submission — /api/bed/[id]/story  (R9 OCAP + R11)
+// ---------------------------------------------------------------------------
+export function bedStoryCanonicalTags(opts: {
+  community?: string | null;
+  consentToContact?: boolean;
+}): string[] {
+  // OCAP: storyteller = community line. lane:community + NO comms: EVER.
+  // R11: consent_to_contact means "ok to reply about THIS story", NOT
+  // marketing — it is deliberately IGNORED here and never promoted to comms:.
+  const tags: string[] = ['role:storyteller', LANE_COMMUNITY_TAG];
+  const place = communityPlaceTag(opts.community);
+  if (place) tags.push(place);
+  return tags;
+}
+
+// ---------------------------------------------------------------------------
+// Feedback widget — /api/feedback
+// ---------------------------------------------------------------------------
+export function feedbackCanonicalTags(): string[] {
+  // No comms: — feedback is not a subscribe.
+  return ['source:website'];
+}

--- a/v2/src/lib/ghl/index.ts
+++ b/v2/src/lib/ghl/index.ts
@@ -1251,8 +1251,8 @@ export const ghl = {
 
     // P3c R9 (OCAP): the submitter is a community recipient reporting an issue.
     // Add role:community + lane:community (+ place:community:<slug> when known)
-    // and NEVER any comms:. GHL Smart Router MUST exclude lane:community from
-    // all drips (GHL-side, pending).
+    // and NEVER any comms: from this path. GHL-side: never AUTO-enrol
+    // lane:community into comms:* drips (an explicit opt-in is honored separately).
     tags.push(...supportCanonicalTags({ community: data.community }));
 
     const result = await createOrUpdateContact({
@@ -1577,8 +1577,8 @@ Synced: ${new Date().toLocaleString('en-AU')}
 
     // P3c R9 (OCAP — highest priority): a goods recipient is a community-line
     // person. role:community + lane:community (+ place:community:<slug> when
-    // known) + interest:beds|washer. NO comms: EVER. GHL Smart Router MUST
-    // exclude lane:community from all drips (GHL-side, pending).
+    // known) + interest:beds|washer. This path grants NO comms:. GHL-side:
+    // never AUTO-enrol lane:community into comms:* drips (opt-in honored separately).
     tags.push(...claimCanonicalTags({ productType: data.productType, community: data.community }));
 
     const customFields: Record<string, string> = {};
@@ -1639,8 +1639,8 @@ Claimed: ${new Date().toLocaleString('en-AU')}
     if (isWasher) tags.push(TAGS.claimedWasher);
 
     // P3c R9 (OCAP): an additional claim is still a community recipient.
-    // role:community + lane:community + interest:beds|washer. NO comms: EVER.
-    // GHL Smart Router MUST exclude lane:community from all drips (GHL-side, pending).
+    // role:community + lane:community + interest:beds|washer. Grants NO comms:.
+    // GHL-side: never AUTO-enrol lane:community into comms:* drips (opt-in honored).
     tags.push(...claimCanonicalTags({ productType, community }));
 
     const result = await createOrUpdateContact({

--- a/v2/src/lib/ghl/index.ts
+++ b/v2/src/lib/ghl/index.ts
@@ -8,6 +8,20 @@
  * - Workflow triggers
  */
 
+import {
+  injectProjectTag,
+  contactCanonicalTags,
+  partnershipCanonicalTags,
+  partnershipCanonicalFields,
+  newsletterCanonicalTags,
+  newsletterCanonicalFields,
+  orderCanonicalTags,
+  supportCanonicalTags,
+  claimCanonicalTags,
+  bedStoryCanonicalTags,
+  feedbackCanonicalTags,
+} from './canonical-tags';
+
 // Configuration from environment
 const GHL_API_KEY = process.env.GHL_API_KEY || '';
 const GHL_LOCATION_ID = process.env.GHL_LOCATION_ID || '';
@@ -31,6 +45,15 @@ const CUSTOM_FIELDS = {
   // cross-project reports. Other projects (Empathy Ledger, JusticeHub) set
   // their own value via their own entry points.
   projectDesignation: process.env.GHL_FIELD_PROJECT_DESIGNATION || '',
+  // P3c canonical custom fields. Both must be CREATED in GHL before automation
+  // switch-on (see GHL-UI dependency list). If a key is unset the field is
+  // simply not written — code never blocks on it.
+  // newsletter_consent (Yes/No) — set to "Yes" whenever comms:goods-newsletter
+  // is granted (R8 explicit-consent capture).
+  newsletterConsent: process.env.GHL_FIELD_NEWSLETTER_CONSENT || '',
+  // capital_tier (text/dropdown) — partnership ticket-size, written here as a
+  // field instead of a belonging-ladder tier: tag (R10).
+  capitalTier: process.env.GHL_FIELD_CAPITAL_TIER || '',
 };
 
 // Helper: inject the Goods project designation into a customFields map.
@@ -576,7 +599,11 @@ async function createOrUpdateContact(data: ContactData): Promise<GHLResponse> {
       ...(name ? { name } : {}),
       ...(phone ? { phone } : {}),
       ...(companyName ? { companyName } : {}),
-      tags: data.tags || [],
+      // P3c chokepoint invariant: EVERY Goods write carries the canonical Goods
+      // router tag (project:act-gd), and the final tag array is deduped. No
+      // per-feature path can omit the router tag or double a tag. The flat
+      // goods-* tags pass through untouched (additive contract).
+      tags: injectProjectTag(data.tags || []),
       source: data.source || 'Goods on Country Website',
     };
 
@@ -1161,6 +1188,13 @@ export const ghl = {
       tags.push(TAGS.sponsor);
     }
 
+    // P3c additive canonical tags: role:buyer (retail) / role:supporter
+    // (sponsor) + interest:beds|washer + source:website. NO comms: — a
+    // transactional order receipt is not marketing consent.
+    tags.push(
+      ...orderCanonicalTags({ productTypes: data.productTypes, isSponsorship: data.isSponsorship }),
+    );
+
     const customFields: Record<string, string> = {};
     if (CUSTOM_FIELDS.orderNumber) {
       customFields[CUSTOM_FIELDS.orderNumber] = data.orderNumber;
@@ -1215,6 +1249,12 @@ export const ghl = {
     const tags = [TAGS.supportRequest, tagForAsset(data.assetId)];
     if (isUrgent) tags.push('goods-urgent');
 
+    // P3c R9 (OCAP): the submitter is a community recipient reporting an issue.
+    // Add role:community + lane:community (+ place:community:<slug> when known)
+    // and NEVER any comms:. GHL Smart Router MUST exclude lane:community from
+    // all drips (GHL-side, pending).
+    tags.push(...supportCanonicalTags({ community: data.community }));
+
     const result = await createOrUpdateContact({
       email: isEmail ? data.userContact : '',
       phone: isEmail ? undefined : data.userContact,
@@ -1265,6 +1305,11 @@ Submitted: ${new Date().toLocaleString('en-AU')}
       customFields[CUSTOM_FIELDS.message] = data.message;
     }
     withGoodsProject(customFields);
+    // P3c R10: ticket size becomes a `capital_tier` custom field, NOT a
+    // belonging-ladder tier: tag. The flat goods-tier-* tag is kept below
+    // (additive). Written only when both a value and a configured field id
+    // exist — never blocks on the field being absent.
+    Object.assign(customFields, partnershipCanonicalFields(data.fundingTier, CUSTOM_FIELDS.capitalTier));
 
     // Build segment/tier/timeline tags so Smart Router can route by
     // partner type (foundation, corporate, buyer, investor, community)
@@ -1283,14 +1328,24 @@ Submitted: ${new Date().toLocaleString('en-AU')}
       segmentTags.push('goods-capital-interest');
     }
 
+    // P3c additive canonical tags. Media pack request → role:media; otherwise
+    // role:funder|partner|buyer mapped from segment/type + source:website. NO
+    // comms: (a partnership inquiry is not marketing consent) and NO tier: tag.
+    const canonicalTags = isMedia
+      ? ['role:media', 'source:website']
+      : partnershipCanonicalTags({
+          partnershipType: data.partnershipType,
+          partnerSegment: data.partnerSegment,
+        });
+
     const result = await createOrUpdateContact({
       email: data.contactEmail,
       phone: data.contactPhone,
       name: data.contactName,
       companyName: data.organizationName,
       tags: isMedia
-        ? [TAGS.mediaRequest]
-        : [TAGS.partnerLead, ...segmentTags],
+        ? [TAGS.mediaRequest, ...canonicalTags]
+        : [TAGS.partnerLead, ...segmentTags, ...canonicalTags],
       customFields,
       source: isMedia ? 'Website Contact: Media Pack Request' : 'Partnership Inquiry',
     });
@@ -1449,12 +1504,21 @@ Synced: ${new Date().toLocaleString('en-AU')}
     const tags = [TAGS.newsletter];
     if (sourceTag) tags.push(`goods-src-${sourceTag}`);
 
+    // P3c R8: every caller of this method is an explicit subscribe/follow form
+    // (generic signup, sponsor "Stay in the loop", canberra "Stay close to the
+    // story"), so granting comms:goods-newsletter is a genuine opt-in. Add the
+    // canonical send-trigger + source/interest/place extras keyed off the
+    // source tag, AND stamp newsletter_consent=Yes to capture the consent.
+    tags.push(...newsletterCanonicalTags(sourceTag));
+    const customFields = newsletterCanonicalFields(CUSTOM_FIELDS.newsletterConsent);
+    withGoodsProject(customFields);
+
     const result = await createOrUpdateContact({
       email,
       phone,
       name: opts.name,
       tags,
-      customFields: withGoodsProject({}),
+      customFields,
       source: sourceTag ? `Newsletter Signup (${sourceTag})` : 'Newsletter Signup',
     });
 
@@ -1510,6 +1574,12 @@ Synced: ${new Date().toLocaleString('en-AU')}
     const tags = [TAGS.recipient, tagForAsset(data.assetId)];
     if (isBed) tags.push(TAGS.claimedBed);
     if (isWasher) tags.push(TAGS.claimedWasher);
+
+    // P3c R9 (OCAP — highest priority): a goods recipient is a community-line
+    // person. role:community + lane:community (+ place:community:<slug> when
+    // known) + interest:beds|washer. NO comms: EVER. GHL Smart Router MUST
+    // exclude lane:community from all drips (GHL-side, pending).
+    tags.push(...claimCanonicalTags({ productType: data.productType, community: data.community }));
 
     const customFields: Record<string, string> = {};
     if (CUSTOM_FIELDS.assetId) {
@@ -1567,6 +1637,11 @@ Claimed: ${new Date().toLocaleString('en-AU')}
     const tags: string[] = [tagForAsset(assetId)];
     if (isBed) tags.push(TAGS.claimedBed);
     if (isWasher) tags.push(TAGS.claimedWasher);
+
+    // P3c R9 (OCAP): an additional claim is still a community recipient.
+    // role:community + lane:community + interest:beds|washer. NO comms: EVER.
+    // GHL Smart Router MUST exclude lane:community from all drips (GHL-side, pending).
+    tags.push(...claimCanonicalTags({ productType, community }));
 
     const result = await createOrUpdateContact({
       email: '',


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until the GHL-side prerequisites below are done
Merging deploys to production and changes live GHL tagging. The `lane:community` OCAP guard depends on a GHL-side rule (below). Draft until that's in place.

## OCAP: agency model (not exclusion) — Ben 2026-06-08
`lane:community` is the **relationship lane, not the funnel**. A community-line contact (bed recipient, storyteller, support reporter) is **never auto-enrolled** into any `comms:*` drip/newsletter and is never an automation segment. It is **NOT** "locked out of communication" — operational messages (triggered by their own action), human-deliberate 1:1, and anything they **explicitly opt into** all still flow. A `comms:*` may sit on a `lane:community` contact **only** when paired with explicit consent evidence (`newsletter_consent=Yes`); for storyteller/Elder lines the opt-in is **human-confirmed**, not a checkbox. Canon: `wiki/concepts/ghl-audience-comms-automation.md` §5.

## What this does (P3c — additive, flat `goods-*` tags untouched)
Aligns every Goods GHL write to ACT's canonical tag contract, at the single chokepoint (`v2/src/lib/ghl/index.ts` → `createOrUpdateContact`).

- **`project:act-gd` at the chokepoint** — injected + deduped on every write; no path can omit the router tag.
- **R9 (OCAP):** `lane:community` + `role:community`/`role:storyteller` on both claim paths, support, and bed-story. These forms grant no `comms:`.
- **R8 (consent):** `comms:goods-newsletter` granted only on explicit opt-in (dedicated newsletter / sponsor / canberra forms) + `newsletter_consent=Yes`. Contact form has no subscribe control → `comms:` stays off.
- **R10:** partnership ticket-size → `capital_tier` custom field, never a `tier:` tag (reserved for the belonging ladder).
- **R11:** bed-story `consent_to_contact` kept as a reply-marker; never promoted to `comms:`.
- New pure-builder module `canonical-tags.ts` + 49 tests pinning the contract.

## GHL-side prerequisites (must be done before marking ready / merging)
1. **Smart Router — no AUTO-enrol of `lane:community`:** ensure no automation adds a `comms:*` drip tag to a `lane:community` contact. Protection is primarily at the source (community forms grant no `comms:`); the router rule is the backstop against accidental/automated grants. It must **NOT** block a drip the person explicitly opted into — a `comms:*` paired with `newsletter_consent=Yes` is a kept opt-in. For storyteller/Elder lines, route opt-ins through a human confirmation.
2. **Create custom fields** + set env vars: `newsletter_consent` → `GHL_FIELD_NEWSLETTER_CONSENT`; `capital_tier` → `GHL_FIELD_CAPITAL_TIER`. (Code no-ops gracefully if unset.)
3. **Flip the newsletter send-trigger** from flat `goods-newsletter` to `comms:goods-newsletter` (both co-exist after this PR; retire the flat tag later).

## Verification
- `npx tsc --noEmit` → exit 0 (clean across `v2`).
- `npx vitest run` → 237 passed (188 pre-existing + 49 new), exit 0.
- Diff scope: 7 files, all under `v2/`.

## Known follow-up (not in this PR)
In-app portal paths (`logInboundMessage`/`logUserRequest`, bed-scan SMS) also touch community-line contacts but currently get only `project:act-gd`, not `lane:community`. Needs a read-first pass to avoid mistagging non-community people before adding the OCAP marker.

Plan: `thoughts/shared/plans/2026-06-08-whole-system-forms-tag-alignment.md` §E + OCAP note. Evidence: `thoughts/shared/reviews/goods-forms-tag-mapping-2026-06-08.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
