### PR TITLE
feat(ghl): align Goods forms to canonical tag contract (P3c, OCAP R8–R11)

### DIFF
--- a/v2/src/app/api/contact/route.ts
+++ b/v2/src/app/api/contact/route.ts
@@ -69,8 +69,21 @@ export async function POST(request: NextRequest) {
         source: `Website Contact: ${body.subject || 'General Inquiry'}`,
       });
 
-      if (body.subscribe) {
-        await ghl.addToNewsletter(body.email, body.name, 'contact-form');
+      // R8 (Spam Act 2003): `subscribe === true` is the explicit opt-in signal —
+      // it means the user ticked the newsletter checkbox on the contact form, so
+      // it carries consent for the goods-newsletter send-trigger. Pass it through
+      // as newsletterConsent='Yes'. Without it, no enrolment happens.
+      // TODO(tag-align): the /contact UI does NOT yet render a `subscribe`
+      // opt-in checkbox (the form never sends this field) — this branch is dormant
+      // until a default-OFF checkbox is added that sets subscribe=true. Adding the
+      // checkbox is the last step to make the consent path live.
+      if (body.subscribe === true) {
+        await ghl.addToNewsletter({
+          email: body.email,
+          name: body.name,
+          tag: 'contact-form',
+          newsletterConsent: 'Yes',
+        });
       }
     }
 

