### PR TITLE
ci: add chore/** push trigger + bump actions to v5 (Node24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ name: CI
 
 on:
   push:
-    branches: [main, 'feat/**', 'fix/**']
+    branches: [main, 'feat/**', 'fix/**', 'chore/**']
   pull_request:
   schedule:
     # Daily live asset-register drift check at 19:00 UTC.
@@ -25,8 +25,8 @@ jobs:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -45,8 +45,8 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'


### PR DESCRIPTION
Housekeeping on the CI gate.

**1. Add `chore/**` to the push trigger** — `chore` branches now get the hermetic drift+tests gate on push, matching `feat/**` and `fix/**`. (Chore PRs already ran CI via the `pull_request` trigger; this covers pre-PR pushes too.)

**2. Bump GitHub Actions to v5 (Node24)** — `actions/checkout@v4 → @v5` and `actions/setup-node@v4 → @v5` in both jobs. v5 runs on Node24. Per [GitHub's changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), runners force JS actions to Node24 from **2026-06-02** and default to Node24 from **2026-06-16**, with Node20 removed September 2026. Lands the bump before the brownout.

`node-version: '20'` (project test runtime) is intentionally left alone — separate from the action runtime, bump independently later if wanted.

YAML validated. ci.yml is gitignored so force-added (as the original CI gate commit was). Config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)