### PR TITLE
Loop C: hardened backlog-ingestion loop + verified canon governance facts

### DIFF
--- a/scripts/loop-c-changed-docs.mjs
+++ b/scripts/loop-c-changed-docs.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Loop C incremental file-list helper.
+ *
+ * Prints a JSON object { repo, files } of backlog docs (wiki/outputs +
+ * thoughts/shared/handoffs, *.md/*.txt, media dirs excluded) that have changed
+ * since the last Loop C run. Keys off file mtime vs a stored marker, because most
+ * backlog docs are untracked (so `git diff` would miss them).
+ *
+ * Usage:
+ *   node scripts/loop-c-changed-docs.mjs            # print {repo, files} changed since marker (all if no marker)
+ *   node scripts/loop-c-changed-docs.mjs --stamp    # also write the marker = now (call AFTER a successful run)
+ *   node scripts/loop-c-changed-docs.mjs --all      # ignore marker, list everything
+ *
+ * Feed the JSON straight into the workflow:
+ *   Workflow({ scriptPath: 'scripts/loop-c-ingestion.workflow.js', args: <this JSON> })
+ */
+import { readdirSync, statSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+const REPO = process.cwd()
+const ROOTS = ['wiki/outputs', 'thoughts/shared/handoffs']
+const EXCLUDE = /(^|\/)(brand-review-2026-05-28|utopia-media)(\/|$)/
+const MARKER = join(REPO, 'wiki/canon/.loop-c-lastrun')
+const argv = new Set(process.argv.slice(2))
+
+function walk(dir, out) {
+  let entries
+  try { entries = readdirSync(dir, { withFileTypes: true }) } catch { return out }
+  for (const e of entries) {
+    const full = join(dir, e.name)
+    if (e.isDirectory()) walk(full, out)
+    else if (/\.(md|txt)$/.test(e.name)) out.push(full)
+  }
+  return out
+}
+
+const since = !argv.has('--all') && existsSync(MARKER) ? Number(readFileSync(MARKER, 'utf8').trim()) || 0 : 0
+const all = ROOTS.flatMap((r) => walk(join(REPO, r), []))
+const files = all
+  .map((f) => relative(REPO, f))
+  .filter((rel) => !EXCLUDE.test(rel))
+  .filter((rel) => since === 0 || statSync(join(REPO, rel)).mtimeMs > since)
+  .sort()
+
+if (argv.has('--stamp')) {
+  writeFileSync(MARKER, String(Date.now()))
+  process.stderr.write(`[loop-c] marker stamped to now; ${files.length} docs were in scope this run\n`)
+}
+
+process.stdout.write(JSON.stringify({ repo: REPO, files }))
+process.stderr.write(`\n[loop-c] ${files.length} ${since === 0 ? 'docs (full — no marker)' : 'changed docs since last run'}\n`)

--- a/scripts/loop-c-ingestion.workflow.js
+++ b/scripts/loop-c-ingestion.workflow.js
@@ -1,0 +1,241 @@
+export const meta = {
+  name: 'loop-c-ingestion',
+  description: 'Loop C (hardened): ground-and-verify ingestion of Goods backlog docs into canon/artifact-register candidates. Extracts with doc-framing, adversarially verifies every claimed drift against the real source (incl. named code files), dedups + classifies vs known canon sources. Dry-run: returns candidates, writes nothing. RED=count-only.',
+  phases: [
+    { title: 'Extract', detail: 'Sonnet extractor per doc — fact + sourceSnippet + docFraming' },
+    { title: 'Verify', detail: 'skeptical adversarial check of each current-drift claim against the real file' },
+    { title: 'Synthesize', detail: 'dedup + classify candidates vs known canon sources' },
+  ],
+}
+
+// ── Inputs ───────────────────────────────────────────────────────────────────
+// args = { repo?: string, files: string[] }   (files = repo-relative paths to scan)
+// Incremental mode: caller passes only changed files (e.g. `git diff --name-only <lastrun>`).
+const REPO = (args && args.repo) || '/Users/benknight/Code/Goods Asset Register'
+const FILES = (args && args.files) || []
+if (!FILES.length) throw new Error('loop-c-ingestion: pass args.files (repo-relative doc paths). For a full run, generate with find; for incremental, pass git-changed files.')
+
+// ── Reference: canon + ALL canon-adjacent code sources (so we do not re-propose existing facts) ──
+const CANON_REF = `CANON facts (canon.ts) id = value | note:
+beds-deployed=496 | stretch-beds-deployed=133 | basket-beds=363(legacy) | washers-deployed=28 | washers-working=14 | communities-served=9 (10 distinct) | plastic-kg=2660
+revenue-received=741111 AUD(site) | accounts-receivable=143000 | revenue-xero-paid=650910.79 | revenue-carveout=713827
+stretch-price=750 | marginal-buykit=685 | marginal-factory=426 | marginal-community=421(MODELLED) | save-per-bed=194
+cleared-voices=6 | el-published-stories=0
+Money facts AMBER; 3 revenue cuts do NOT reconcile (P0 human gate). marginal-community MODELLED. Storyteller/recipient = RED.`
+
+const KNOWN_SOURCES = `ALREADY IN CANON or canon-adjacent CODE — a candidate matching any of these is NOT new (set existsIn):
+- canon.ts: all ids above.
+- products.ts (existsIn=products.ts): bed 26kg, 188x92x25cm, 200kg capacity, 20kg plastic/bed, ~5min assembly, 10+yr life, 5yr warranty, steel poles 26.9mm OD x 2.6mm wall x 1950mm, price $750.
+- asset-canonical.ts (existsIn=asset-canonical.ts): beds 496 (363 basket + 133 stretch), washers 28 deployed / 14 working, communities 9 / 10 distinct, plastic 2660kg.
+- cost-model/engine.ts (existsIn=engine.ts): marginal $684.79/$425.74/$420.74, save $194, fixed block ~$109,500/yr, break-even 1679/338/333, contribution $65/$324/$329, leg-kit $344.05, raw shred $40, 8.6x idiot index, ~$110,046 already invested, freight delta $70/bed, volume gate ~300/yr.
+- grant-content.ts / compendium.ts (existsIn=grant-content.ts): totalReceived $741,111, receivables $143,000.
+- qbe-areas.json (existsIn=qbe-areas.json): 12 diagnostic areas + V4 now->target scores + keystone (Area 09) + blockers + CASE knockouts.`
+
+// ── Schemas ──────────────────────────────────────────────────────────────────
+const EXTRACT_SCHEMA = {
+  type: 'object', additionalProperties: true,
+  properties: {
+    file: { type: 'string' },
+    facts: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: true,
+        properties: {
+          claim: { type: 'string' },
+          value: { type: 'string' },
+          unit: { type: 'string' },
+          sourceSnippet: { type: 'string', description: 'the exact sentence/line from the doc this came from' },
+          docFraming: { type: 'string', enum: ['current', 'historical', 'fixed', 'stale-flagged', 'proposed', 'external-ref', 'unknown'], description: 'how the DOC frames this value' },
+          refersToCodeFile: { type: 'string', description: 'path if the doc attributes the value to a code/data file, else ""' },
+          matchesCanonId: { type: 'string' },
+          conflictsCanonId: { type: 'string' },
+          conflictNote: { type: 'string' },
+          isNewCandidate: { type: 'boolean' },
+          suggestedDomain: { type: 'string' },
+          confidence: { type: 'string', enum: ['high', 'med', 'low'] },
+        },
+        required: ['claim', 'value', 'sourceSnippet', 'docFraming', 'matchesCanonId', 'conflictsCanonId', 'isNewCandidate', 'confidence'],
+      },
+    },
+    artifact: {
+      type: 'object', additionalProperties: true,
+      properties: {
+        shouldRegister: { type: 'boolean' },
+        suggestedTitle: { type: 'string' },
+        pillar: { type: 'string' },
+        type: { type: 'string' },
+        citesCanon: { type: 'array', items: { type: 'string' } },
+        qbeAreas: { type: 'array', items: { type: 'string' } },
+        dataClass: { type: 'string' },
+        note: { type: 'string' },
+      },
+      required: ['shouldRegister', 'suggestedTitle', 'pillar', 'citesCanon', 'dataClass'],
+    },
+    redQuotes: {
+      type: 'object', additionalProperties: true,
+      properties: {
+        count: { type: 'number' },
+        speakers: { type: 'array', items: { type: 'string' }, description: 'MUST be [] for RED content' },
+        consentMentioned: { type: 'boolean' },
+        note: { type: 'string' },
+      },
+      required: ['count'],
+    },
+    summary: { type: 'string' },
+  },
+  required: ['file', 'facts', 'artifact', 'redQuotes', 'summary'],
+}
+
+const VERIFY_SCHEMA = {
+  type: 'object', additionalProperties: true,
+  properties: {
+    isLiveDrift: { type: 'boolean' },
+    evidenceLine: { type: 'string', description: 'the exact line proving live or not-live' },
+    reason: { type: 'string' },
+  },
+  required: ['isLiveDrift', 'reason'],
+}
+
+const SYN_SCHEMA = {
+  type: 'object', additionalProperties: true,
+  properties: {
+    uniqueCandidates: {
+      type: 'array',
+      items: {
+        type: 'object', additionalProperties: true,
+        properties: {
+          claim: { type: 'string' }, value: { type: 'string' }, unit: { type: 'string' },
+          domain: { type: 'string' }, claimLabel: { type: 'string' }, dataClass: { type: 'string' },
+          existsIn: { type: 'string' }, recommend: { type: 'string' },
+        },
+        required: ['claim', 'value', 'domain', 'existsIn', 'recommend'],
+      },
+    },
+  },
+  required: ['uniqueCandidates'],
+}
+
+// ── Prompts ──────────────────────────────────────────────────────────────────
+const extractPrompt = (rel) => `You are the Loop C ingestion extractor for the Goods Alignment Engine. Read ONE backlog doc and extract structured candidates. Read-only.
+
+FILE: ${REPO}/${rel}
+
+${CANON_REF}
+
+CRITICAL GROUNDING RULES (this loop previously produced false positives by ignoring them):
+- For EVERY fact, capture sourceSnippet = the exact sentence/line you took it from.
+- Set docFraming to how THE DOC frames the value:
+  * current = the doc asserts this as a live/true value right now
+  * historical = a past/dated/superseded value
+  * fixed = the doc says this was WRONG and has been corrected/replaced
+  * stale-flagged = the doc warns "stale / do not use / do not repeat / quarantined"
+  * proposed = a target/modelled/hypothetical figure
+  * external-ref = a value the doc attributes to a code/data file or external system it is AUDITING (not the doc's own present claim)
+  * unknown = cannot tell
+- Only set conflictsCanonId when the value is docFraming=current AND contradicts canon. A value the doc itself labels fixed/stale/historical/external-ref is NOT a live conflict — record it with that framing and an empty conflictsCanonId.
+- If the doc attributes a value to a code/data file (e.g. "impact-model.ts has $550"), set refersToCodeFile to that path. Do NOT assume it is live — that file may already be corrected.
+- Never report a value you cannot see verbatim in the file. Watch units (e.g. "25 L tub" is litres, not 25 kg).
+
+Extract:
+1. facts[] — claim, value AS WRITTEN, unit, sourceSnippet, docFraming, refersToCodeFile, matchesCanonId, conflictsCanonId+conflictNote (only if current), isNewCandidate (real citable fact not in canon), suggestedDomain, confidence.
+2. artifact — shouldRegister + suggestedTitle, pillar, type, citesCanon[] (only canon ids), qbeAreas[] (01-12), dataClass, note.
+3. redQuotes — COUNT ONLY. If storyteller/recipient quotes/profiles present (RED): count + consentMentioned + one-line note. speakers MUST be []. Never verbatim, never names. Non-RED: count 0.
+4. summary — one line.
+
+Budget: read only this file. Set file to "${rel}".`
+
+const verifyPrompt = (c) => `You are a SKEPTICAL drift verifier for the Goods Alignment Engine. A previous pass claimed a LIVE drift. Prove or refute it. Default to isLiveDrift=FALSE unless the value is unambiguously a current/live truth that contradicts canon.
+
+CLAIMED DRIFT: value "${c.value}" said to conflict canon ${c.canonId} (canon value differs).
+SOURCE DOC: ${REPO}/${c.file}
+DOC SNIPPET: ${JSON.stringify(c.sourceSnippet || '')}
+DOC FRAMING (extractor's call): ${c.docFraming || 'unknown'}
+${c.refersToCodeFile ? `ATTRIBUTED CODE FILE: ${REPO}/${c.refersToCodeFile} — READ IT and check whether the value is a LIVE assignment or only appears in a comment / is absent.` : ''}
+
+Steps: Read the source doc region (and the code file if attributed). Decide: is this value asserted as a CURRENT/LIVE truth, or is it documenting something stale/fixed/historical/hypothetical, or only present in a comment, or absent/hallucinated? Return isLiveDrift (true only if a live value genuinely contradicts canon now), evidenceLine (the exact line), reason. Budget: read only what you need.`
+
+// ── Phase 1: Extract ─────────────────────────────────────────────────────────
+phase('Extract')
+const extracted = await parallel(
+  FILES.map((rel) => () => agent(extractPrompt(rel), { label: `x:${rel.split('/').pop().slice(0, 18)}`, phase: 'Extract', schema: EXTRACT_SCHEMA, model: 'sonnet' }))
+)
+const ok = extracted.filter(Boolean)
+const norm = (s) => String(s == null ? '' : s).toLowerCase().replace(/[^a-z0-9.]/g, '').trim()
+const allFacts = ok.flatMap((r) => (r.facts || []).map((f) => ({ ...f, file: r.file })))
+
+// matched + framing tallies
+const matchedTally = {}
+for (const f of allFacts) if (f.matchesCanonId) matchedTally[f.matchesCanonId] = (matchedTally[f.matchesCanonId] || 0) + 1
+const framingTally = {}
+for (const f of allFacts) framingTally[f.docFraming || 'unknown'] = (framingTally[f.docFraming || 'unknown'] || 0) + 1
+
+// drift candidates = only docFraming=current conflicts (grounding gate)
+const driftCandidates = allFacts.filter((f) => f.conflictsCanonId && (f.docFraming || '') === 'current')
+const droppedByFraming = allFacts.filter((f) => f.conflictsCanonId && (f.docFraming || '') !== 'current').length
+log(`Extract: ${ok.length}/${FILES.length} docs, ${allFacts.length} facts. Conflicts: ${driftCandidates.length} current (to verify) + ${droppedByFraming} dropped by framing (fixed/stale/historical/external-ref). Framing: ${JSON.stringify(framingTally)}`)
+
+// ── Phase 2: Verify (skeptical, adversarial) ─────────────────────────────────
+phase('Verify')
+const verified = await parallel(
+  driftCandidates.map((c) => () =>
+    agent(verifyPrompt(c), { label: `v:${c.conflictsCanonId}`, phase: 'Verify', schema: VERIFY_SCHEMA, model: 'sonnet' })
+      .then((v) => ({ canonId: c.conflictsCanonId, value: c.value, file: c.file, refersToCodeFile: c.refersToCodeFile || '', sourceSnippet: c.sourceSnippet || '', verdict: v }))
+      .catch(() => null)
+  )
+)
+const confirmedDrift = verified.filter(Boolean).filter((v) => v.verdict && v.verdict.isLiveDrift)
+const refutedDrift = verified.filter(Boolean).filter((v) => !(v.verdict && v.verdict.isLiveDrift))
+log(`Verify: ${confirmedDrift.length} confirmed live drift, ${refutedDrift.length} refuted (false positives caught)`)
+
+// ── Phase 3: Synthesize candidates (dedup + classify vs known sources) ────────
+phase('Synthesize')
+const candMap = {}
+for (const f of allFacts) {
+  if (!f.isNewCandidate) continue
+  const k = norm(f.claim).slice(0, 44) + '|' + norm(f.value)
+  if (!candMap[k]) candMap[k] = { claim: f.claim, value: f.value, unit: f.unit || '', domain: f.suggestedDomain || '', confidence: f.confidence || '', count: 0 }
+  candMap[k].count++
+}
+const candidates = Object.values(candMap).sort((a, b) => b.count - a.count)
+
+const CHUNK = 60
+const chunks = []
+for (let i = 0; i < candidates.length; i += CHUNK) chunks.push(candidates.slice(i, i + CHUNK))
+const synth = await parallel(
+  chunks.map((ch, idx) => () =>
+    agent(
+      `You are the Loop C synthesis/dedup pass.
+${KNOWN_SOURCES}
+
+Candidates (chunk ${idx + 1}/${chunks.length}), JS-deduped by exact claim+value. Merge near-duplicates and classify EACH:
+${JSON.stringify(ch)}
+
+Return per unique candidate: claim, value, unit, domain (assets/money/cost/product/story/pipeline/governance/market/other), claimLabel (verified/modelled/target/future/internal-only — money & funder PIPELINE targets are NOT verified), dataClass (green/amber/red), existsIn (canon.ts/products.ts/asset-canonical.ts/engine.ts/grant-content.ts/qbe-areas.json/none), recommend (add-to-canon/already-covered/human-review/drop).
+Rules: money/revenue NEVER add-to-canon -> human-review. Anything matching known sources -> existsIn + already-covered. Drop trivia/prose/dups. Be conservative: when unsure -> human-review, not add-to-canon. Classify only; invent nothing.`,
+      { label: `synth:${idx + 1}/${chunks.length}`, phase: 'Synthesize', schema: SYN_SCHEMA, model: 'sonnet' }
+    )
+  )
+)
+let uniqueCandidates = synth.filter(Boolean).flatMap((s) => s.uniqueCandidates || [])
+const seen = new Set()
+uniqueCandidates = uniqueCandidates.filter((c) => {
+  const k = norm(c.claim).slice(0, 44) + '|' + norm(c.value)
+  if (seen.has(k)) return false
+  seen.add(k)
+  return true
+})
+// keep only genuinely-new, conservatively-recommended
+const newForCanon = uniqueCandidates.filter((c) => (c.existsIn || 'none').toLowerCase() === 'none' && c.recommend === 'add-to-canon')
+log(`Synthesize: ${uniqueCandidates.length} unique candidates, ${newForCanon.length} genuinely-new add-to-canon`)
+
+return {
+  docsProcessed: ok.length,
+  docsTotal: FILES.length,
+  factsTotal: allFacts.length,
+  framingTally,
+  matchedTally,
+  drift: { confirmed: confirmedDrift, refutedCount: refutedDrift.length, droppedByFramingCount: droppedByFraming },
+  candidates: { total: uniqueCandidates.length, newForCanon },
+  red: { totalQuoteInstances: ok.reduce((s, r) => s + ((r.redQuotes && r.redQuotes.count) || 0), 0), redFiles: ok.filter((r) => r.redQuotes && r.redQuotes.count > 0).length, note: 'counts only; no names, no verbatim' },
+  artifacts: ok.filter((r) => r.artifact && r.artifact.shouldRegister).map((r) => ({ file: r.file, title: r.artifact.suggestedTitle, pillar: r.artifact.pillar })),
+}