--- a/v2/src/app/api/newsletter/route.ts
+++ b/v2/src/app/api/newsletter/route.ts
@@ -9,6 +9,16 @@ export async function POST(request: NextRequest) {
     const phone = (body.phone as string | undefined)?.trim() || undefined;
     const name = (body.name as string | undefined)?.trim() || undefined;
     const tag = body.tag as string | undefined;
+    // R8 (Spam Act 2003): explicit consent gate. The newsletter send-trigger
+    // (goods-newsletter / comms:goods-newsletter) is granted ONLY when the form
+    // sends newsletterConsent==='Yes' from a default-OFF opt-in checkbox.
+    // Submitting the form is NOT consent. Accept either an explicit string flag
+    // or a boolean `consent` from the UI. TODO(tag-align): the live Goods
+    // newsletter forms (footer, get-involved, sponsor, canberra) do not yet
+    // render an opt-in checkbox — until they do, signups create leads but are
+    // NOT enrolled (OCAP-safe). Add the default-OFF checkbox at the form.
+    const newsletterConsent =
+      body.newsletterConsent === 'Yes' || body.consent === true ? 'Yes' : undefined;
 
     if (!email && !phone) {
       return NextResponse.json(
@@ -27,7 +37,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const ghlResult = await ghl.addToNewsletter({ email, phone, name, tag });
+    const ghlResult = await ghl.addToNewsletter({ email, phone, name, tag, newsletterConsent });
 
     console.log('[Newsletter Signup]', {
       channel: email && phone ? 'email+phone' : email ? 'email' : 'phone',

--- a/v2/src/lib/ghl/canonical-tags.ts
+++ b/v2/src/lib/ghl/canonical-tags.ts
@@ -1,0 +1,160 @@
+/**
+ * Canonical GHL tag contract for Goods (project:act-gd)
+ * ============================================================================
+ *
+ * ONE GHL account ("A Curious Tractor") · ONE canonical, namespaced tag
+ * contract across every ACT web surface. This module brings the Goods site's
+ * flat `goods-*` vocabulary onto that contract.
+ *
+ * Canon: wiki/concepts/ghl-crm-taxonomy.md §3 (namespaces) + §7 (OCAP/consent)
+ *        wiki/concepts/ghl-audience-comms-automation.md §5 (5-layer model)
+ * Plan:  thoughts/shared/plans/2026-06-08-whole-system-forms-tag-alignment.md §E
+ * Rulings implemented here: R8 (consent gate), R9 (lane:community), R10
+ *        (capital_tier field, drop the tier tag), R11 (story consent ≠ comms).
+ *
+ * 5-LAYER MODEL (the load-bearing invariant):
+ *   1 DESCRIBE  identity tags (project:/role:/interest:/place:/source:) — NEVER trigger a send
+ *   2 SEGMENT   smart-lists (saved tag queries)
+ *   3 ENROL     comms:* — the ONLY send-trigger; granted ONLY with explicit
+ *               newsletter_consent=Yes (Spam Act 2003)
+ *   4 ACT       workflows
+ *   5 GATE      consent (explicit only) + community-line (lane:community ⇒ ZERO comms ever, OCAP)
+ *
+ * GOLDEN RULE: identity tags never trigger a send; only `comms:` does, and
+ * `comms:` is granted by a consent-capturing form — never a hand-added flat tag.
+ *
+ * lane:community OCAP AGENCY MODEL (Ben, 2026-06-08): the lane = the relationship
+ * lane, not the funnel. A community-line contact is NEVER auto-enrolled into any
+ * comms:* and is never an automation segment. A comms:* may sit on them ONLY with
+ * explicit consent evidence (their own choice; storyteller/Elder opt-ins
+ * human-confirmed). Out of the machine, not out of communication. The strip-guard
+ * below removes any comms:* that arrives on a lane:community contact through THIS
+ * code path — defense-in-depth so a wrong tag can never become a wrong send.
+ *
+ * TRANSITION NOTE: we ADD canonical tags; we do NOT yet remove the flat `goods-*`
+ * tags, because the live GHL Smart Router branches on them today. Flat-tag removal
+ * happens in plan phase P5 (GHL tag migration), AFTER the Smart Router branches are
+ * re-keyed to the canonical tags in the GHL UI. Removing them here would break live
+ * routing before the dashboard side is migrated.
+ */
+
+/** The Goods project router tag — stamped on EVERY Goods write at the chokepoint. */
+export const PROJECT_TAG = 'project:act-gd';
+
+/** OCAP community-line marker. A contact carrying this is NEVER auto-enrolled in comms:*. */
+export const LANE_COMMUNITY = 'lane:community';
+
+/**
+ * Custom-field key for R10 capital-partnership ticket size. This is a TICKET-SIZE
+ * field, NOT the belonging-ladder `tier:` namespace — keep them apart. Env-driven
+ * so the live GHL custom-field id is configured in the dashboard, not hard-coded.
+ * If unset, the value is dropped (see R10 fallback) rather than half-wired.
+ */
+export const CAPITAL_TIER_FIELD_ID = process.env.GHL_FIELD_CAPITAL_TIER || '';
+
+/**
+ * Flat `goods-*` (and a few `act-*`/`project-goods`) tag → canonical namespaced
+ * tag(s). One flat tag may expand to several canonical tags. A flat tag NOT in
+ * this map is passed through unchanged (so per-asset `goods-asset-*`, source
+ * `goods-src-*`, and live Smart-Router branch keys survive — they are migrated
+ * in plan phase P5, not here).
+ *
+ * SAFETY: this map NEVER produces a `comms:*` tag. comms:* enrolment is granted
+ * ONLY by the consent-gated newsletter path (see grantNewsletterComms), never by
+ * mapping an inquiry/identity tag.
+ */
+const FLAT_TO_CANONICAL: Record<string, string[]> = {
+  // --- Roles ---
+  'goods-media': ['role:media', 'interest:media-pack'],
+  'goods-customer': ['role:buyer'],
+  'goods-bed-owner': ['interest:beds'],
+  'goods-washer-owner': ['interest:washer'],
+  'goods-sponsor': ['role:supporter'],
+  'goods-partner-lead': ['role:partner'],
+  // Capital-stack interest = a funder/investor lead. Adds role:funder on top of
+  // the role:partner that goods-partner-lead already contributes (a capital
+  // partner is both). NOT a comms: enrolment — inquiry ≠ consent.
+  'goods-capital-interest': ['role:funder', 'interest:capital'],
+  'goods-washer-interest': ['role:buyer', 'interest:washer'],
+  'goods-recipient': ['role:community', LANE_COMMUNITY],
+  'goods-support-request': ['role:community', 'interest:support', LANE_COMMUNITY],
+  'goods-story-submitter': ['role:storyteller', LANE_COMMUNITY],
+  'goods-feedback': ['role:supporter', 'interest:feedback'],
+  // 'goods-inquiry' carries no role on its own (subject-specific tags do); leave as-is.
+
+  // R11: bed-story consent_to_contact = "ok to reply about THIS story", NOT
+  // marketing consent. It maps to a story-followup IDENTITY tag (never a send),
+  // and NEVER to comms:*. (Belt-and-braces: these contacts also carry
+  // lane:community via goods-story-submitter, so the strip-guard would remove
+  // any comms:* anyway.) goods-no-contact intentionally maps to nothing.
+  'goods-consent-to-contact': ['interest:story-followup'],
+
+  // --- Strategic prospecting (internal, cold — must NEVER get comms:) ---
+  'goods-buyer-target': ['role:buyer'],
+  'goods-capital-target': ['role:funder'],
+  'goods-partner-target': ['role:partner'],
+};
+
+/**
+ * Map a method's flat tag list to the canonical contract:
+ *  - inject `project:act-gd` (R: general)
+ *  - inject `source:website` when the write originates from a public form
+ *  - expand mapped flat tags to their canonical namespaced equivalents
+ *  - KEEP the original flat tags (live Smart Router still branches on them — P5 removes them)
+ *  - enforce the OCAP strip-guard: if lane:community is present, remove ANY comms:*
+ *
+ * @param flatTags    the tags the public method built (goods-*, act-*, …)
+ * @param opts.source 'website' to add source:website (public-form origin); omit for non-form (cron/admin)
+ */
+export function toCanonicalTags(
+  flatTags: string[],
+  opts?: { source?: 'website' | 'none' },
+): string[] {
+  const out = new Set<string>();
+
+  // Always stamp the project router tag.
+  out.add(PROJECT_TAG);
+
+  // Public-form writes get source:website. Non-form callers (strategic-target
+  // cron, bed-scan SMS) pass source:'none' so we don't mislabel their origin.
+  if (!opts || opts.source === 'website' || opts.source === undefined) {
+    out.add('source:website');
+  }
+
+  for (const tag of flatTags) {
+    if (!tag) continue;
+    // Keep the original flat tag (transition: Smart Router still needs it).
+    out.add(tag);
+    // Add canonical expansion(s) if mapped.
+    const mapped = FLAT_TO_CANONICAL[tag];
+    if (mapped) for (const m of mapped) out.add(m);
+  }
+
+  // OCAP strip-guard: a community-line contact NEVER carries an auto-granted
+  // comms:* through this path. This is defense-in-depth — the maps above never
+  // emit comms:*, but if a caller ever passed one alongside lane:community, drop it.
+  if (out.has(LANE_COMMUNITY)) {
+    for (const t of Array.from(out)) {
+      if (t.startsWith('comms:')) out.delete(t);
+    }
+  }
+
+  return Array.from(out);
+}
+
+/**
+ * R8 — Spam Act 2003 consent gate for the goods-newsletter send-trigger.
+ *
+ * Returns the `comms:goods-newsletter` enrolment tag ONLY when explicit consent
+ * was captured (`newsletter_consent === 'Yes'`). With anything else (implied
+ * consent, missing checkbox) it returns [] — the contact is still created as a
+ * lead via the identity tags, but is NOT enrolled into the newsletter send.
+ *
+ * This is the single place comms:goods-newsletter is ever minted.
+ */
+export function grantNewsletterComms(newsletterConsent: 'Yes' | string | undefined): string[] {
+  return newsletterConsent === 'Yes' ? ['comms:goods-newsletter'] : [];
+}
+
+/** Env-driven custom-field id for the consent flag, mirroring the act.place contract. */
+export const NEWSLETTER_CONSENT_FIELD_ID = process.env.GHL_FIELD_NEWSLETTER_CONSENT || '';

--- a/v2/src/lib/ghl/index.ts
+++ b/v2/src/lib/ghl/index.ts
@@ -1359,8 +1359,9 @@ Submitted: ${new Date().toLocaleString('en-AU')}
 
       await addContactNote(result.contact.id, noteText);
 
-      // Smart Router branches on goods-partner-lead OR goods-media,
-      // and can now sub-branch on goods-segment-*, goods-tier-*, goods-timeline-*.
+      // Smart Router branches on goods-partner-lead OR goods-media, and can
+      // sub-branch on goods-segment-* / goods-timeline-*. (Ticket size moved
+      // off goods-tier-* to the capital_tier custom field — R10.)
       await fireSmartRouter(result.contact.id);
     }
 

--- a/v2/src/lib/ghl/index.ts
+++ b/v2/src/lib/ghl/index.ts
@@ -6,7 +6,21 @@
  * - Support ticket triage
  * - Partnership inquiry management
  * - Workflow triggers
+ *
+ * TAG CONTRACT: every write funnels through createOrUpdateContact(), which maps
+ * the flat `goods-*` tags onto ACT's canonical namespaced contract (project:act-gd,
+ * role:/interest:/source:/lane:community) via ./canonical-tags. See that module
+ * for the 5-layer model, the R8 consent gate, and the R9 OCAP lane:community
+ * strip-guard. wiki/concepts/ghl-crm-taxonomy.md is the source of truth.
  */
+
+import {
+  toCanonicalTags,
+  grantNewsletterComms,
+  CAPITAL_TIER_FIELD_ID,
+  NEWSLETTER_CONSENT_FIELD_ID,
+  LANE_COMMUNITY,
+} from './canonical-tags';
 
 // Configuration from environment
 const GHL_API_KEY = process.env.GHL_API_KEY || '';
@@ -212,6 +226,12 @@ interface ContactData {
   tags?: string[];
   customFields?: Record<string, string>;
   source?: string;
+  /**
+   * Tag-contract origin. 'website' (default) = a public form → adds source:website.
+   * 'none' = a non-form caller (strategic-target cron, bed-scan SMS) → no source:website.
+   * Passed through to toCanonicalTags() at the chokepoint.
+   */
+  tagSource?: 'website' | 'none';
 }
 
 interface OrderContactData {
@@ -570,13 +590,21 @@ async function createOrUpdateContact(data: ContactData): Promise<GHLResponse> {
     const existingContact = duplicateKey ? await findContact(duplicateKey) : null;
     console.log('[GHL] Existing contact search result:', existingContact ? `Found: ${existingContact.id}` : 'Not found');
 
+    // CANONICAL TAG CONTRACT — the one place every Goods write gets stamped with
+    // project:act-gd + source:website and its flat goods-* tags expanded to the
+    // namespaced canonical contract. The OCAP lane:community strip-guard runs
+    // here too (drops any comms:* that arrives on a community-line contact).
+    const canonicalTags = toCanonicalTags(data.tags || [], {
+      source: data.tagSource ?? 'website',
+    });
+
     const contactData: Record<string, unknown> = {
       locationId: GHL_LOCATION_ID,
       ...(email ? { email } : {}),
       ...(name ? { name } : {}),
       ...(phone ? { phone } : {}),
       ...(companyName ? { companyName } : {}),
-      tags: data.tags || [],
+      tags: canonicalTags,
       source: data.source || 'Goods on Country Website',
     };
 
@@ -1063,17 +1091,22 @@ export const ghl = {
     }
 
     try {
-      // Ensure contact exists (creates if not, returns id either way)
+      // Ensure contact exists (creates if not, returns id either way).
+      // R9 (OCAP): bed-scan targets a community recipient → lane:community. This
+      // is a server/cron caller (not a public web form) → tagSource:'none' so we
+      // don't stamp source:website on it.
       const upsert = await createOrUpdateContact({
         phone,
         name: opts.contactName || undefined,
         tags: [
           'goods-bed-scan',
+          LANE_COMMUNITY,
           ...(opts.assetId ? [tagForAsset(opts.assetId)] : []),
           ...(opts.tags || []),
         ],
         customFields: withGoodsProject({}),
         source: opts.assetId ? `Bed scan ${opts.assetId}` : 'Bed scan reminder',
+        tagSource: 'none',
       });
       const contactId = upsert.contact?.id;
       if (!contactId) {
@@ -1264,17 +1297,29 @@ Submitted: ${new Date().toLocaleString('en-AU')}
     if (CUSTOM_FIELDS.message && data.message) {
       customFields[CUSTOM_FIELDS.message] = data.message;
     }
-    withGoodsProject(customFields);
 
-    // Build segment/tier/timeline tags so Smart Router can route by
-    // partner type (foundation, corporate, buyer, investor, community)
-    // and by ticket size (under-25k, 25-100k, 100-500k, 500k+, loan).
+    // R10: fundingTier encodes CAPITAL TICKET SIZE (under-25k, 25-100k, …, 500k+,
+    // recoverable, patient-debt). It must NOT become the belonging-ladder `tier:`
+    // namespace (curious→steward). Move it to the dedicated `capital_tier` custom
+    // field and DROP the `goods-tier-*` tag entirely.
+    if (data.fundingTier) {
+      if (CAPITAL_TIER_FIELD_ID) {
+        customFields[CAPITAL_TIER_FIELD_ID] = data.fundingTier;
+      }
+      // FALLBACK (OCAP-safe): if the capital_tier custom-field id isn't configured
+      // in env yet, we DROP the tier value rather than half-wire it or let it
+      // pollute `tier:`. The ticket size is also preserved in the note + the
+      // partnership_inquiries DB row, so no signal is lost.
+      // TODO(tag-align): set GHL_FIELD_CAPITAL_TIER in the deployed env (create the
+      // "Capital Tier" custom field in GHL) so ticket size lands on the contact.
+    }
+
+    // Build segment/timeline tags so Smart Router can route by partner type
+    // (foundation, corporate, buyer, investor, community) and by timeline.
+    // NOTE: goods-tier-* is intentionally NOT built here (see R10 above).
     const segmentTags: string[] = [];
     if (data.partnerSegment) {
       segmentTags.push(`goods-segment-${data.partnerSegment}`);
-    }
-    if (data.fundingTier) {
-      segmentTags.push(`goods-tier-${data.fundingTier}`);
     }
     if (data.timeline) {
       segmentTags.push(`goods-timeline-${data.timeline}`);
@@ -1282,6 +1327,8 @@ Submitted: ${new Date().toLocaleString('en-AU')}
     if (data.partnershipType === 'capital-interest') {
       segmentTags.push('goods-capital-interest');
     }
+
+    withGoodsProject(customFields);
 
     const result = await createOrUpdateContact({
       email: data.contactEmail,
@@ -1332,6 +1379,9 @@ Submitted: ${new Date().toLocaleString('en-AU')}
       ...(data.tags || []),
     ];
 
+    // Internal cold-prospecting sync (CivicGraph/GrantScope), NOT a public form.
+    // tagSource:'none' = no source:website. These contacts must NEVER get comms:*
+    // (the canonical map never mints comms: from these role tags).
     const result = await createOrUpdateContact({
       email: data.contactEmail,
       phone: data.contactPhone,
@@ -1340,6 +1390,7 @@ Submitted: ${new Date().toLocaleString('en-AU')}
       tags,
       customFields: withGoodsProject({}),
       source: 'GrantScope Goods Workspace',
+      tagSource: 'none',
     });
 
     if (result.success && result.contact?.id) {
@@ -1428,37 +1479,65 @@ Synced: ${new Date().toLocaleString('en-AU')}
    *
    * Backward-compatible: the legacy positional signature
    * `addToNewsletter(email, name?, tag?)` still works.
+   *
+   * R8 (Spam Act 2003 consent gate): the newsletter send-trigger (goods-newsletter
+   * + comms:goods-newsletter) is granted ONLY when explicit consent is captured
+   * (`newsletterConsent: 'Yes'`). Without it, the contact is still created as a
+   * lead (project:act-gd + source) but gets NO send-trigger tag — neither the flat
+   * `goods-newsletter` the live Smart Router enrols on, nor the canonical
+   * `comms:goods-newsletter`. Submitting a form is NOT consent. The opt-in
+   * checkbox (default OFF) must set newsletterConsent='Yes' at the form.
    */
   async addToNewsletter(
-    optsOrEmail: { email?: string; phone?: string; name?: string; tag?: string } | string,
+    optsOrEmail:
+      | { email?: string; phone?: string; name?: string; tag?: string; newsletterConsent?: 'Yes' | string }
+      | string,
     name?: string,
     tag?: string,
   ): Promise<GHLResponse> {
     const opts = typeof optsOrEmail === 'string'
-      ? { email: optsOrEmail, name, tag }
+      ? { email: optsOrEmail, name, tag, newsletterConsent: undefined as string | undefined }
       : optsOrEmail;
 
     const email = cleanString(opts.email);
     const phone = cleanString(opts.phone);
     const sourceTag = opts.tag;
+    const hasConsent = opts.newsletterConsent === 'Yes';
 
     if (!email && !phone) {
       return { success: false, error: 'Email or phone is required' };
     }
 
-    const tags = [TAGS.newsletter];
+    // Source tag is an identity marker (where they came from) — safe without consent.
+    const tags: string[] = [];
     if (sourceTag) tags.push(`goods-src-${sourceTag}`);
+
+    // R8: ONLY grant the send-trigger tags with explicit consent. The flat
+    // goods-newsletter is the live Smart-Router enrolment key — granting it
+    // without consent is the Spam Act violation, so it is gated too.
+    if (hasConsent) {
+      tags.push(TAGS.newsletter); // flat send-trigger (live router) — transition
+      tags.push(...grantNewsletterComms(opts.newsletterConsent)); // canonical comms:goods-newsletter
+    }
+
+    // Stamp the consent flag as a custom field when configured + consented.
+    const customFields = withGoodsProject({});
+    if (hasConsent && NEWSLETTER_CONSENT_FIELD_ID) {
+      customFields[NEWSLETTER_CONSENT_FIELD_ID] = 'Yes';
+    }
 
     const result = await createOrUpdateContact({
       email,
       phone,
       name: opts.name,
       tags,
-      customFields: withGoodsProject({}),
+      customFields,
       source: sourceTag ? `Newsletter Signup (${sourceTag})` : 'Newsletter Signup',
     });
 
-    if (result.success && result.contact?.id) {
+    // Only fire the router (which can enrol into the newsletter drip) when the
+    // person actually consented. No consent = no send path.
+    if (hasConsent && result.success && result.contact?.id) {
       await fireSmartRouter(result.contact.id);
     }
 
@@ -1564,7 +1643,11 @@ Claimed: ${new Date().toLocaleString('en-AU')}
     const isWasher = productType.toLowerCase().includes('wash') ||
                      productType.toLowerCase().includes('machine');
 
-    const tags: string[] = [tagForAsset(assetId)];
+    // R9 (OCAP): an additional-claim is still a community recipient. The flat
+    // tags here (asset + claimed-*) don't carry goods-recipient, so add the
+    // protective lane:community marker explicitly. role:community follows from
+    // the recipient already carrying goods-recipient from their first claim.
+    const tags: string[] = [tagForAsset(assetId), LANE_COMMUNITY];
     if (isBed) tags.push(TAGS.claimedBed);
     if (isWasher) tags.push(TAGS.claimedWasher);
 
@@ -1596,7 +1679,8 @@ Claimed: ${new Date().toLocaleString('en-AU')}
    * Log an inbound message from a user
    */
   async logInboundMessage(data: UserMessageData): Promise<GHLResponse> {
-    const tags = [TAGS.userMessage];
+    // R9 (OCAP): inbound message from a claimed recipient = community line.
+    const tags = [TAGS.userMessage, LANE_COMMUNITY];
     if (data.assetId) tags.push(tagForAsset(data.assetId));
 
     const result = await createOrUpdateContact({
@@ -1606,6 +1690,7 @@ Claimed: ${new Date().toLocaleString('en-AU')}
       tags,
       customFields: withGoodsProject({}),
       source: 'User Message',
+      tagSource: 'none',
     });
 
     if (result.success && result.contact?.id) {
@@ -1630,7 +1715,8 @@ Sent: ${new Date().toLocaleString('en-AU')}
    * Log a user request (blanket, pillow, parts, etc.)
    */
   async logUserRequest(data: UserRequestData): Promise<GHLResponse> {
-    const tags = [TAGS.userRequest];
+    // R9 (OCAP): a request (blanket/pillow/parts) from a recipient = community line.
+    const tags = [TAGS.userRequest, LANE_COMMUNITY];
     if (data.assetId) tags.push(tagForAsset(data.assetId));
     // Request-type tag lets the Smart Router branch on what's being asked for
     // (blanket, pillow, parts, etc.) without code changes.
@@ -1645,6 +1731,7 @@ Sent: ${new Date().toLocaleString('en-AU')}
       tags,
       customFields: withGoodsProject({}),
       source: 'User Request',
+      tagSource: 'none',
     });
 
     if (result.success && result.contact?.id) {


### PR DESCRIPTION
## What
Aligns all Goods (goodsoncountry.com) public-form GHL writes to ACT's canonical tag contract at the single chokepoint (`v2/src/lib/ghl/index.ts` → `createOrUpdateContact`). Implements the locked OCAP / Spam-Act rulings R8–R11.

## Changes
- **R9 (OCAP, highest)** — `lane:community` on recipient-claim, support, and bed-story paths (+ secondary recipient paths). Strip-guard drops any `comms:*` that lands on a `lane:community` contact.
- **R8 (Spam Act)** — `comms:goods-newsletter` granted only on explicit `newsletterConsent='Yes'`; all newsletter forms fail safe (lead, not enrolled) until an opt-in checkbox is added.
- **`project:act-gd`** stamped on every write at the chokepoint.
- **R10** — `goods-tier-*` (ticket size) → `capital_tier` field; tag dropped (NOT the belonging-ladder `tier:`).
- **R11** — bed-story `consent_to_contact` → `interest:story-followup`, never `comms:`.
- Full flat→canonical map shipped.

## Notes
- Flat `goods-*` tags intentionally KEPT — the live Smart Router still branches on them; removal is gated to P5 (after the GHL-UI re-key).
- TODOs left where newsletter opt-in checkboxes still need adding in the form UI.
- tsc clean. No live GHL calls. Report: `thoughts/shared/handoffs/general/2026-06-08_goods-tag-align.md` (in act-global-infrastructure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)