### PR TITLE
fix(canon): align storyteller records to Empathy Ledger (Annie, Tracy, Gloria)

### DIFF
--- a/v2/src/lib/data/compendium.ts
+++ b/v2/src/lib/data/compendium.ts
@@ -541,7 +541,7 @@ export const communityVoices: CommunityVoice[] = [
     context: 'Feedback shaped lower bed design.',
   },
   {
-    id: 'annie', name: 'Annie Morrison', role: 'Elder', community: 'Tennant Creek', state: 'NT',
+    id: 'annie', name: 'Annie Morrison', role: 'Community member', community: 'Tennant Creek', state: 'NT',
     quotes: ['I like to do more, you know, but helping all the people.'],
   },
 
@@ -569,10 +569,8 @@ export const communityVoices: CommunityVoice[] = [
     id: 'chloe', name: 'Chloe', role: 'Aboriginal Homeless Fringe Support Worker, Bega', community: 'Kalgoorlie', state: 'WA',
     quotes: ['As a support worker here, I see how much proper bedding is needed in the community. So many people are sleeping on the floor or on old, unsuitable mattresses. Something as simple as a good bed makes a huge difference — it improves their health, helps with mobility, and gives them dignity.'],
   },
-
-  // Mt Isa
   {
-    id: 'tracy', name: 'Tracy McCartney', role: 'Support Worker', community: 'Mt Isa', state: 'QLD',
+    id: 'tracy', name: 'Tracy McCartney', role: 'Support Worker', community: 'Kalgoorlie', state: 'WA',
     quotes: ["The new mattress design is not just about comfort — it's about dignity and health. Lightweight, washable, and off the ground, it addresses real challenges people face living rough or moving between camps."],
   },
 

--- a/v2/src/lib/data/content.ts
+++ b/v2/src/lib/data/content.ts
@@ -216,7 +216,7 @@ export const quotes = [
   {
     text: 'I like to do more, you know, but helping all the people.',
     author: 'Annie Morrison',
-    context: 'Elder, Tennant Creek',
+    context: 'Community member, Tennant Creek',
     theme: 'community-need',
     verified: true,
   },
@@ -231,7 +231,7 @@ export const quotes = [
   {
     text: 'The new mattress design is not just about comfort — it\'s about dignity and health.',
     author: 'Tracy McCartney',
-    context: 'Support Worker, Mt Isa',
+    context: 'Support Worker, Kalgoorlie',
     theme: 'health',
     verified: true,
   },
@@ -422,7 +422,7 @@ export const impactStories = [
   {
     id: 'gloria-health',
     title: 'Rest for Recovery',
-    person: 'Gloria',
+    person: 'Gloria Turner',
     location: 'Kalgoorlie, WA',
     quote: 'The impact of a mattress on overall health.',
     summary: 'Gloria is a great-grandmother on dialysis. For her, a mattress isn\'t about comfort. It\'s about managing chronic illness.',

--- a/v2/src/lib/data/curated-quotes.ts
+++ b/v2/src/lib/data/curated-quotes.ts
@@ -149,7 +149,7 @@ export const curatedQuotes: Record<string, CuratedQuote[]> = {
     },
   ],
 
-  'Gloria': [
+  'Gloria Turner': [
     {
       text: 'Sleep on a good mattress. For the back, the legs, the muscles.',
       context: 'On sleep quality',


### PR DESCRIPTION
Aligns three storyteller facts in the canon data to the Empathy Ledger source of truth. Ben confirmed EL is correct in each case during the 2026-06-08 ledger-draft review. Without these, the alignment loops and the gated admin grid keep re-flagging the same drift.

## Changes (3 files, +6/-8)
- **Annie Morrison** — drop the "Elder" label (EL `elderStatus=false`). `role 'Elder' → 'Community member'` in `compendium.ts`; context `'Elder, Tennant Creek' → 'Community member, Tennant Creek'` in `content.ts`.
- **Tracy McCartney** — move the person record from **Mt Isa, QLD → Kalgoorlie, WA** (EL location) in `compendium.ts` + `content.ts`. The Mt Isa *deployment* record (2 beds, Kalkadoon) is a separate fact and is **unchanged**.
- **Gloria Turner** — rename the curated-quotes key `'Gloria' → 'Gloria Turner'` (her confirmed EL `display_name`) plus the matching `content.ts` person field.

## Why the Gloria rename matters
Loop E's consent gate flagged the `gloria-turner` ledger draft: the cleared roster keyed her as `'Gloria'` but the draft/EL use the full name, so the gate couldn't tie the name to a cleared record (local `check:drift:ci` exit 1). The rename:
1. **Clears the consent gate** — the draft name now matches a cleared record.
2. **Fixes a latent bug** — the gated `/admin/stories` grid sources names from EL (`"Gloria Turner"`) and was silently failing `getCuratedQuotes()` against the `'Gloria'` key. It now resolves.

No public surface changes: the public `/stories` featured story carries its own inline quote and never calls `getCuratedQuotes`.

## Verification
- `npm run check:drift:ci` → exit 0 (was exit 1 on the Gloria consent gate)
- `npx tsc --noEmit` → exit 0, no errors

## Not in this PR
No ledger drafts published, no consent flags flipped, no portraits promoted — those remain deliberate human steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)