--- a/scripts/loop-c-ingestion.workflow.js
+++ b/scripts/loop-c-ingestion.workflow.js
@@ -11,8 +11,10 @@ export const meta = {
 // ── Inputs ───────────────────────────────────────────────────────────────────
 // args = { repo?: string, files: string[] }   (files = repo-relative paths to scan)
 // Incremental mode: caller passes only changed files (e.g. `git diff --name-only <lastrun>`).
-const REPO = (args && args.repo) || '/Users/benknight/Code/Goods Asset Register'
-const FILES = (args && args.files) || []
+// NOTE: the Workflow tool delivers `args` as a JSON STRING, so parse it.
+const ARGS = typeof args === 'string' ? (args.trim() ? JSON.parse(args) : {}) : (args || {})
+const REPO = ARGS.repo || '/Users/benknight/Code/Goods Asset Register'
+const FILES = ARGS.files || []
 if (!FILES.length) throw new Error('loop-c-ingestion: pass args.files (repo-relative doc paths). For a full run, generate with find; for incremental, pass git-changed files.')
 
 // ── Reference: canon + ALL canon-adjacent code sources (so we do not re-propose existing facts) ──

--- a/v2/src/lib/data/canon.ts
+++ b/v2/src/lib/data/canon.ts
@@ -20,7 +20,7 @@
 import { CANONICAL_ASSETS } from './asset-canonical';
 
 export type ClaimLabel = 'verified' | 'modelled' | 'target' | 'future' | 'internal-only';
-export type CanonDomain = 'assets' | 'money' | 'story' | 'product' | 'cost' | 'pipeline';
+export type CanonDomain = 'assets' | 'money' | 'story' | 'product' | 'cost' | 'pipeline' | 'governance';
 /** GREEN = public-safe. AMBER = internal/management. RED = recipient/storyteller data, never to external models, never auto-published. */
 export type DataClass = 'green' | 'amber' | 'red';
 /** 'auto' = a drift script can re-derive from a live source. 'manual' = a human must re-pull and reconcile (all money). */
@@ -160,6 +160,42 @@ export const CANON: CanonFact[] = [
     domain: 'story', claimLabel: 'verified', dataClass: 'amber',
     source: 'Empathy Ledger API (goods-on-country project)', check: 'manual', asAt: '2026-06-03', owner: 'Ben',
     definition: '240 storytellers, 0 published. Site falls back to local journeyStories until EL publish-flips land.',
+  },
+
+  // ── Governance / legal (entity structure — QBE Area 09 keystone. ABNs are public ABR records.) ──
+  // Added 2026-06-08 by Loop C; each fact hand-verified against the area-09 legal review + grant-content.ts orgIdentity.
+  {
+    id: 'entity-operating-now', label: 'Current operating entity', value: 'Nicholas Marchesi (sole trader), ABN 21 591 780 066',
+    domain: 'governance', claimLabel: 'verified', dataClass: 'green',
+    source: 'wiki/outputs/2026-05-29-qbe-area-09-legal-structure-full-review.md + grant-content.ts orgIdentity', check: 'manual', asAt: '2026-05-29', owner: 'Ben/Nic',
+    definition: 'Goods trades, invoices and contracts through this sole trader today, during migration to the company. The migration starting point, not the destination.',
+    reconcilesWith: ['entity-trading-goforward'],
+  },
+  {
+    id: 'entity-trading-goforward', label: 'Go-forward trading entity', value: 'A Curious Tractor Pty Ltd, ACN 697 347 676 / ABN 36 697 347 676, t/a Goods on Country',
+    domain: 'governance', claimLabel: 'verified', dataClass: 'green',
+    source: 'grant-content.ts orgIdentity (ABN confirmed 2026-05-29, registered 21 Apr 2026); area-09 review', check: 'manual', asAt: '2026-05-29', owner: 'Ben/Nic',
+    definition: 'Confirmed go-forward trading company; all operations migrate to it in FY2026-27. Goods on Country is its trading name, not a separate company. Do not present the migration as finished externally.',
+  },
+  {
+    id: 'entity-dgr-home', label: 'Charity / DGR home', value: 'The Butterfly Movement Ltd, ABN 22 155 132 684',
+    domain: 'governance', claimLabel: 'verified', dataClass: 'green',
+    source: 'area-09 review citing ABN Lookup (extracted 2026-05-06): active company, ACNC charity, PBI, GST, DGR Item 1', check: 'manual', asAt: '2026-05-06', owner: 'Ben/Nic',
+    definition: 'The ONLY DGR / public-benevolent vehicle for Goods, operational from FY2026-27 (~1 July 2026), gifted from TABOO Foundation. DGR is never via Goods / A Curious Tractor / A Kind Tractor directly, and not before the FY2026-27 handover.',
+  },
+  {
+    id: 'entity-dormant', label: 'Dormant entity (do not cite)', value: 'A Kind Tractor Ltd, ABN 73 669 029 341',
+    domain: 'governance', claimLabel: 'verified', dataClass: 'green',
+    source: 'area-09 review citing ABN Lookup (extracted 2026-05-18): active company / ACNC charity but NOT DGR-entitled', check: 'manual', asAt: '2026-05-18', owner: 'Ben/Nic',
+    definition: 'DORMANT and NOT used — not the trading entity, not the charity, not DGR. Do not use it as the Goods vehicle or claim DGR for it. (grant-content.ts previously mis-listed it with ABN 50 001 350 152 + DGR true; corrected 2026-05-29.)',
+  },
+
+  // ── Pipeline / capital (match-gate tracking — AMBER, manual; the headline conversion metric) ──
+  {
+    id: 'signed-lois', label: 'Signed LOIs', value: 0, unit: 'LOIs',
+    domain: 'pipeline', claimLabel: 'verified', dataClass: 'amber',
+    source: 'GHL Supporter-Journey pipeline (Committed / Signed-LOI stage)', check: 'manual', asAt: '2026-05-30', owner: 'Ben',
+    definition: 'Signed letters of intent across all 3 Goods pipelines. The QBE match gate needs >=3 signed LOIs by 31 Aug 2026; this is the headline conversion metric. A moving number — re-confirm from GHL before citing.',
   },
 ];
 

