### PR TITLE
feat: EL storyteller alignment cockpit + syndication-gate clearance

### DIFF
--- a/v2/src/app/admin/el-storytellers/page.tsx
+++ b/v2/src/app/admin/el-storytellers/page.tsx
@@ -9,17 +9,62 @@ export const metadata: Metadata = {
 
 export const dynamic = 'force-dynamic';
 
+// EL is one Next app serving both /api and /admin, so the API base is also
+// the app base. Deep-link straight to the EL storyteller edit screen.
+const EL_APP_URL =
+  process.env.EMPATHY_LEDGER_API_URL || 'https://empathy-ledger.vercel.app';
+
+function editInElHref(id: string): string {
+  return `${EL_APP_URL.replace(/\/$/, '')}/admin/storytellers/${id}/edit`;
+}
+
+// A single token (no space) means we only hold a first name — an identity gap
+// the elder/community has to resolve in EL, never us.
+function isFirstNameOnly(displayName: string): boolean {
+  return displayName.trim().split(/\s+/).length < 2;
+}
+
+function initials(displayName: string): string {
+  return displayName
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+// EL profile lifecycle status → label + colour. This is NOT consent — it's
+// whether the profile is live, half-built, awaiting review, or disabled.
+const STATUS_META: Record<string, { label: string; cls: string; attention: boolean }> = {
+  active: { label: 'Active', cls: 'bg-emerald-100 text-emerald-800', attention: false },
+  pending_review: { label: 'Pending review', cls: 'bg-amber-100 text-amber-800', attention: true },
+  needs_content: { label: 'Needs content', cls: 'bg-gray-100 text-gray-600', attention: true },
+  inactive: { label: 'Inactive', cls: 'bg-rose-100 text-rose-800', attention: true },
+};
+
+function statusMeta(status?: string | null) {
+  return (status && STATUS_META[status]) || { label: status || 'Unknown', cls: 'bg-gray-100 text-gray-500', attention: false };
+}
+
 export default async function ElStorytellersIndex() {
   const tellers = await getGoodsStorytellers();
+
+  const firstNameOnly = tellers.filter((s) => isFirstNameOnly(s.displayName));
+  // avatarUrl is mapped from public_avatar_url, so a missing one means the
+  // portrait isn't cleared for public surfaces — a real consent signal.
+  const noPublicPortrait = tellers.filter((s) => !s.avatarUrl);
+  const needsReview = tellers.filter((s) => statusMeta(s.contentStatus).attention);
+
   return (
     <div className="space-y-6 pb-16">
       <header className="flex items-start justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Storytellers in Empathy Ledger (Goods)</h1>
           <p className="mt-1 text-sm text-gray-500 max-w-prose">
-            Every Goods storyteller in EL. Click any to see how voice cards in
-            <code className="mx-1 rounded bg-gray-100 px-1">trip-stories.ts</code> can reference them
-            via <code className="rounded bg-gray-100 px-1">storytellerSlug</code>.
+            Every Goods storyteller in EL. EL is the source of truth — review here, then{' '}
+            <span className="font-medium text-gray-700">Edit in EL</span> to fix. Voice cards in{' '}
+            <code className="mx-1 rounded bg-gray-100 px-1">trip-stories.ts</code> reference these via{' '}
+            <code className="rounded bg-gray-100 px-1">storytellerSlug</code>.
           </p>
         </div>
         <Link
@@ -30,6 +75,30 @@ export default async function ElStorytellersIndex() {
         </Link>
       </header>
 
+      {/* Needs-attention banner — counts identity gaps the reviewer should action in EL */}
+      {tellers.length > 0 &&
+        (firstNameOnly.length > 0 || noPublicPortrait.length > 0 || needsReview.length > 0) && (
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm">
+            <span className="font-semibold text-amber-900">Needs attention</span>
+            {needsReview.length > 0 && (
+              <span className="text-amber-800">
+                <span className="font-semibold">{needsReview.length}</span> not active (review / draft / disabled)
+              </span>
+            )}
+            {firstNameOnly.length > 0 && (
+              <span className="text-amber-800">
+                <span className="font-semibold">{firstNameOnly.length}</span> first-name only
+              </span>
+            )}
+            {noPublicPortrait.length > 0 && (
+              <span className="text-amber-800">
+                <span className="font-semibold">{noPublicPortrait.length}</span> no public portrait
+              </span>
+            )}
+            <span className="text-amber-700/70">Fix in EL — this view is read-only.</span>
+          </div>
+        )}
+
       {tellers.length === 0 ? (
         <p className="rounded border border-dashed border-gray-300 bg-gray-50 p-6 text-center text-sm text-gray-600">
           No storytellers loaded (EL API may be rate-limited). Refresh in a moment.
@@ -39,26 +108,72 @@ export default async function ElStorytellersIndex() {
           <table className="min-w-full text-sm">
             <thead className="bg-gray-50 text-xs uppercase tracking-wide text-gray-500">
               <tr>
-                <th className="px-4 py-2 text-left">Name</th>
+                <th className="px-4 py-2 text-left">Storyteller</th>
                 <th className="px-4 py-2 text-left">Community</th>
+                <th className="px-4 py-2 text-left" title="EL profile lifecycle — not a consent grant">Status</th>
                 <th className="px-4 py-2 text-left">Elder</th>
                 <th className="px-4 py-2 text-left">Slug (use this on voice cards)</th>
                 <th className="px-4 py-2 text-left">Public page</th>
+                <th className="px-4 py-2 text-right">Edit</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
               {tellers.map((s) => {
                 const slug = slugify(s.displayName);
+                const firstNameGap = isFirstNameOnly(s.displayName);
+                const st = statusMeta(s.contentStatus);
                 return (
                   <tr key={s.id} className="hover:bg-amber-50/30">
-                    <td className="px-4 py-2 font-medium text-gray-900">{s.displayName}</td>
+                    <td className="px-4 py-2">
+                      <div className="flex items-center gap-3">
+                        {s.avatarUrl ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={s.avatarUrl}
+                            alt={s.displayName}
+                            className="h-9 w-9 flex-none rounded-full object-cover ring-1 ring-gray-200"
+                            referrerPolicy="no-referrer"
+                          />
+                        ) : (
+                          <span
+                            className="flex h-9 w-9 flex-none items-center justify-center rounded-full bg-gray-100 text-xs font-semibold text-gray-400 ring-1 ring-dashed ring-gray-300"
+                            title="No portrait in EL"
+                          >
+                            {initials(s.displayName) || '—'}
+                          </span>
+                        )}
+                        <div className="min-w-0">
+                          <div className="font-medium text-gray-900">{s.displayName}</div>
+                          {firstNameGap && (
+                            <span className="mt-0.5 inline-block rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-800">
+                              first-name only
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    </td>
                     <td className="px-4 py-2 text-gray-600">{s.community || '—'}</td>
+                    <td className="px-4 py-2">
+                      <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${st.cls}`}>
+                        {st.label}
+                      </span>
+                    </td>
                     <td className="px-4 py-2">{s.elderStatus ? '✓' : ''}</td>
                     <td className="px-4 py-2 font-mono text-xs text-amber-700">{slug}</td>
                     <td className="px-4 py-2">
                       <Link href={`/storytellers/${slug}`} target="_blank" className="text-blue-700 hover:underline">
                         /storytellers/{slug} ↗
                       </Link>
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      <a
+                        href={editInElHref(s.id)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center rounded-md border border-gray-300 px-2.5 py-1 text-xs font-medium text-gray-700 hover:border-amber-400 hover:bg-amber-50 hover:text-amber-800"
+                      >
+                        Edit in EL ↗
+                      </a>
                     </td>
                   </tr>
                 );

--- a/v2/src/app/admin/el-storytellers/page.tsx
+++ b/v2/src/app/admin/el-storytellers/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
-import { getGoodsStorytellers, slugify } from '@/lib/storytellers';
+import { getGoodsStorytellersWithClearance, slugify, type StorytellerClearance } from '@/lib/storytellers';
 
 export const metadata: Metadata = {
   title: 'Storytellers (EL) · Goods admin',
@@ -46,14 +46,27 @@ function statusMeta(status?: string | null) {
   return (status && STATUS_META[status]) || { label: status || 'Unknown', cls: 'bg-gray-100 text-gray-500', attention: false };
 }
 
+// "Cleared for the Goods public surface" verdict, derived from EL's canonical
+// syndication gate (stories_for_site). cleared = passes the gate; candidate =
+// published in a Goods-carried project. cleared=0 & candidate>0 = a real
+// consent gap holding content back ("Blocked").
+function clearanceVerdict(c: StorytellerClearance) {
+  if (c.cleared > 0)
+    return { label: 'On Goods', cls: 'bg-emerald-100 text-emerald-800', attention: false, detail: `${c.cleared} cleared by gate` };
+  if (c.candidate > 0)
+    return { label: 'Blocked', cls: 'bg-rose-100 text-rose-800', attention: true, detail: `${c.candidate} published, held by gate` };
+  return { label: 'No public stories', cls: 'bg-gray-100 text-gray-500', attention: false, detail: 'nothing published for Goods' };
+}
+
 export default async function ElStorytellersIndex() {
-  const tellers = await getGoodsStorytellers();
+  const tellers = await getGoodsStorytellersWithClearance();
 
   const firstNameOnly = tellers.filter((s) => isFirstNameOnly(s.displayName));
   // avatarUrl is mapped from public_avatar_url, so a missing one means the
   // portrait isn't cleared for public surfaces — a real consent signal.
   const noPublicPortrait = tellers.filter((s) => !s.avatarUrl);
   const needsReview = tellers.filter((s) => statusMeta(s.contentStatus).attention);
+  const blocked = tellers.filter((s) => clearanceVerdict(s.clearance).attention);
 
   return (
     <div className="space-y-6 pb-16">
@@ -77,9 +90,14 @@ export default async function ElStorytellersIndex() {
 
       {/* Needs-attention banner — counts identity gaps the reviewer should action in EL */}
       {tellers.length > 0 &&
-        (firstNameOnly.length > 0 || noPublicPortrait.length > 0 || needsReview.length > 0) && (
+        (blocked.length > 0 || firstNameOnly.length > 0 || noPublicPortrait.length > 0 || needsReview.length > 0) && (
           <div className="flex flex-wrap items-center gap-x-6 gap-y-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm">
             <span className="font-semibold text-amber-900">Needs attention</span>
+            {blocked.length > 0 && (
+              <span className="font-medium text-rose-700">
+                <span className="font-semibold">{blocked.length}</span> blocked from Goods (consent gap)
+              </span>
+            )}
             {needsReview.length > 0 && (
               <span className="text-amber-800">
                 <span className="font-semibold">{needsReview.length}</span> not active (review / draft / disabled)
@@ -111,6 +129,7 @@ export default async function ElStorytellersIndex() {
                 <th className="px-4 py-2 text-left">Storyteller</th>
                 <th className="px-4 py-2 text-left">Community</th>
                 <th className="px-4 py-2 text-left" title="EL profile lifecycle — not a consent grant">Status</th>
+                <th className="px-4 py-2 text-left" title="Cleared by EL's syndication gate (stories_for_site)">On Goods?</th>
                 <th className="px-4 py-2 text-left">Elder</th>
                 <th className="px-4 py-2 text-left">Slug (use this on voice cards)</th>
                 <th className="px-4 py-2 text-left">Public page</th>
@@ -122,6 +141,7 @@ export default async function ElStorytellersIndex() {
                 const slug = slugify(s.displayName);
                 const firstNameGap = isFirstNameOnly(s.displayName);
                 const st = statusMeta(s.contentStatus);
+                const cv = clearanceVerdict(s.clearance);
                 return (
                   <tr key={s.id} className="hover:bg-amber-50/30">
                     <td className="px-4 py-2">
@@ -156,6 +176,14 @@ export default async function ElStorytellersIndex() {
                     <td className="px-4 py-2">
                       <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${st.cls}`}>
                         {st.label}
+                      </span>
+                    </td>
+                    <td className="px-4 py-2">
+                      <span
+                        className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${cv.cls}`}
+                        title={cv.detail}
+                      >
+                        {cv.label}
                       </span>
                     </td>
                     <td className="px-4 py-2">{s.elderStatus ? '✓' : ''}</td>

--- a/v2/src/lib/empathy-ledger/client.ts
+++ b/v2/src/lib/empathy-ledger/client.ts
@@ -288,6 +288,31 @@ async function fetchFromELSupabase<T>(
   return response.json();
 }
 
+// Call an EL Postgres function via PostgREST. Used for the canonical
+// syndication gate (stories_for_site) so we never reimplement gate logic.
+async function fetchFromELSupabaseRpc<T>(
+  fn: string,
+  body: Record<string, unknown>,
+  select = '',
+  options: { revalidate?: number } = {},
+): Promise<T> {
+  const url = `${EL_SUPABASE_URL}/rest/v1/rpc/${fn}${select ? `?${select}` : ''}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'apikey': EL_SUPABASE_KEY,
+      'Authorization': `Bearer ${EL_SUPABASE_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+    next: { revalidate: options.revalidate ?? 60 },
+  });
+  if (!response.ok) {
+    throw new Error(`EL Supabase RPC error: ${response.status}`);
+  }
+  return response.json();
+}
+
 export const empathyLedger = {
   /**
    * Check if Empathy Ledger integration is enabled
@@ -443,6 +468,59 @@ export const empathyLedger = {
     } catch (error) {
       console.error('[EmpathyLedger] Failed to fetch storytellers:', error);
       return [];
+    }
+  },
+
+  /**
+   * Per-storyteller "cleared for the Goods public surface" verdict.
+   *
+   * `cleared` = stories that pass EL's canonical syndication gate
+   * (stories_for_site RPC — published + public + explicit consent + not
+   * withdrawn + elder-review satisfied + syndication enabled + site carries
+   * the project). We call the RPC, never reimplement the gate.
+   *
+   * `candidate` = published stories in the site's mapped project(s) — the
+   * gate's universe. cleared=0 while candidate>0 means a real consent gap
+   * (content exists for Goods but the gate is holding it back = "Blocked").
+   *
+   * Returns {} on any failure (cockpit degrades to no verdict, never throws).
+   */
+  async getGoodsSiteClearance(): Promise<Record<string, { cleared: number; candidate: number }>> {
+    if (!ENABLE_EMPATHY_LEDGER || !EL_SUPABASE_URL || !EL_SUPABASE_KEY) return {};
+    try {
+      // Site + its mapped project ids (slug-based, no hardcoded ids).
+      const siteRows = await fetchFromELSupabase<
+        { id: string; syndication_site_projects: { project_id: string }[] }[]
+      >('syndication_sites', `slug=eq.${GOODS_SITE_SLUG}&select=id,syndication_site_projects(project_id)`);
+      const projectIds = (siteRows[0]?.syndication_site_projects ?? [])
+        .map((p) => p.project_id)
+        .filter(Boolean);
+
+      const [clearedRows, candidateRows] = await Promise.all([
+        fetchFromELSupabaseRpc<{ storyteller_id: string | null }[]>(
+          'stories_for_site',
+          { p_site_slug: GOODS_SITE_SLUG },
+          'select=storyteller_id',
+        ),
+        projectIds.length
+          ? fetchFromELSupabase<{ storyteller_id: string | null }[]>(
+              'stories',
+              `status=eq.published&project_id=in.(${projectIds.join(',')})&select=storyteller_id`,
+            )
+          : Promise.resolve([]),
+      ]);
+
+      const out: Record<string, { cleared: number; candidate: number }> = {};
+      const bump = (id: string | null, key: 'cleared' | 'candidate') => {
+        if (!id) return;
+        (out[id] ??= { cleared: 0, candidate: 0 })[key]++;
+      };
+      clearedRows.forEach((r) => bump(r.storyteller_id, 'cleared'));
+      candidateRows.forEach((r) => bump(r.storyteller_id, 'candidate'));
+      return out;
+    } catch (error) {
+      console.error('[EmpathyLedger] Failed to compute Goods site clearance:', error);
+      return {};
     }
   },
 

--- a/v2/src/lib/empathy-ledger/client.ts
+++ b/v2/src/lib/empathy-ledger/client.ts
@@ -417,7 +417,29 @@ export const empathyLedger = {
         limit: params.limit,
         page: params.page,
       });
-      return response.storytellers;
+      const storytellers = response.storytellers;
+
+      // Enrich with EL profile lifecycle status (content_status). The content-hub
+      // API doesn't return it, so read it directly. Best-effort: on any failure
+      // the list still returns, just without status.
+      if (storytellers.length > 0 && EL_SUPABASE_URL && EL_SUPABASE_KEY) {
+        try {
+          const ids = storytellers.map((s) => s.id).join(',');
+          const rows = await fetchFromELSupabase<{ id: string; content_status: string | null }[]>(
+            'storytellers',
+            `id=in.(${ids})&select=id,content_status`,
+          );
+          const statusById = new Map(rows.map((r) => [r.id, r.content_status]));
+          return storytellers.map((s) => ({
+            ...s,
+            contentStatus: (statusById.get(s.id) ?? null) as EmpathyLedgerStoryteller['contentStatus'],
+          }));
+        } catch (enrichError) {
+          console.error('[EmpathyLedger] Failed to enrich storyteller status:', enrichError);
+        }
+      }
+
+      return storytellers;
     } catch (error) {
       console.error('[EmpathyLedger] Failed to fetch storytellers:', error);
       return [];

--- a/v2/src/lib/empathy-ledger/types.ts
+++ b/v2/src/lib/empathy-ledger/types.ts
@@ -89,6 +89,11 @@ export interface EmpathyLedgerStoryteller {
   storyCount: number;
   featured: boolean;
   community: string | null;
+  // EL profile lifecycle state. NOT a consent grant — it tracks whether the
+  // profile is live (active), still being built (needs_content), awaiting a
+  // reviewer (pending_review), or disabled (inactive). Enriched via direct
+  // EL-Supabase read; the content-hub API does not return it.
+  contentStatus?: 'active' | 'needs_content' | 'pending_review' | 'inactive' | null;
 }
 
 // --- Syndication API types (rich analysis data) ---

--- a/v2/src/lib/storytellers.ts
+++ b/v2/src/lib/storytellers.ts
@@ -45,3 +45,21 @@ export async function listStorytellerSlugs(): Promise<{ slug: string; name: stri
   const all = await getGoodsStorytellers();
   return all.map((s) => ({ slug: slugify(s.displayName), name: s.displayName }));
 }
+
+export type StorytellerClearance = { cleared: number; candidate: number };
+export type GoodsStorytellerRow = EmpathyLedgerStoryteller & { clearance: StorytellerClearance };
+
+/**
+ * Storytellers + their "cleared for the Goods public surface" verdict, derived
+ * from EL's canonical syndication gate. For the admin cockpit only.
+ */
+export async function getGoodsStorytellersWithClearance(): Promise<GoodsStorytellerRow[]> {
+  const [tellers, clearance] = await Promise.all([
+    getGoodsStorytellers(),
+    empathyLedger.getGoodsSiteClearance(),
+  ]);
+  return tellers.map((s) => ({
+    ...s,
+    clearance: clearance[s.id] ?? { cleared: 0, candidate: 0 },
+  }));
+}


### PR DESCRIPTION
Turns the read-only Goods `admin/el-storytellers` table into a review surface. EL stays the single source of truth — you review here and **Edit in EL** to fix.

## What's added
- **Portrait thumbnails** (initials fallback flags no public-cleared avatar)
- **`first-name only`** badge — identity gap to resolve in EL
- **Status** badge from `storytellers.content_status` — labelled as *profile lifecycle, NOT a consent grant*
- **On Goods?** verdict — derived from EL's canonical syndication gate (`stories_for_site` RPC, called via PostgREST, never reimplemented):
  - `On Goods` — ≥1 story passes the gate (surfaced publicly now)
  - `Blocked` — published Goods-project stories exist but none clear the gate = a real consent gap
  - `No public stories` — nothing published for Goods to carry
- **Needs attention** banner counting blocked / not-active / first-name-only / no-public-portrait
- **Edit in EL ↗** deep-link straight to the EL storyteller edit screen

## Honesty notes
- A literal "consent status" column has no backing data for Goods — `syndication_consent` has 0 rows for the Goods site (it carries stories via the gate / project mapping). So no faked consent column; the real consent signals surfaced are "no public portrait" and the gate verdict.
- `candidate` (the Blocked denominator) = published stories in the site's mapped project, resolved by slug at runtime — no hardcoded ids.

## Today's baseline
9 storytellers On Goods, **0 Blocked** — every published Goods story currently clears consent. The Blocked signal stays dark until a real gap appears (withdrawal / elder-review pending / syndication disabled).

## Verification
- `npx tsc --noEmit` clean across the repo
- `stories_for_site` RPC EXECUTE granted to anon/authenticated/service_role (the Goods key can call it)
- No file overlap with the concurrent GHL work on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)