--- a/wiki/canon/loop-c-full-backlog-review.md
+++ b/wiki/canon/loop-c-full-backlog-review.md
@@ -1,0 +1,109 @@
+# Loop C — Full Backlog Ingestion Review (dry-run)
+
+**Generated:** 2026-06-08 · **Engine:** Loop C (ingestion) · **Mode:** full backlog, NO writes to registers
+**Scope:** 202 backlog docs (`wiki/outputs/` + `thoughts/shared/handoffs/`, media dirs excluded) · **Model:** Sonnet extractors + Sonnet synthesis
+**Run:** workflow `wrntzibjg` · 232 agents · **8.54M tokens · ~19 min** · 3,338 facts → 184 conflicts / 1,779 candidates
+**Fixes applied vs scope-test:** RED count-only ✓ · JS+LLM dedup barrier ✓ · dedup vs canon.ts/engine.ts/qbe-areas.json ✓
+
+> Candidate report for human review. Nothing written to canon.ts / artifact-register.json. Money stays a manual gate (→ `needs-signoff.md`). RED = counts only (118 quote-instances across 30 docs; **no names, no verbatim** — fix worked).
+
+---
+
+## 1. Headline
+
+**After hand-verification, the run's precision is poor: the 14 "live drift" conflicts are 100% false positives (§2), and the 1,779 candidates over-produced badly (§5).** Loop C has good recall (it finds every place a number-string appears) but cannot distinguish a live value from a comment, a unit, or a hallucination. Its output is a *lead list to verify*, never a fact source to trust. Cost ran **2.4× the scope-test estimate** (8.5M not ~3.5M). Net: the loop needs a grounding/precision pass (§5) before it earns any trust — that is now the priority over adding its output to canon.
+
+---
+
+## 2. "ACTIONABLE DRIFT" — VERIFIED FALSE POSITIVES ⚠️
+
+The full run flagged 14 conflicts as wrong numbers in live code. **Hand-verification against the actual files found 0 real ones — all 14 are false positives.** This is the most important result of the run: the codebase is canon-clean, and the extractor cannot tell a live value from a comment.
+
+| Flagged | Reality (verified) |
+|---------|--------------------|
+| impact-model.ts `$550` | comment documenting drift that was *removed*: "// per-stage costs that summed to a non-canonical $550 and were [deleted]" |
+| compendium.ts `$513,148` | comment describing a *fixed* double-count; line 349 uses canonical AR |
+| metrics.ts `$832,832` | `CRITICAL:` comment explaining the void filter; filter is LIVE in code (`status=not.in.(VOIDED,DELETED)`) |
+| supplier-quotes.ts `$600` | comment: "INV-1507 $600/bed was for the DISCONTINUED Weave Bed" |
+| grant-content.ts `$778,162` | not present — file carries `totalReceived: 741_111` ("is FINAL") |
+| outreach-targets.ts `9,225kg` | hallucinated — line 202 says "2,660kg+ // canonical: see asset-canonical.ts" |
+| story-atoms.ts `25kg/bed` | unit misread — "20 kg of plastic that fits in a **25 L tub**" |
+| content.ts beds `471 / 493 / 419` | per-community distribution (guarded by `validateContent`), not a beds-deployed total |
+| stretch-beds `132` | live DB vs register — the asset-drift loop's job, not a code edit |
+| cleared-voices `25` | real definitional question (display-cleared vs consent-cleared), not a code bug |
+
+**Action 1 (fix live drifts) is cancelled — there is nothing to fix.** Editing any of these would damage correct, intentionally-documented code. The existing canon/asset/artifact drift loops are already keeping the live code clean; Loop C's job is the *backlog*, and on the backlog it confirmed no live leakage.
+
+---
+
+## 3. Historical drift (170 of 184) — a propagation map, not a fix list
+
+The remaining ~170 conflicts are stale numbers in **dated handoffs/reports** (e.g. AR $82,500 in 19 docs, $600/bed in 13, $537,595 Grantscope revenue in 13, communities=8 in 10, beds=389 in 9). You don't edit dated documents — but this is a useful map of **how far each retired number propagated** before canon was set. Headline: the pre-canon era scattered ~6 different revenue figures and 4 different bed counts across the backlog. That scatter is exactly what the canon registry now prevents.
+
+---
+
+## 4. GENUINELY-NEW canon candidates (deduped, high-value)
+
+1,779 raw candidates are too noisy to action wholesale (§5). But three domains are genuinely **absent from canon today** and worth adding as new canon facts/domains:
+
+### 4a. Governance / legal — NEW domain (this is the QBE Area-09 keystone, the #1 blocker)
+- **Operating entity (now):** Nicholas Marchesi, sole trader, **ABN 21 591 780 066**
+- **A Curious Tractor Pty Ltd** — **ACN 697 347 676**, incorporated 2026-04-28, trading as Goods on Country (future trading entity)
+- **The Butterfly Movement Ltd** — **ABN 22 155 132 684**, confirmed charity/DGR vehicle, min 3 directors
+- **A Kind Tractor Ltd** — **ABN 73 669 029 341** — DORMANT, not the trading entity
+- Supply Nation cert: 50%+ Indigenous ownership, free via Oonchiumpa, **before 1 July 2026**
+- QBE match gate: **≥3 signed LOIs by 31 Aug 2026**; Stage 2 apply Sept 2026
+- ⚠️ stale internal conflict: QBE cap "$200K vs $400K" appears unresolved in some docs — **canon should settle it at $400K** (confirmed per induction deck) to kill that conflict
+
+### 4b. Capital stack / pipeline — NEW `pipeline` domain
+- **Signed LOIs / committed = $0** across all 3 Goods pipelines (the match gate is open)
+- Funder universe: First Australians Capital ($100K–2M), SEDI First Nations (~$2.5M), RMF Plastics ($60M nat.), NPSIF ($300K–1M), Disaster Ready Fund R4 ($142.5M, due 29 May), FNCE Advice Grant (due 2026-09-03)
+- Demand signal: Utopia requested **160 more beds** (26 Nov 2025); Centrecorp committed **107–109 beds**; open demand ~885 beds
+- Key dates: SEFA LOI Aug 2026 · investment memo 2026-06-30 · QBE Stage 2 Sept 2026
+
+### 4c. Market context — candidate `market` facts (mostly green/public-safe)
+Washing machines last 1–2 yr in remote communities (vs 10+ for ours) · $125K Commonwealth procurement threshold (200 beds @ $560 = $112K sits under it) · NACCHO = 144 ACCHOs as a procurement channel · Grantscope: 1,546 communities / 4,952 entities mapped.
+
+### 4d. Product (CAVEAT — mostly already canon)
+~23 "new" product specs (26kg, 188×92×25, 200kg, 20kg plastic, steel 26.9mm) are **already in `products.ts`** — the synthesis flagged them new only because I didn't give it `products.ts`/`asset-canonical.ts` as known sources. Genuinely new here: survival rate 95% (n=15–20), Year-3 target 5,000 beds, Speed Queen unit $2,995, washer sell prices $4,000–4,500, named BOM suppliers (Defy Design / DNA Steel / Centre Canvas), ~1,000 beds/yr factory throughput.
+
+---
+
+## 5. Calibration — productionizing Loop C
+
+What this run taught us:
+
+- **Dedup is still too loose.** 2,095→1,779 only collapsed exact claim+value; semantic near-dups survived across the ~30 synthesis chunks. Fix: a final whole-set semantic dedup pass (one agent over the deduped value-keys), or cluster by `(domain, rounded-value)` before synthesis.
+- **Expand "known sources"** to include `products.ts`, `asset-canonical.ts`, `content.ts`, `compendium.ts` — or the loop keeps re-proposing facts that are already canon (the 119 "assets" + 23 product candidates are almost all already-covered).
+- **Conflicts are the product; candidates are a backlog.** The 14 live-drift conflicts are immediately actionable; the 1,779 candidates are a triage queue, not an auto-add list. Future runs should foreground conflicts and treat candidates as opt-in.
+- **RED fix verified.** 118 instances / 30 docs, count-only, zero names/verbatim leaked.
+- **Cost reality:** ~$50–85 equivalent (8.5M Sonnet tokens) for a full sweep. Run it on a schedule (monthly?), not every session. Incremental mode (only docs changed since last run) would cut this ~10×.
+- **Money never auto-writes** — the 3 money conflicts (metrics.ts $832,832, compendium.ts $513,148, grant-content.ts $778,162) go to `/reconcile` + `needs-signoff.md`.
+
+---
+
+## 6. Recommended next steps (your call)
+
+1. **Fix the 3 🔴 live drifts** — `impact-model.ts` $550→$426 (public), beds-deployed 493/471/419→496 (consolidate to canon), metrics.ts void-filter (→ /reconcile). These are real and some are public-facing.
+2. **Add the governance + pipeline domains to canon.ts** — the entity/ABN facts and the $0-LOI / demand / deadline facts. High value, low risk (mostly green/amber, no money auto-write).
+3. **Harden Loop C** (dedup pass + expanded known-sources + incremental mode) before scheduling it.
+
+---
+
+## 7. Hardening — VERIFIED (2026-06-08)
+
+Rebuilt the loop as `scripts/loop-c-ingestion.workflow.js` (tracked; `.claude/` is gitignored) with a **grounding pass** (every fact carries a `docFraming`: current / historical / fixed / stale-flagged / proposed / external-ref) and a **skeptical adversarial verify** (each `current` drift claim is re-checked against the real source — including the named code file — defaulting to not-drift). Plus expanded known-sources (products.ts, asset-canonical.ts, engine.ts, grant-content.ts, qbe-areas.json) and tighter dedup.
+
+**Precision test** — re-ran the 5 docs that produced the worst false positives (canon-sweep-report, public-copy-quarantine, grantscope-matches, area-04, canonical-numbers-sheet):
+
+| Metric | Raw run | Hardened run |
+|--------|---------|--------------|
+| False-positive "live drift" | ~7 (100% false) | **0** |
+| Confirmed live drift | — | 0 (correct — codebase is clean) |
+| Values caught by framing (not-current) | 0 (no framing) | 59 of 177 (43 stale / 8 external-ref / 8 historical) |
+| Drift claims sent to verify → refuted | n/a | 5 → 5 refuted |
+| add-to-canon candidates | ~10/doc | 4 total (conservative) |
+
+**Cost of precision:** the verify stage reads source/code files, so per-doc cost ~2.2× (~93k vs ~41k tokens). A full 202-doc hardened run ≈ ~18–19M tokens — which is why **incremental mode** (scan only git-changed docs) is required before scheduling.
+
+**Remaining productionization gaps (not yet done):** (1) the script's `args.files` input isn't received via the Workflow tool's top-level `args` (worked around with an inlined test runner) — needs fixing so it's parameterizable; (2) incremental file-list wrapper (`git diff --name-only <lastrun>`); (3) scheduling (cron / M3 / `/schedule`). Run it via `Workflow({scriptPath: 'scripts/loop-c-ingestion.workflow.js'})` with a file list.

--- a/wiki/canon/loop-c-full-backlog-review.md
+++ b/wiki/canon/loop-c-full-backlog-review.md
@@ -106,4 +106,21 @@ Rebuilt the loop as `scripts/loop-c-ingestion.workflow.js` (tracked; `.claude/` 
 
 **Cost of precision:** the verify stage reads source/code files, so per-doc cost ~2.2× (~93k vs ~41k tokens). A full 202-doc hardened run ≈ ~18–19M tokens — which is why **incremental mode** (scan only git-changed docs) is required before scheduling.
 
-**Remaining productionization gaps (not yet done):** (1) the script's `args.files` input isn't received via the Workflow tool's top-level `args` (worked around with an inlined test runner) — needs fixing so it's parameterizable; (2) incremental file-list wrapper (`git diff --name-only <lastrun>`); (3) scheduling (cron / M3 / `/schedule`). Run it via `Workflow({scriptPath: 'scripts/loop-c-ingestion.workflow.js'})` with a file list.
+**Productionization — DONE (2026-06-08):**
+- **args fix:** the Workflow tool delivers `args` as a JSON *string*; the script now parses it, so it's parameterizable by file list. Verified end-to-end on a 1-doc run.
+- **incremental helper:** `scripts/loop-c-changed-docs.mjs` prints `{repo, files}` of backlog docs changed since a mtime marker (`wiki/canon/.loop-c-lastrun`). Keys off mtime, not git, because most backlog docs are untracked.
+
+## 8. How to run / schedule
+
+**Run (incremental):**
+```
+node scripts/loop-c-changed-docs.mjs            # prints {repo, files} changed since last run (or --all for full)
+# then, in a Claude session, feed that JSON to the loop:
+Workflow({ scriptPath: 'scripts/loop-c-ingestion.workflow.js', args: <the JSON> })
+node scripts/loop-c-changed-docs.mjs --stamp    # after a clean run, advance the marker
+```
+
+**Scheduling — honest constraint (NOT auto-scheduled):** Loop C needs the local repo + the Workflow tool, which limits the options:
+- `CronCreate` (in-session cron) is session-only and recurring jobs auto-expire after 7 days → **cannot do monthly.**
+- `/schedule` remote-agent routines are persistent, but a remote runner may not have the repo checkout or the Workflow tool → **viability untested.**
+- **Recommendation:** run it **manually ~monthly** (the 3 commands above) — it's a 2-minute trigger. Loop C is dry-run / Tier 1, so an unattended run is within the AFK boundary, but it spends tokens (incremental keeps it bounded). Only wire a `/schedule` routine after one remote run proves the runner has repo + Workflow access.

--- a/wiki/canon/loop-c-scope-test.md
+++ b/wiki/canon/loop-c-scope-test.md
@@ -1,0 +1,81 @@
+# Loop C — Ingestion Scope-Test (dry-run)
+
+**Generated:** 2026-06-08 · **Engine:** Loop C (ingestion) · **Mode:** scope-test, NO writes to canon.ts or artifact-register.json
+**Folder:** `wiki/outputs/2026-06-02-qbe-catalytic-pitch/` (7 files) · **Model:** Sonnet (7 parallel extractors)
+**Run:** workflow `w5fn93ii5` · 287,442 tokens · 94s · 204 facts / 119 new-candidate flags / 13 conflicts
+
+> This is a candidate report for human review. Nothing here has been added to the registers. Money stays a manual sign-off (Loop A / `needs-signoff.md`). RED storyteller data is reported as counts only — no names, no verbatim quotes.
+
+---
+
+## 1. Quality verdict — PASS (with one fix needed)
+
+Sonnet extraction quality was high enough for the full run:
+
+- **Canon matching:** correctly tied every restated number to its canon id (`beds-deployed`, `stretch-beds-deployed`, `washers-*`, `communities-served`, `plastic-kg`, `stretch-price`, `marginal-*`, `save-per-bed`, `revenue-*`) across all 7 files. No false matches observed.
+- **Conflict detection:** caught the standing 3-cut revenue problem unprompted and explained each gap with a plausible cause (older cut / narrower scope / different as-at). It correctly treated the doc-self-flagged stale figure ($537,595) as a known-stale cut, not a true error.
+- **New-fact recall:** surfaced real facts absent from canon (cost-model curve, capital stack, program terms, governance, market context).
+- **Bonus:** flagged a plaintext password leak (`goods2026`) sitting in `02-qbe-diagnostic-alignment.md`.
+
+**Fix before the full run (RED handling):** on the RED voice map (`05`) the agent correctly withheld verbatim quotes, **but it returned the full ~29-name storyteller roster** in `speakers[]`. For RED-class files the identities themselves are sensitive. The production prompt/schema must force **count-only for RED** (no names beyond the canon `cleared-voices` set). This is the one calibration change the scope-test exists to catch.
+
+---
+
+## 2. Conflicts (drift) — 6 unique, all route to human review
+
+These are the high-value output. Most are NOT canon errors — they are artifacts citing older/narrower cuts, which is exactly what the engine is meant to surface.
+
+| # | In doc | Canon | Likely cause | Route |
+|---|--------|-------|--------------|-------|
+| 1 | Receivables **$82,500** (deck + Notion Area 04) | `accounts-receivable` = **$143,000** | Pre-dates Homeland $44K + Regional Arts $16.5K additions | money sign-off |
+| 2 | Raised **$733,410.79** | `revenue-received` = **$741,111** | Different as-at / carve-out rule | money sign-off |
+| 3 | Verified-paid grants **~$588K** | `revenue-xero-paid` = **$650,910.79** | ~$63K unexplained gap (PICC inclusion?) | money sign-off (P0) |
+| 4 | V4 diagnostic **$537,595** | (all 3 cuts) | Doc self-flags as stale/narrower | note only |
+| 5 | **3** deck-cleared / **25** display-cleared voices | `cleared-voices` = **6** | Different consent tiers (deck vs `curated-quotes.ts` display vs EL-pitch) | define the tiers |
+| 6 | **$344** "city-factory cost" (slide 06) | `marginal-factory` = **$426** | $344 is the *leg-kit* line, not the factory marginal — mislabel risk in the deck | copy fix |
+
+Conflicts 1–4 are the standing P0 revenue reconciliation — they belong in `needs-signoff.md`, not a canon edit. Conflict 5 is a real definitional gap worth closing (what does `cleared-voices` count?). Conflict 6 is a deck-copy accuracy risk.
+
+---
+
+## 3. New canon candidates (deduped) — for human triage, NOT auto-added
+
+204 raw facts collapse to a small unique set. **Critical dedup note:** many "new" candidates already live in **`cost-model/engine.ts`** (cost curve) or **`qbe-areas.json`** (diagnostic scores) — so the production loop must dedup against ALL canon sources, not just the 18 facts in `canon.ts`, or it will propose duplicates.
+
+**A. Cost-model (verify against `engine.ts` before adding — likely already derived there):**
+fixed-cost block ~$109,500/yr · break-even 1,679 / 338 / 333 beds/yr (Buy-Kit/Factory/Community) · contribution $65 / $324 / $329 · leg-kit finished $344.05 vs raw plastic ~$40 (8.6× markup) · press capex spent ~$110,046 · run-rate ~120 beds/yr (modelled) · ~2.8× lift to break-even · container capacity ~30 beds/week · community fair-wage $130/bed (band $100–160).
+
+**B. Capital stack / pipeline (genuinely NEW — no `pipeline` facts in canon yet):**
+QBE ask ~$400K signed match-eligible · QBE program: up to $400K from $1M shared pool, at-least-matched (confirmed per induction deck; doc hedged it as unconfirmed → canon would settle it) · signed LOIs = **0** · funder targets: Minderoo $840K–1.5M, Snow ~$150K, Sefa ~$300K, PRF ~$500K (+$7,469 paid), TFF ~$300K, FAC $100K–2M · factory capex $112K–222K, site capex $100K–150K. *(All AMBER; pipeline targets are `target` claim-label, not `verified`.)*
+
+**C. QBE diagnostic (already in `qbe-areas.json` / Loop D — do not duplicate):**
+V4 scores, "strong proof / weak paperwork", CASE 5-of-6 knockouts, keystone = Legal Structure.
+
+**D. Governance / legal (NEW, high-value):**
+operating entity = sole trader (Nicholas Marchesi, ABN 21 591 780 066) · Supply Nation 51% cert deadline 1 July · FY26 net loss (no surplus).
+
+**E. Market context (LOW confidence — provenance pending):**
+~$3M/yr remote washing-machine provider · Convergence benchmark $1 concessional → ~$4.10 mobilised.
+
+---
+
+## 4. Artifact registration
+
+The folder is already represented in `artifact-register.json` by `pitch-deck-blueprint` and `catalytic-pitch-bundle`. The extractor proposed registering all 7 files individually — **recommend NOT** splitting; the bundle entry covers them. Action: refresh `citesCanon[]` on the two existing entries to include the cost-model + pipeline ids once those candidates land, and bump `lastVerified`.
+
+---
+
+## 5. RED handling
+
+`05-goods-voice-map.md`: ~28–29 distinct storytellers, ~35+ quote instances. Verbatim withheld ✓. Roster **quarantined from this report** (count only). The 25-vs-6 consent-tier gap (conflict 5) is the only RED item that needs a human decision.
+
+---
+
+## 6. Calibration for the full run (202 docs, 2.8MB)
+
+- **Cost:** ~41k tokens/doc on Sonnet → full backlog ≈ **~3.5–4M tokens ≈ ~$20–35 one-time** (≈5× on Opus). Sonnet quality is sufficient; Opus not needed for extraction.
+- **Add a dedup/synthesis barrier:** extract per-doc in parallel, then ONE pass that dedups facts across all docs AND against `engine.ts` + `qbe-areas.json` + `canon.ts`. Without it, 204 raw facts (mostly repeats) drown the signal.
+- **RED prompt fix:** count-only for RED files; never emit the storyteller roster.
+- **Money never auto-writes:** route all money conflicts to `needs-signoff.md` (Loop A already owns this).
+- **Skip media dirs:** `brand-review-2026-05-28/` (14M) and `utopia-media/` (3.2M) are images — exclude from the text sweep.
+- **Security pass is a freebie:** the extractor catches leaked credentials/PII in docs — worth keeping as an explicit ask.


### PR DESCRIPTION
## What this is

Loop C of the alignment engine — backlog ingestion (extract facts/conflicts/artifacts from `wiki/outputs/` + `thoughts/shared/handoffs/` into canon/artifact-register candidates). Built, run at full scale, verified, and hardened. **Dry-run by design: writes nothing to the registers; money is never auto-written; RED storyteller data is count-only.**

## Headline finding — the codebase is canon-clean

The raw 202-doc Sonnet run flagged 14 "live drift" conflicts. **Hand-verification against the actual files found 100% false positives** — values sitting inside comments documenting *already-fixed* drift, unit misreads (`"25 L tub"` → "25kg/bed"), hallucinations (9,225kg / $778,162 not in the files), and per-community distributions read as a deploy total. Nothing to fix; the existing canon/asset/artifact loops already keep live code tidy.

## Hardening (proven)

Rebuilt the loop with a **grounding pass** (`docFraming`: current/fixed/stale-flagged/historical/external-ref/proposed — only `current` conflicts become drift candidates) and a **skeptical adversarial verify** (re-reads the source, including any named code file, before calling anything live drift), plus expanded known-sources and tighter dedup.

Precision test on the 5 worst-offender docs: **7 false positives → 0.**

## What's in this PR

- `scripts/loop-c-ingestion.workflow.js` — the hardened, reusable loop (extract → verify → synthesize). Parameterized by file list via `args` (run with `Workflow({scriptPath, args})`).
- `scripts/loop-c-changed-docs.mjs` — incremental file-list helper (mtime marker, `--stamp`/`--all`).
- `v2/src/lib/data/canon.ts` — new `governance` domain with 4 entity facts hand-verified vs the area-09 legal review + ABN Lookup (Marchesi sole trader; A Curious Tractor Pty Ltd; Butterfly Movement DGR home; A Kind Tractor dormant), plus pipeline `signed-lois=0`.
- `wiki/canon/loop-c-scope-test.md`, `wiki/canon/loop-c-full-backlog-review.md` — the run reviews, verification correction, and hardening proof.

## Gates

- `npx tsc --noEmit` — clean
- `npm run check:drift:ci` (hermetic canon/artifact/qbe-readiness guards) — green

## Note on scheduling

Not auto-scheduled. CronCreate is session-only / 7-day-max (no monthly); a remote `/schedule` routine may lack the repo + Workflow tool (untested). Recommend a manual ~monthly run (docs in §8 of the full-backlog review). A full hardened run ≈ 18–19M tokens, so use incremental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)