### PR TITLE
Funder report: Snow figure reconciliation + alignment beats (washers, stage/focus/ignition)

### DIFF
--- a/v2/scripts/generate-funder-report.mjs
+++ b/v2/scripts/generate-funder-report.mjs
@@ -121,6 +121,9 @@ process.stdout.write(JSON.stringify({
   investmentTiers: f.investmentTiers,
   headlineAchievements: f.headlineAchievements,
   additionalContext: f.additionalContext,
+  stageOfGrowth: f.stageOfGrowth,
+  focusAreas: f.focusAreas,
+  ignition: f.ignition,
 }));
 })();
 `));
@@ -240,6 +243,23 @@ const RESOLVERS = {
   },
   'headline-achievements': async () => realFunder.headlineAchievements || '_(no headline achievements configured)_',
   'additional-context': async () => realFunder.additionalContext || '',
+  'stage-of-growth': async () => {
+    const s = realFunder.stageOfGrowth;
+    if (!s?.dial?.length) return '_(stage of growth not configured)_';
+    const dial = s.dial.map((d, i) => (i === s.currentIndex ? `**${d}**` : d)).join(' · ');
+    return `**Stage: ${s.dial[s.currentIndex]}**\n\n${dial}\n\n${s.stepChange}`;
+  },
+  'focus-area': async () => {
+    const f = realFunder.focusAreas;
+    if (!f?.length) return '_(focus areas not configured)_';
+    return f.map((x, i) => `**${i + 1}. ${x.title}**\n\n${x.body}`).join('\n\n');
+  },
+  'ignition': async () => {
+    const ig = realFunder.ignition;
+    if (!ig) return '_(ignition not configured)_';
+    const chain = (ig.chain || []).map((c, i) => `${i + 1}. ${c}`).join('\n');
+    return `${ig.narrative}\n\n${chain}`;
+  },
   'financials-at-a-glance': async () => {
     const c = realFunder.commitment;
     const rows = ['| Item | Value |','|---|---|'];
@@ -280,6 +300,7 @@ const SECTION_FILES = {
   'safeguarding-risks': '13-safeguarding-risks.md','commitment-progress': '14-commitment-progress.md',
   'upcoming-commitments': '15-upcoming-commitments.md','whats-next': '16-whats-next.md',
   'country-acknowledgement': '17-country-acknowledgement.md',
+  'stage-of-growth': '18-stage-of-growth.md','focus-area': '19-focus-area.md','ignition': '20-ignition.md',
 };
 
 const sectionsDir = join(__dirname, '..', '..', 'wiki', 'templates', 'funder-report', 'sections');

--- a/v2/scripts/generate-funder-report.mjs
+++ b/v2/scripts/generate-funder-report.mjs
@@ -101,7 +101,8 @@ function tsxEval(code) {
 
 const configJson = JSON.parse(await tsxEval(`
 import { getFunder } from './src/lib/funders/registry';
-const f = getFunder(${JSON.stringify(funderSlug)});
+(async () => {
+const f = await getFunder(${JSON.stringify(funderSlug)});
 if (!f) { console.error('not found'); process.exit(1); }
 process.stdout.write(JSON.stringify({
   slug: f.slug,
@@ -121,6 +122,7 @@ process.stdout.write(JSON.stringify({
   headlineAchievements: f.headlineAchievements,
   additionalContext: f.additionalContext,
 }));
+})();
 `));
 
 // Hydrate runtime methods
@@ -143,27 +145,38 @@ async function fetchXero(qs) {
 }
 
 const RESOLVERS = {
+  // NOTE: bed resolvers filter product ILIKE %bed% so washers/other assets are
+  // NOT counted as beds (matches the canonical impact-fetcher.ts logic).
   'beds-deployed-this-period': async () => {
     const res = await goods.from('assets').select('unique_id', { count: 'exact', head: true })
-      .gte('supply_date', period.start).lte('supply_date', period.end).eq('status', 'deployed');
+      .ilike('product', '%bed%').gte('supply_date', period.start).lte('supply_date', period.end).eq('status', 'deployed');
     return String(res.count ?? 0);
   },
   'beds-allocated-this-period': async () => {
     const res = await goods.from('assets').select('unique_id', { count: 'exact', head: true })
-      .gte('supply_date', period.start).lte('supply_date', period.end).eq('status', 'allocated');
+      .ilike('product', '%bed%').gte('supply_date', period.start).lte('supply_date', period.end).eq('status', 'allocated');
     return String(res.count ?? 0);
   },
   'beds-total-this-period': async () => {
     const res = await goods.from('assets').select('unique_id', { count: 'exact', head: true })
-      .gte('supply_date', period.start).lte('supply_date', period.end).in('status', ['deployed', 'allocated']);
+      .ilike('product', '%bed%').gte('supply_date', period.start).lte('supply_date', period.end).in('status', ['deployed', 'allocated']);
     return String(res.count ?? 0);
   },
+  // Washing machines delivered this period (product = "Washing Machine").
+  'washers-total-this-period': async () => {
+    const res = await goods.from('assets').select('unique_id', { count: 'exact', head: true })
+      .ilike('product', '%wash%').gte('supply_date', period.start).lte('supply_date', period.end).in('status', ['deployed', 'allocated']);
+    return String(res.count ?? 0);
+  },
+  // Telemetry-working washers — honest number (28 deployed all-time, 14 reporting).
+  'washers-working': async () => '14 telemetry-confirmed working (of 28 deployed to date)',
+  // Plastic = STRETCH beds only (recycled HDPE). Basket beds are not a plastic product.
   'plastic-kg-transferred': async () => {
     const res = await goods.from('assets').select('unique_id', { count: 'exact', head: true })
-      .gte('supply_date', period.start).lte('supply_date', period.end).in('status', ['deployed', 'allocated']);
+      .ilike('product', '%stretch%').gte('supply_date', period.start).lte('supply_date', period.end).in('status', ['deployed', 'allocated']);
     const beds = res.count ?? 0;
     const kg = beds * 20;
-    return `**${kg.toLocaleString()} kg** (${(kg/1000).toFixed(2)} tonnes) — ${beds} beds × 20 kg HDPE`;
+    return `**${kg.toLocaleString()} kg** (${(kg/1000).toFixed(2)} tonnes) — ${beds} Stretch beds × 20 kg HDPE`;
   },
   'communities-served': async () => {
     const { data } = await goods.from('assets').select('community')
@@ -181,7 +194,7 @@ const RESOLVERS = {
       return '```\nCommitment:  $' + total.toLocaleString('en-AU') + '\nPaid:        ' + bar + ' ' + pct + '%  ($' + paid.toLocaleString('en-AU') + ')\n```';
     }
     const periodRes = await goods.from('assets').select('unique_id', { count: 'exact', head: true })
-      .gte('supply_date', period.start).lte('supply_date', period.end).in('status', ['deployed', 'allocated']);
+      .ilike('product', '%bed%').gte('supply_date', period.start).lte('supply_date', period.end).in('status', ['deployed', 'allocated']);
     const periodCount = periodRes.count ?? 0;
     const total = c.totalUnits;
     const pct = total > 0 ? Math.round((periodCount/total)*100) : 0;

--- a/v2/src/lib/funders/configs/snow.ts
+++ b/v2/src/lib/funders/configs/snow.ts
@@ -20,10 +20,18 @@ export const snowConfig: FunderConfig = {
     email: 's.grimsley-ballard@snowfoundation.org.au',
     phone: '0417 851 341',
   },
+  // FINANCIAL DRIFT FLAG (2026-06-09): paidToDate/toBePaid below are STALE.
+  // Live Xero (read-only, contact-level) shows Snow ~$493,129.79 received over 3yr,
+  // $0 outstanding (i.e. the 2025-26 slice is fully PAID, not $275K paid / $120K pending).
+  // totalAud $395,000 is the 2024/OC0014 grant commitment specifically (still valid).
+  // DO NOT trust paidToDate/toBePaid until the FY26-only slice is carved out + the 2
+  // residual checks clear. See wiki/outputs/funder-reports/snow/2026-06-09-snow-figure-reconciliation.md
+  // The report's financials-at-a-glance / commitment-progress also render the LIVE
+  // [METRIC: xero-drawn-aud] resolver, which is the source to prefer.
   commitment: {
     totalAud: 395000,
-    paidToDateAud: 275000,
-    toBePaidAud: 120000,
+    paidToDateAud: 275000, // STALE — see flag above; slice now fully paid
+    toBePaidAud: 120000, // STALE — see flag above
     invoicesRaisedAud: 434500, // inc-GST, across 6 invoices (2 missing)
     reportsSubmitted: '3 of 3 due so far ✓',
     nextReportDue: '31/07/2026 (FY26 Operational acquittal)',

--- a/v2/src/lib/funders/configs/snow.ts
+++ b/v2/src/lib/funders/configs/snow.ts
@@ -40,10 +40,16 @@ export const snowConfig: FunderConfig = {
   },
   photoTags: ['snow-funded', 'trip-may-2026'],
   tone: 'evidence-and-named',
+  // Section order follows the 7-beat narrative spine (person -> numbers ->
+  // stage of growth -> focus -> ignition -> proof/governance -> invitation).
+  // The 3 new beats are inserted after the headline numbers; order is reviewable.
   sections: [
     'cover',
     'financials-at-a-glance',
     'headline-achievements',
+    'stage-of-growth',
+    'focus-area',
+    'ignition',
     'investment-priorities',
     'alignment-principles',
     'safeguarding-risks',
@@ -209,4 +215,34 @@ export const snowConfig: FunderConfig = {
     '### Product\n- **3 generations of stretch beds** developed (V1 → V3, V4 in design). 25 kg of plastic waste diverted per bed.\n- **Containerised washing machine V1** built and field-tested with Bloomfield family in Tennant Creek (Jan 2026).\n- **Production plant infrastructure** progressed from concept to near-complete containerised facility (shredder + extruder + CNC router for bed components). Investment to date ~$100,000 (TFN + ACT).\n- **15-20 beds deployed** across 8 families for field testing (Diane Stokes, Norm Frank, Utopian Homelands, Tennant Creek participants) prior to the Centrecorp scale-up. Trip-period numbers below.\n\n### Partnership\n- **Oonchiumpa Bloomfield family** partnership formalising — paid cultural consultation at university research rates (~$3,800/day), tiered payment structures, planned co-hosting of production plant.\n- **Four health organisations** initiated engagement after the 2025 Healthy Homes forum.\n- **Centrecorp Foundation** confirmed partnership for May 17-27 Central Australia deployment (Mparntwe + Utopia homelands).\n- **Homeland School Company** confirmed Q3 deployment — 1-2 washers + 65 beds across Maningrida communities.\n\n### Demand validation\n- **200-350 bed requests** logged from communities + health organisations.\n- **Diane Stokes** received 1 bed, requested 20 more within 2 weeks, offered to self-fund.\n- **Norm Frank** requested 3 beds in maroon after his daughter trialled them.\n- **Utopian Homelands** requested beds for every child (~6,000 worth).\n- **Palm Island Community Company** offered to purchase a production plant outright after watching the production video.\n- **QIC** committed to building 50 beds with staff for NAIDOC week.',
   additionalContext:
     '## RHD + Healthy Homes connection\n\n- Cleanable, durable beds and washing machines are foundational health interventions, especially relevant to **Rheumatic Heart Disease prevention** through housing quality and sleep health.\n- Four health organisations engaged after the 2025 Healthy Homes forum. **Anna Phillip** (Healthy Homes Project Coordinator) is a primary contact.\n- **Remote Laundry Collective**: washing machines built with Bloomfield family in January 2026; same production plant will scale washing machine access.\n- Multi-product capability means RHD-relevant interventions (beds + washers + fridges) flow from one infrastructure investment.',
+  // PROPOSED 2026-06-09 (Claude) — grounded in canon + the Snow catch-up email.
+  // Confirm dial labels, current stage, focus priorities, and the ignition chain
+  // with Ben before sending. These three are the narrative spine's beats 3-5.
+  stageOfGrowth: {
+    dial: ['Prototype', 'Pilot', 'Scaling', 'On-Country production'],
+    currentIndex: 2, // Scaling, building toward on-country production
+    stepChange:
+      'This period Goods began crossing from delivering beds to making them on country. The containerised production plant reached roughly 85% complete, the washing-machine line grew to a 28-unit field fleet (14 telemetry-confirmed working), and the first paid local production roles are forming in Alice Springs. The step-change is the shift from beds delivered to community toward beds made by community.',
+  },
+  focusAreas: [
+    {
+      title: 'Commission the on-country production plant',
+      body: 'Finish the containerised facility (about 85% complete) and make the community siting decision (Tennant Creek or Mparntwe), so beds are made on country rather than freighted in.',
+    },
+    {
+      title: 'Stand up paid local production roles in Alice Springs',
+      body: 'Turn delivery into local employment. The first roles forming now are the proof point for the community-owned production model, and the part of this work Snow is most excited about.',
+    },
+  ],
+  ignition: {
+    chain: [
+      "Snow's anchor capital, given before the proof was in the houses",
+      'de-risked the on-country production plant',
+      'the plant lets beds be made on country, not freighted in',
+      'which creates paid local jobs (the Alice Springs roles forming now)',
+      'and turns the next 1,000 beds into a local-employment story',
+    ],
+    narrative:
+      'Snow backed Goods before the proof was in the houses. That anchor capital de-risked the production plant, and the plant is what turns a delivered bed into a locally made one. The Alice Springs roles forming now are the first jobs out of that decision. Your support is the spark under the shift from beds delivered to community toward beds made by community, and it is what makes the next 1,000 beds a local-employment story rather than a freight invoice.',
+  },
 };

--- a/v2/src/lib/funders/generate.ts
+++ b/v2/src/lib/funders/generate.ts
@@ -33,6 +33,9 @@ const SECTION_FILES: Record<SectionKey, string> = {
   'commitment-progress': '14-commitment-progress.md',
   'upcoming-commitments': '15-upcoming-commitments.md',
   'whats-next': '16-whats-next.md',
+  'stage-of-growth': '18-stage-of-growth.md',
+  'focus-area': '19-focus-area.md',
+  'ignition': '20-ignition.md',
   'country-acknowledgement': '17-country-acknowledgement.md',
 };
 

--- a/v2/src/lib/funders/metrics.ts
+++ b/v2/src/lib/funders/metrics.ts
@@ -38,26 +38,39 @@ function scopedAssetsQuery(ctx: ReportContext) {
   return q;
 }
 
+// Bed resolvers filter product ILIKE %bed% so washers/other assets are NOT
+// counted as beds (matches impact-fetcher.ts; the unfiltered query over-counted).
 const bedsDeployedThisPeriod: MetricResolver = async (ctx) => {
-  const res = await scopedAssetsQuery(ctx).eq('status', 'deployed');
+  const res = await scopedAssetsQuery(ctx).ilike('product', '%bed%').eq('status', 'deployed');
   return String(res.count ?? 0);
 };
 
 const bedsAllocatedThisPeriod: MetricResolver = async (ctx) => {
-  const res = await scopedAssetsQuery(ctx).eq('status', 'allocated');
+  const res = await scopedAssetsQuery(ctx).ilike('product', '%bed%').eq('status', 'allocated');
   return String(res.count ?? 0);
 };
 
 const bedsThisPeriodAllStatuses: MetricResolver = async (ctx) => {
-  const res = await scopedAssetsQuery(ctx).in('status', ['deployed', 'allocated']);
+  const res = await scopedAssetsQuery(ctx).ilike('product', '%bed%').in('status', ['deployed', 'allocated']);
   return String(res.count ?? 0);
 };
 
+// Washing machines delivered this period (product = "Washing Machine").
+const washersThisPeriod: MetricResolver = async (ctx) => {
+  const res = await scopedAssetsQuery(ctx).ilike('product', '%wash%').in('status', ['deployed', 'allocated']);
+  return String(res.count ?? 0);
+};
+
+// Telemetry-working washers — honest number (28 deployed all-time, 14 reporting).
+const washersWorking: MetricResolver = async () =>
+  '14 telemetry-confirmed working (of 28 deployed to date)';
+
+// Plastic = STRETCH beds only (recycled HDPE). Basket beds are not a plastic product.
 const plasticKgTransferred: MetricResolver = async (ctx) => {
-  const res = await scopedAssetsQuery(ctx).in('status', ['deployed', 'allocated']);
+  const res = await scopedAssetsQuery(ctx).ilike('product', '%stretch%').in('status', ['deployed', 'allocated']);
   const beds = res.count ?? 0;
   const kg = beds * PLASTIC_KG_PER_BED;
-  return `**${kg.toLocaleString()} kg** (${(kg / 1000).toFixed(2)} tonnes) — ${beds} beds × ${PLASTIC_KG_PER_BED} kg HDPE`;
+  return `**${kg.toLocaleString()} kg** (${(kg / 1000).toFixed(2)} tonnes) — ${beds} Stretch beds × ${PLASTIC_KG_PER_BED} kg HDPE`;
 };
 
 const communitiesServed: MetricResolver = async (ctx) => {
@@ -93,7 +106,7 @@ const commitmentProgressBar: MetricResolver = async (ctx) => {
   // (e.g. 496 beds against a 109-unit commitment), so clamp the bar to 0-20
   // segments and the displayed pct to 0-100 — an unclamped `'░'.repeat(20-filled)`
   // throws RangeError on overshoot and surfaces as a [METRIC ERROR] in the deck.
-  const periodRes = await scopedAssetsQuery(ctx).in('status', ['deployed', 'allocated']);
+  const periodRes = await scopedAssetsQuery(ctx).ilike('product', '%bed%').in('status', ['deployed', 'allocated']);
   const periodCount = periodRes.count ?? 0;
   const total = c.totalUnits;
   const rawPct = total > 0 ? Math.round((periodCount / total) * 100) : 0;
@@ -207,6 +220,29 @@ const additionalContext: MetricResolver = async (ctx) => {
   return ctx.funder.additionalContext || '';
 };
 
+// Beat 3: where we are on the journey + this period's step-change.
+const stageOfGrowth: MetricResolver = async (ctx) => {
+  const s = ctx.funder.stageOfGrowth;
+  if (!s?.dial?.length) return '_(stage of growth not configured)_';
+  const dial = s.dial.map((d, i) => (i === s.currentIndex ? `**${d}**` : d)).join(' · ');
+  return `**Stage: ${s.dial[s.currentIndex]}**\n\n${dial}\n\n${s.stepChange}`;
+};
+
+// Beat 4: the 1-2 priorities this capital is unlocking now.
+const focusArea: MetricResolver = async (ctx) => {
+  const f = ctx.funder.focusAreas;
+  if (!f?.length) return '_(focus areas not configured)_';
+  return f.map((x, i) => `**${i + 1}. ${x.title}**\n\n${x.body}`).join('\n\n');
+};
+
+// Beat 5: how THIS funder's support ignited the momentum (catalytic chain).
+const ignition: MetricResolver = async (ctx) => {
+  const ig = ctx.funder.ignition;
+  if (!ig) return '_(ignition not configured)_';
+  const chain = (ig.chain || []).map((c, i) => `${i + 1}. ${c}`).join('\n');
+  return `${ig.narrative}\n\n${chain}`;
+};
+
 const financialsAtAGlance: MetricResolver = async (ctx) => {
   const c = ctx.funder.commitment;
   const rows: string[] = [];
@@ -242,6 +278,8 @@ export const MetricResolvers: Record<string, MetricResolver> = {
   'beds-deployed-this-period': bedsDeployedThisPeriod,
   'beds-allocated-this-period': bedsAllocatedThisPeriod,
   'beds-total-this-period': bedsThisPeriodAllStatuses,
+  'washers-total-this-period': washersThisPeriod,
+  'washers-working': washersWorking,
   'plastic-kg-transferred': plasticKgTransferred,
   'communities-served': communitiesServed,
   'commitment-progress-bar': commitmentProgressBar,
@@ -253,6 +291,9 @@ export const MetricResolvers: Record<string, MetricResolver> = {
   'investment-tiers': investmentTiersTable,
   'headline-achievements': headlineAchievements,
   'additional-context': additionalContext,
+  'stage-of-growth': stageOfGrowth,
+  'focus-area': focusArea,
+  'ignition': ignition,
   'financials-at-a-glance': financialsAtAGlance,
   'period-label': periodLabel,
   'period-start': periodStart,

--- a/v2/src/lib/funders/types.ts
+++ b/v2/src/lib/funders/types.ts
@@ -31,6 +31,9 @@ export type SectionKey =
   | 'commitment-progress'
   | 'upcoming-commitments'
   | 'whats-next'
+  | 'stage-of-growth'        // where Goods is on the journey + this period's step-change
+  | 'focus-area'            // the 1-2 priorities this capital is unlocking now
+  | 'ignition'              // how THIS funder's support ignited the momentum (catalytic)
   | 'country-acknowledgement';
 
 export type ReportTone = 'short-and-visual' | 'evidence-and-named';
@@ -81,6 +84,25 @@ export interface FunderContact {
   phone?: string;
 }
 
+/** Stage-of-growth dial: where Goods sits on the journey + this period's step-change. */
+export interface StageOfGrowthSpec {
+  dial: string[];          // ordered stages, e.g. ['Prototype','Pilot','Scaling','On-Country production']
+  currentIndex: number;    // 0-based index into dial = where Goods is now
+  stepChange: string;      // markdown: the concrete step-change THIS period
+}
+
+/** A focus area: one priority the funder's capital is unlocking now. */
+export interface FocusAreaSpec {
+  title: string;
+  body: string;            // markdown
+}
+
+/** Catalytic attribution: how THIS funder's support ignited the momentum. */
+export interface IgnitionSpec {
+  chain: string[];         // ordered links in the catalytic chain (rendered as a numbered list, no arrows)
+  narrative: string;       // markdown paragraph
+}
+
 export interface ReportPeriod {
   slug: string;      // e.g. "2026-Q2"
   label: string;     // human readable, e.g. "Q2 2026"
@@ -111,6 +133,9 @@ export interface FunderConfig {
   investmentTiers?: InvestmentTierSpec[];
   headlineAchievements?: string;  // markdown blob — funder-specific narrative
   additionalContext?: string;     // e.g. RHD section for Snow
+  stageOfGrowth?: StageOfGrowthSpec; // beat 3: where we are on the journey
+  focusAreas?: FocusAreaSpec[];      // beat 4: what we're focused on next
+  ignition?: IgnitionSpec;           // beat 5: how your support ignites change
 }
 
 /**

--- a/wiki/articles/capital/funder-register.md
+++ b/wiki/articles/capital/funder-register.md
@@ -16,7 +16,7 @@ Do not mix received funding with pipeline. Snow Foundation Round 4 is currently 
 
 | Measure | Amount | What it means | Status |
 |---|---:|---|---|
-| Received funder/program subtotal from current source trail | $405,685 | Snow, TFN, FRRR/VFFF, AMP Spark and QBE Stage 1. | Needs finance reconciliation. |
+| Received funder/program subtotal from current source trail | $405,685 | Snow, TFN, FRRR/VFFF, AMP Spark and QBE Stage 1. | Needs finance reconciliation. NOTE: uses the stale Snow $193,785; re-derive with the restated Snow ~$493,130 (2026-06-09). |
 | Warm Snow Foundation Round 4 pathway | $130,000 | Pipeline / draft pathway only. Not included in received funding. | Needs proposal and current Snow confirmation. |
 | REAL Innovation Fund / DEWR pathway | $2,400,000 | Two site pathway: $1.2M for Townsville and $1.2M for Alice Springs over three years. Not included in received funding. | EOI / application pathway; confirm current status and lead entities. |
 
@@ -26,7 +26,7 @@ This is the table mentors and funders should be able to read first. It should ev
 
 | Funder / source | Amount | Timing | Instrument | Relationship read | Evidence and review action |
 |---|---:|---|---|---|---|
-| Snow Foundation | $193,785 | 2023-2025 | Grant / philanthropic support | Anchor funder. Sally Grimsley-Ballard is a key relationship and has been close enough to the work to travel to Tennant Creek. | Confirm cash receipt dates, purpose restrictions and Round 4 status. See [[../investors/snow-foundation]] and [[../sources/funding-journey]]. |
+| Snow Foundation | ~$493,130 | 2023-2026 | Grant / philanthropic support | Anchor funder. Sally Grimsley-Ballard is a key relationship and has been close enough to the work to travel to Tennant Creek. | Restated 2026-06-09 from $193,785 (stale) via live Xero pull, contact-level, $0 outstanding. 2 Xero-UI checks pending (Goods-coding; any pre-2023-06 revenue). See `wiki/outputs/funder-reports/snow/2026-06-09-snow-figure-reconciliation.md`, [[../investors/snow-foundation]] and [[../sources/funding-journey]]. |
 | The Funding Network | $130,000 | September / December 2025 source trail | Grant / live pitch raise | Strong proof that the story can move people when told directly. Also a connector network. | Confirm exact pledge versus received timing and reporting obligations. See [[../investors/tfn]]. |
 | FRRR + VFFF Backing the Future | $50,000 | July 2025 | Joint grant | Rural, regional and youth/community credibility. FRRR administers and VFFF co-funds. | Do not count this as two separate $50K grants. See [[../investors/frrr]] and [[../investors/vfff]]. |
 | AMP Spark | $21,900 | June 2024 | Program / accelerator support | Social enterprise credential and early support. | Confirm purpose, acquittal and alumni pathway. See [[../investors/amp]]. |

--- a/wiki/articles/investors/snow-foundation.md
+++ b/wiki/articles/investors/snow-foundation.md
@@ -1,6 +1,6 @@
 # Snow Foundation
 
-> Existing anchor funder. $193K received across multiple rounds. Long-term partnership model (not one-off grants). Co-invested in Jigsaw alongside the SEFA-led syndicate. Sally Grimsley-Ballard sits on Goods advisory group.
+> Existing anchor funder. ~$493K received across multiple rounds (Xero, contact-level, 2026-06-09, $0 outstanding; supersedes the earlier $193K snapshot, see `wiki/outputs/funder-reports/snow/2026-06-09-snow-figure-reconciliation.md`, 2 Xero-UI checks pending). Long-term partnership model (not one-off grants). Co-invested in Jigsaw alongside the SEFA-led syndicate. Sally Grimsley-Ballard sits on Goods advisory group.
 
 ## Mandate
 
@@ -19,7 +19,7 @@ Rebecca Parkinson (QBE induction): "Snow Foundation partners long-term, flexible
 
 ## Current state
 
-- Received: $193K cumulative.
+- Received: ~$493,129.79 cumulative (Xero 3-yr, contact-level, 2026-06-09, $0 outstanding). The earlier $193K figure is superseded. 2 Xero-UI checks pending: that all Snow invoices are Goods-coded, and whether any Snow revenue predates 2023-06-09. See `wiki/outputs/funder-reports/snow/2026-06-09-snow-figure-reconciliation.md`.
 - Pipeline: Snow R4 at $130K target.
 - Proposed 2026 role: **letter of support** acting as catalytic signal to open SEFA + Mindaroo + PFI commitments.
 

--- a/wiki/outputs/funder-reports/2026-06-09-impact-report-alignment-and-automation.md
+++ b/wiki/outputs/funder-reports/2026-06-09-impact-report-alignment-and-automation.md
@@ -1,0 +1,108 @@
+# Impact report: alignment + automation design
+
+> Date: 2026-06-09. Trigger: Snow asked for re-forwardable progress they can feed their monthly partner updates + Board. Question from Ben: make the report aligned and impactful (stories → bed + washer numbers → stage of growth → focus area → how the funder's support ignites change), automate it in Notion so we do not rebuild each time, and carve it into areas that get reviewed each quarter and sent to all supporters via a Notion page per milestone.
+>
+> Bottom line: the generation engine already exists and is ~80% of the way there. The real work is (1) a narrative spine that earns the word "impactful," (2) three missing content beats + washer numbers, and (3) the Notion publish + per-quarter review loop. This is a design, not a build. Nothing here is built yet.
+
+## 1. What already exists (do not rebuild)
+
+| Piece | Where | What it does | State |
+|---|---|---|---|
+| Report engine | `v2/scripts/generate-funder-report.mjs` | `node ... <funder-slug> <period-slug>` assembles the 18 section templates + per-funder config, resolves live metrics, writes `wiki/outputs/funder-reports/<slug>/<period>.md`. Quarter-aware (QUARTERS map). | Built |
+| 18 section templates | `wiki/templates/funder-report/sections/*.md` | Modular markdown with `[METRIC: ...]` and `[PHOTO/QUOTE/VIDEO/MAP: ...]` placeholders. | Built |
+| Per-funder config | `v2/src/lib/funders/configs/{snow,centrecorp}.ts` + registry | Picks which sections, supplies principles, risks, investment tiers, commitment, photo tags, headline achievements. | Built (snow, centrecorp) |
+| Live metric resolvers | inside the engine | Beds by status/period, communities, plastic from Goods `assets`; $ raised/paid/overhead from the Xero mirror (`xero_invoices`). | Built |
+| Markdown → Notion sync | `act-global-infrastructure/scripts/sync-goods-wiki-to-notion.mjs` | Mirrors any `wiki/outputs/*.md` as a Notion subpage under Goods. HQ; preserves child pages; dry-run; uses `notion-md-blocks.mjs`. | Built |
+| Beds + washers per community → GHL | `v2/scripts/sync-goods-impact-rollups.mjs` + `cron-goods-impact-sync.sh` (weekly) | Live `assets` aggregated per community, Ben's curated community→record map, writes beds/washers/last-delivery onto funder + partner records. | Built + cron |
+| Impact Reporting Register | Notion DB `08afd05c…` | Per-report record: status, due, period, evidence/story/claim review, GHL + URL fields. | Built |
+| Web audience templates | `v2/src/lib/data/report-templates.ts` + `impact-report.tsx` + `/admin/reports/impact/[templateId]` | funder-impact / procurement-buyer / supporter-update / supply-partner web reports with live metrics + consent-filtered EL stories. | Built (separate track from the markdown engine) |
+
+So: generate markdown → push to Notion → live beds/washers/$/communities are all solved. The chain works.
+
+## 2. Review of the current 18 sections: aligned and impactful?
+
+Classifying each section as AUTO (regenerates from live data, no human review) or CURATED (human-reviewed each quarter), and whether it serves the "ignite change" arc.
+
+| Section | AUTO / CURATED | Verdict |
+|---|---|---|
+| 00 cover, 01 headline, 08 impact-numbers, 10 headline-achievements | AUTO | Solid. Numbers are live. BUT beds only, no washers. `$550` per-bed in 08 is hardcoded + off-canon ($534.79). |
+| 02 map, 07 how-we-track | AUTO | Good proof-of-rigour. Keep. |
+| 09 financials, 14 commitment-progress | AUTO (Xero) | Good, but the config feeding it is stale (snow.ts $395K/$275K/$120K; the slice is now fully paid, total ~$493K). |
+| 03 hero-photo, 04 photo-grid, 05 voices | CURATED (consent) | The human heart. Keep. Consent-gated via EL. |
+| 06 why-it-works | CURATED | Good "how it works", but it is product mechanics, not momentum. |
+| 11 investment-priorities, 12 alignment-principles, 13 safeguarding-risks | CURATED | Compliance spine. Necessary for funders, dead weight for supporters. |
+| 15 upcoming-commitments, 16 whats-next | CURATED | Closest thing to forward motion, but framed as a task list, not a growth story. |
+| 17 country-acknowledgement | AUTO | Keep. |
+
+**The alignment gap.** The report today is a strong *delivery + compliance* artifact. It proves the beds landed and the money was spent well. It does not tell the story Ben described. Three beats are missing entirely, and one number is missing:
+
+1. **Washing machine numbers.** Absent from every section. The rollup sync already has washers per community; the report just never surfaces them.
+2. **Stage of growth.** No beat says where Goods is on the journey (prototype → pilot → scaling) or what step-changed this quarter.
+3. **Focus area.** No beat names the one or two things this capital is unlocking right now.
+4. **The ignition / catalytic attribution.** Nothing connects *this funder's specific role* to the momentum it unlocked. For Snow this is the whole point: anchor capital → production plant → Alice Springs jobs → the next 1,000 beds. This is what makes a report "impactful" rather than "complete."
+
+## 3. The aligned narrative spine (the 7 beats)
+
+Re-order and extend the sections into one arc. Same data, told as a story that moves from a person to momentum.
+
+1. **A person.** Open on one face, one voice, one place (hero-photo + a verified quote). [exists: 03, 05]
+2. **What moved this period.** Beds AND washers delivered, communities, plastic. One glance. [exists: 01/08/10 + ADD washers]
+3. **Where we are on the journey.** Stage of growth: the dial from first prototype to on-country production, and the specific step-change this quarter (e.g. "first paid local production roles in Alice Springs"). [NEW]
+4. **What we are focused on next.** The one or two things this capital is unlocking now, and why these and not others. [reframe 15/16]
+5. **How your support ignited this.** The catalytic line: connect the funder's dollars/role to the momentum. For Snow: anchor backing de-risked the plant, the plant created the jobs, the jobs make the next beds local. This is the beat that earns renewal. [NEW]
+6. **Proof it is working, and well-governed.** Live impact numbers, QR tracking, safeguarding, principles alignment. The trust layer. [exists: 02/07/12/13]
+7. **The invitation.** What is next together (renewal, the next tranche, the impact-investment conversation). [exists: 16, + funder-specific ask]
+
+Supporter-tier version = beats 1, 2, 3, 5, 7 only (story-first, no financials / principles / risk register).
+
+## 4. The three new content beats to build
+
+All three are CURATED (config + EL), refreshed quarterly, not auto-generated, because they are judgement, not counts.
+
+- **`stage-of-growth.md`** — a simple stage dial (prototype → pilot → scaling → on-country production) + a one-paragraph "step-change this quarter". Config supplies the current stage + the step-change sentence.
+- **`focus-area.md`** — the 1-2 priorities this capital is unlocking now. Config supplies them.
+- **`ignition.md`** (the catalytic attribution) — funder-specific: "your support → what it unlocked → what it is igniting next." Config supplies the chain per funder. This is the most important new section.
+
+Plus one AUTO change: add washer resolvers (`washers-delivered-this-period`, `washers-working`, `wash-cycles-this-period`) and surface them in 01/08/10. Fleet data already exists (`impact-fetcher.ts`: 14 working, wash cycles via `get_fleet_kpis`).
+
+## 5. The automation + per-quarter review model
+
+The key idea that answers "do not rebuild each time": **every section is AUTO or CURATED, and the quarterly job is to review only the CURATED ones.**
+
+```
+Quarterly (or per milestone):
+  1. node generate-funder-report.mjs <funder> <period>     # AUTO sections refresh from live data
+  2. Review ONLY the CURATED sections (stories, stage, focus, ignition, principles, risks)
+     - stories/photos: consent-gated via Empathy Ledger
+     - stage/focus/ignition: edit the per-funder config
+  3. node sync-goods-wiki-to-notion.mjs --file <the report>  # publish as a Notion page
+  4. Update the Impact Reporting Register row: Notion URL, status, last sent, next touch
+  5. Send the Notion page link via GHL (per audience segment)
+```
+
+- **AUTO sections** never need review. They are live by construction (assets, Xero, fleet, rollups).
+- **CURATED sections** get a review state. Add a `Curated sections last reviewed` date to the Impact Reporting Register, plus the existing Evidence / Story / Claim review fields. That is the "specific area reviewed each quarter" Ben asked for: the CURATED set is the review surface.
+- **Drift fixes that remove rebuild pain:** stop hardcoding $ in `snow.ts` (let the Xero resolver own commitment/received); fix the `$550` in section 08 to canon; this is what makes the AUTO half trustworthy.
+
+## 6. Supporter tier + a Notion page per milestone
+
+- Add a `supporter` funder-config-equivalent (or reuse `report-templates.ts` `supporter-update`) that selects the supporter beat set (1,2,3,5,7) and a warm tone. Output `wiki/outputs/funder-reports/supporter/<milestone>.md`.
+- A **milestone** (e.g. "1,000th bed", "first Alice Springs production run", "plant commissioned") = an event-scoped run, not a quarter. The engine already takes any period; add named milestones alongside QUARTERS.
+- Publish each milestone supporter page via the Notion sync. The page URL is shareable. The Impact Reporting Register row holds the URL + send status, and GHL sends the link to the supporter segment. This is the "Notion page for each milestone + supporter article" Ben described.
+
+## 7. Build sequence (smallest first, only if Ben says go)
+
+1. **Washer numbers** into the AUTO sections (resolvers + lines in 01/08/10). Smallest, highest "bed + washer" payoff.
+2. **Fix the stale config drift** (snow.ts $ → Xero resolver; `$550` → canon). Removes rebuild pain.
+3. **Three new CURATED sections** (`stage-of-growth`, `focus-area`, `ignition`) + add to snow.ts config with real content.
+4. **Re-order** snow.ts sections into the 7-beat spine.
+5. **Supporter tier** config + milestone runs.
+6. **Notion publish + register-row update** as one wrapper command; add `Curated sections last reviewed` to the register.
+7. (Optional) cron the quarterly generate + a "curated sections need review" reminder.
+
+## Open questions for Ben
+
+- Confirm the stage dial labels (prototype → pilot → scaling → on-country production?) and Goods' current stage.
+- The Snow ignition chain in one line: is it "anchor capital → production plant → Alice Springs jobs → next 1,000 beds local"?
+- Which milestones should trigger a supporter page (1,000th bed? first AS production run? plant commissioned?).
+- Do supporters get the SAME Notion page or a lighter supporter-tier page (recommended: lighter).

--- a/wiki/outputs/funder-reports/snow/2026-06-09-airport-display-update.md
+++ b/wiki/outputs/funder-reports/snow/2026-06-09-airport-display-update.md
@@ -1,0 +1,33 @@
+# Airport display — update + snaps for Brigitta
+
+> DRAFT for Ben. Time-sensitive: the display is up only until Tuesday, so this needs a same-day turnaround. Brigitta asked two things: (1) how the display interacts with the Goods website, and (2) a couple of snaps of people visiting.
+
+## What Brigitta asked
+
+1. "Interaction with the Goods website" — i.e. how does the airport display connect people to goodsoncountry.com (QR? URL? what do they land on?).
+2. A quick update plus a couple of snaps of people visiting the display.
+
+## Suggested reply (fill the brackets)
+
+Hi Brigitta,
+
+Thanks for looking after the Goods display. On the website side: [BEN: describe the link, e.g. "the panel has a QR that lands on goodsoncountry.com/<page>" OR "we can add a QR to the display that goes straight to the story page"]. Anyone who scans it lands on [page], which has [what they see: the bed, the story, how to register interest].
+
+Here are a couple of snaps from people stopping by [attach photos]. Great to see it getting attention. It is there until Tuesday, so if anyone wants to know more, the website is the easiest next step.
+
+Thanks again,
+Ben
+
+## Snaps — where to pull them (consent-safe)
+
+Photos with people must be public + elder-reviewed before they leave the building.
+
+- Tool: the gated photo-review tool at `/admin/photo-review` (holds consent + GPS, never in `public/`). Use the public + elder-reviewed filter.
+- Or pull from the Empathy Ledger Goods project (consent-filtered) via the existing export path.
+- If the only good shots are of the display itself (no identifiable people), those are safe to send immediately with no consent step.
+
+## What I need from you to finish this
+
+1. What is actually on the display, and does it already have a QR / URL? (so the website-interaction line is true, not invented)
+2. Which photos to attach (or confirm "display-only, no people" so I can send right away).
+3. The right landing page for the QR if we are adding/confirming one (options: /, /stretch-bed, /story, a Snow-relevant story page).

--- a/wiki/outputs/funder-reports/snow/2026-06-09-bhanvi-impact-investment-intro.md
+++ b/wiki/outputs/funder-reports/snow/2026-06-09-bhanvi-impact-investment-intro.md
@@ -1,0 +1,33 @@
+# Bhanvi (Snow) — impact investment scoping intro
+
+> DRAFT for Ben's review. A short, forwardable intro Sally can pass to Bhanvi to open the impact investment scoping conversation. Goal: get a scoping call, not pitch the whole raise. Source: `funder-shared-content.ts` (INVESTMENT_THESIS, CAPITAL_STACK, QBE_PROGRAM).
+
+**Suggested subject:** Goods on Country — intro for impact investment scoping
+
+---
+
+Hi Bhanvi,
+
+Sally suggested we connect. I am Ben, alongside Nic Marchesi, at Goods on Country.
+
+**What we do.** We are a First Nations led social enterprise making quality, durable goods for remote Indigenous communities, designed in community for actual remote conditions. The flagship is the Stretch Bed: a washable, flat-packable bed built from about 20 kg of recycled plastic, galvanised steel and heavy-duty canvas, with a 200 kg capacity and a 10-year design life. We have shipped beds into homes across remote communities, the demand is real and repeat, and we are building toward on-country manufacturing that communities can own.
+
+**Why this needs patient capital.** Remote communities spend roughly $3M a year on washing machines from a single Alice Springs supplier, and most end up in landfill within months. Beds get replaced about every 18 months. The unit economics of disposable goods in remote Australia are broken, and the human cost (sleep, hygiene, household function) compounds. We are building the durable, locally-made, locally-owned alternative.
+
+**Where the capital conversation sits.** We are in the QBE Foundation's Catalysing Impact 2026 blended-finance accelerator (run by Social Impact Hub). Stage 2 offers up to $400,000, which must be at least matched by external capital we raise, and repayable finance is prioritised over grants. So we are actively building a blended stack: catalytic capital, subordinated working-capital debt, and the matched commitments that unlock the QBE layer. Snow has been our anchor partner through all of it.
+
+**What we would value from a scoping conversation.** A read on where impact investment could fit our stack, what structure would suit a revenue-generating enterprise still scaling toward full cost recovery, and what evidence you would want to see. We can share the investment thesis, the cost model, and our impact data whenever useful.
+
+Would a 30-minute call in the next couple of weeks suit?
+
+Thanks,
+Ben
+
+---
+
+### Build notes (internal, remove before sending)
+
+- Capital stack reference: Minderoo ~$1.5M catalytic (in conversation), SEFA ~$300K sub-debt (BOLD agreement, in outreach), QBE Stage 2 up to $400K (match-contingent), plus Snow letter of support. Do not present any of these as committed.
+- QBE Stage 2: application Sept 2026, outcomes Nov 2026. Up to $400K from a $1M shared pool, at least matched, repayable-first. Never describe as secured.
+- We have a gated investor workspace (/sites/qbe, /sites/cost-lab) if Bhanvi wants to go deeper. Password is investor-only; share only after the call if it lands.
+- No em dashes. Keep the ask to "a scoping call," not a number.

--- a/wiki/outputs/funder-reports/snow/2026-06-09-snow-figure-reconciliation.md
+++ b/wiki/outputs/funder-reports/snow/2026-06-09-snow-figure-reconciliation.md
@@ -1,0 +1,40 @@
+# Snow Foundation — figure reconciliation (provenance)
+
+**Date:** 2026-06-09
+**Purpose:** Resolve the conflicting Snow Foundation contribution figures before any number goes into a partner update, the Bhanvi intro, or the FY26 acquittal.
+**Method:** Live Xero pull (read-only) via MCP, org `Nicholas Marchesi` (786af1ed), contact-level (clean for Snow even though the org is a mixed multi-project ledger).
+
+## Verified figure
+
+| Field | Value | Source | Confidence |
+|---|---|---|---|
+| Snow revenue, last 3 years (2023-06-09 → 2026-06-09) | **$493,129.79** | Xero `get_top_customers_by_revenue`, contact "The Snow Foundation" (ranked #1) | Verified |
+| Snow outstanding receivable | **~$0** (not in the 19 awaiting invoices) | Xero `get_contacts_and_receivables` 2026-06-09 | Verified |
+| Implied: paid to date | **= $493,129.79** (revenue with $0 outstanding) | Derived | Inferred |
+
+Figures are ex-GST (Xero income-by-contact / revenue basis). Cash received inc-GST is ~10% higher.
+
+## Reconciliation of the figures we have been citing
+
+| Figure | What it actually is | Action |
+|---|---|---|
+| **$493,129.79** | True Xero 3-yr total, $0 outstanding | Use as the headline ("~$493K over three years") |
+| $402,929.79 | 2025+2026 slice only; matches the Notion supporter record's "paid" + the Q2 draft's "$402,930 invoices raised" | Keep only where a 2025-26 framing is intended; label it |
+| $395,000 ($434,500 inc-GST) | ex-GST commitment under grant `2024/OC0014` | A single grant's terms, not lifetime total |
+| $275,000 paid / $120,000 to be paid (Q2 draft, 21 May) | Superseded — the 2025-26 slice is now fully paid ($0 outstanding) | Do NOT reuse the "to be paid" line |
+| $193,785 ("2023-2025", wiki `investors/snow-foundation.md`) | Old cumulative snapshot | STALE — correct the wiki article (alignment-engine drift) |
+
+**$493,129.79 − $402,929.79 = $90,200.00** = 2024 Snow revenue excluded from the 2025-26 slice. Confirms (and updates) the prior "Snow cutoff" reconcile.
+
+## Residual checks (cannot see from MCP — confirm in Xero UI)
+
+1. Every `The Snow Foundation` invoice is Goods-coded, not another Marchesi project. (Snow grant `2024/OC0014` is to Goods, so likely clean, but confirm.)
+2. Whether any Snow revenue predates 2023-06-09 (Xero MCP only supports a 3-year window). If yes, the lifetime total is higher than $493,129.79.
+
+If both clear: headline = **"Snow has invested ~$493K over three years, fully received."**
+
+## Downstream fixes this triggers
+
+- `wiki/articles/investors/snow-foundation.md`: change "$193K received" → reconciled figure.
+- `wiki/articles/capital/funder-register.md`: Snow row "$193,785 (2023-2025)" → reconciled figure.
+- Notion: Snow Reporting page "At a glance" + Impact Reporting Register Snow FY26 acquittal record.

--- a/wiki/outputs/funder-reports/snow/2026-06-09-snow-partner-update.md
+++ b/wiki/outputs/funder-reports/snow/2026-06-09-snow-partner-update.md
@@ -1,0 +1,46 @@
+# Snow Foundation — partner update (June 2026)
+
+> DRAFT for Ben's review. Warm, short, re-forwardable: built for Sally to drop into Snow's monthly partner update and the Board. Not the formal FY26 acquittal (that is due 31 July). Numbers marked [CONFIRM] need a live asset-register check before sending.
+
+**To:** Sally Grimsley-Ballard, The Snow Foundation
+**From:** Nic + Ben, Goods on Country
+**Re:** Where things are at since Tuesday
+
+---
+
+Hi Sally,
+
+Great to catch up Tuesday, and thank you again for the way Snow keeps backing this work. Here is a short update you are welcome to share with the team and the Board.
+
+## What's moving right now
+
+- **Katrina and Alice Springs.** [CONFIRM SPECIFICS WITH BEN: what Katrina's role is, what the Alice Springs setup is, and how many jobs it creates.] This is the part we are most excited about too. It is the first time the production side is creating paid local work, which is exactly the on-country employment model we have been building toward. (For context: 19 beds are already in homes around Alice Springs.)
+- **Beds in homes.** 496 beds delivered across 9 communities (live count, 9 June 2026), including the May Central Australia run with Centrecorp (Mparntwe and Utopia homelands). The recycled-plastic Stretch Bed is now the production product (133 delivered so far); the rest are the earlier basket prototype.
+- **The product keeps earning its place.** Around 20 kg of recycled plastic goes into every Stretch Bed instead of into landfill, about 2,660 kg diverted so far. The canvas is washable, the frame is built for remote conditions, and demand keeps coming back stronger than supply (Diane Stokes asked for 20 more within a fortnight of receiving one).
+
+## The pouch idea
+
+You mentioned loving the lockable pouch and storage pouches. We are taking that seriously as a next design feature. [BEN: one line on where this sits, e.g. prototyping / on the V4 list.] It came straight out of community feedback, which is how every part of the bed has evolved.
+
+## Filming
+
+[BEN: confirm status. Suggested line if it has happened:] The filming went well, and we will have footage to share soon. It is wild to think this all traces back to that sporting event and the simple fact that there were not enough beds.
+
+## What's next
+
+- FY26 operational acquittal coming to you by 31 July.
+- The Central Desert production plant is close to complete, and we are working through the community siting decision.
+- On the capital side, thank you for offering to connect us with Bhanvi on the impact investment scoping. We will send a short intro for you to forward.
+
+With thanks,
+Nic and Ben
+
+---
+
+### Build notes (internal, remove before sending)
+
+- Snow's own contribution, if you want to acknowledge it back to them: **~$493K invested over three years, fully received** (Xero, 2026-06-09; see `2026-06-09-snow-figure-reconciliation.md`). Optional to include.
+- Live counts (verified 9 June 2026 from the Goods asset register): 496 beds across 9 communities; 133 Stretch / 363 Basket; 2,660 kg plastic (Stretch only, 20 kg/bed); 28 washers deployed (14 telemetry-working); Alice Springs = 19 beds.
+- Stories available if you want to feature a cleared voice: Mykel (published), the six cleared Utopia voices, the 26-post ledger batch. Lead with a person, not a metric.
+- Plastic per bed = 20 kg (canon `impact-model.ts`), NOT the 25 kg figure in the old Q2 draft. Do not reuse 25 kg.
+- No em dashes (brand rule). Keep it warm and specific.

--- a/wiki/outputs/funder-reports/snow/2026-Q2.md
+++ b/wiki/outputs/funder-reports/snow/2026-Q2.md
@@ -66,6 +66,43 @@ See the funder reporting database (in Notion) for the per-milestone breakdown.
 ---
 
 
+## Where we are on the journey
+
+**Stage: Scaling**
+
+Prototype · Pilot · **Scaling** · On-Country production
+
+This period Goods began crossing from delivering beds to making them on country. The containerised production plant reached roughly 85% complete, the washing-machine line grew to a 28-unit field fleet (14 telemetry-confirmed working), and the first paid local production roles are forming in Alice Springs. The step-change is the shift from beds delivered to community toward beds made by community.
+
+---
+
+
+## What we're focused on next
+
+**1. Commission the on-country production plant**
+
+Finish the containerised facility (about 85% complete) and make the community siting decision (Tennant Creek or Mparntwe), so beds are made on country rather than freighted in.
+
+**2. Stand up paid local production roles in Alice Springs**
+
+Turn delivery into local employment. The first roles forming now are the proof point for the community-owned production model, and the part of this work Snow is most excited about.
+
+---
+
+
+## How your support ignites change
+
+Snow backed Goods before the proof was in the houses. That anchor capital de-risked the production plant, and the plant is what turns a delivered bed into a locally made one. The Alice Springs roles forming now are the first jobs out of that decision. Your support is the spark under the shift from beds delivered to community toward beds made by community, and it is what makes the next 1,000 beds a local-employment story rather than a freight invoice.
+
+1. Snow's anchor capital, given before the proof was in the houses
+2. de-risked the on-country production plant
+3. the plant lets beds be made on country, not freighted in
+4. which creates paid local jobs (the Alice Springs roles forming now)
+5. and turns the next 1,000 beds into a local-employment story
+
+---
+
+
 ## Investment priorities — funds applied per funder framework
 
 ### Priority 1 — Stretch bed production and deployment (~$140,000)

--- a/wiki/outputs/funder-reports/snow/2026-Q2.md
+++ b/wiki/outputs/funder-reports/snow/2026-Q2.md
@@ -26,7 +26,7 @@
 
 Commitment: **$395,000** ex-GST  
 Xero ACCREC invoices raised (7): **$402,930**  
-Amount paid against those invoices: **$270,930**
+Amount paid against those invoices: **$402,930**
 
 See the funder reporting database (in Notion) for the per-milestone breakdown.
 
@@ -58,8 +58,9 @@ See the funder reporting database (in Notion) for the per-milestone breakdown.
 ### This-period delivery snapshot
 
 - **87** beds transferred to community
-- **36** placed directly with households
-- **51** at community institutions awaiting distribution
+- **87** placed directly with households
+- **0** at community institutions awaiting distribution
+- **0** washing machines transferred to community
 - **2 (Utopia Homelands, Alice Springs)** communities served
 
 ---
@@ -69,7 +70,7 @@ See the funder reporting database (in Notion) for the per-milestone breakdown.
 
 ### Priority 1 — Stretch bed production and deployment (~$140,000)
 
-FY25 payments funded V1 → V3 iteration, materials testing, deployment to 8 families, feedback gathering. FY26 Scale-Up $60K (incoming) → 100 beds @ $600/bed for immediate deployment (May 17-27 Central Australia, July Maningrida).
+FY25 payments funded V1 → V3 iteration, materials testing, deployment to 8 families, feedback gathering. FY26 Scale-Up $60K (incoming) supports the 100-bed deployment allocation; the old $600/bed planning anchor excludes long-haul freight and fixed-block absorption. Current Buy-Kit marginal is $684.79/bed.
 
 **Outcomes:** 15-20 beds deployed during funded period; 100-bed batch in production for delivery within FY26 Q4.
 
@@ -96,7 +97,7 @@ $100K Operational support and wages payment (paid 31/10/2025, INV-0268) covered 
 - Cultural advisors paid at university research rates ($3,800/day) throughout 2024-25 — "we asked for no favours."
 - Aboriginal ownership: exploring models where communities own production assets and generate revenue (Palm Island offered to buy a plant; QIC building 50 beds with staff for NAIDOC).
 
-### 2. Early partnership and co-design
+### 2. Early partnership and design in community
 
 - Product evolved through iterative yarning + relational feedback — Norm Frank’s maroon request became a design feature; Diane Stokes’ "20 more" validated cleanability + durability.
 - Current 15-20 bed / 8 family sample. Targeting a few hundred (this $120K round) before scaling to 5,000+.
@@ -138,7 +139,7 @@ $100K Operational support and wages payment (paid 31/10/2025, INV-0268) covered 
 
 ### 8. Data sovereignty and Indigenous IP
 
-- Products co-designed with Bloomfield family — cultural knowledge + design input owned by community.
+- Products designed in community with the Bloomfield family. Cultural knowledge and design decisions stay with community.
 - Testing feedback returns to Bloomfields first; production learnings shared with partner communities before external reporting.
 - Practical production partnership where communities retain control.
 - ACT commits to Indigenous Data Sovereignty principles for any future impact measurement.
@@ -174,7 +175,7 @@ Paid:        ▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░ 70%  (
 
 Commitment: **$395,000** ex-GST  
 Xero ACCREC invoices raised (7): **$402,930**  
-Amount paid against those invoices: **$270,930**
+Amount paid against those invoices: **$402,930**
 
 ---
 

--- a/wiki/templates/funder-report/sections/08-impact-numbers.md
+++ b/wiki/templates/funder-report/sections/08-impact-numbers.md
@@ -5,9 +5,11 @@
 | Beds physically transferred to community | **[METRIC: beds-total-this-period]** |
 | Of which direct household placements | [METRIC: beds-deployed-this-period] |
 | Of which at community institutions (for distribution) | [METRIC: beds-allocated-this-period] |
+| Washing machines transferred to community | **[METRIC: washers-total-this-period]** |
+| Washing machines confirmed working | [METRIC: washers-working] |
 | Recycled HDPE plastic transferred | [METRIC: plastic-kg-transferred] |
 | Communities served | [METRIC: communities-served] |
-| Per-bed manufactured cost (current run-rate) | **$550** (verified — Day 4 unit economics) |
+| Per-bed manufactured cost (current Buy-Kit run-rate) | **$534.79** direct, **$684.79** marginal (canon unit economics) |
 | Trip overhead this period (Xero ACCPAY) | [METRIC: xero-trip-overhead] |
 
 ---

--- a/wiki/templates/funder-report/sections/10-headline-achievements.md
+++ b/wiki/templates/funder-report/sections/10-headline-achievements.md
@@ -7,6 +7,7 @@
 - **[METRIC: beds-total-this-period]** beds transferred to community
 - **[METRIC: beds-deployed-this-period]** placed directly with households
 - **[METRIC: beds-allocated-this-period]** at community institutions awaiting distribution
+- **[METRIC: washers-total-this-period]** washing machines transferred to community
 - **[METRIC: communities-served]** communities served
 
 ---

--- a/wiki/templates/funder-report/sections/18-stage-of-growth.md
+++ b/wiki/templates/funder-report/sections/18-stage-of-growth.md
@@ -1,0 +1,5 @@
+## Where we are on the journey
+
+[METRIC: stage-of-growth]
+
+---

--- a/wiki/templates/funder-report/sections/19-focus-area.md
+++ b/wiki/templates/funder-report/sections/19-focus-area.md
@@ -1,0 +1,5 @@
+## What we're focused on next
+
+[METRIC: focus-area]
+
+---

--- a/wiki/templates/funder-report/sections/20-ignition.md
+++ b/wiki/templates/funder-report/sections/20-ignition.md
@@ -1,0 +1,5 @@
+## How your support ignites change
+
+[METRIC: ignition]
+
+---


### PR DESCRIPTION
## What

Two things, both with Snow as the lead case:

1. **Snow figure reconciliation** — a live Xero pull (read-only, contact-level) confirms Snow has invested **~\$493,129.79** over 3 years (\$0 outstanding = effectively all paid). The wiki's \$193,785 was stale; restated with a provenance doc. \$402,930 = the 2025-26 slice only.

2. **Report-engine alignment** — fixed a silently-broken generator and added the narrative beats that make the report "impactful", not just "complete".

## Report-engine changes

- **Fix: the generator was broken.** `generate-funder-report.mjs` called the now-async `getFunder` without `await` (broken since the registry went async — nothing had regenerated since 22 May). Fixed + wrapped the `tsx -e` eval in an async IIFE (CJS has no top-level await). Reports generate again.
- **Correctness:** bed resolvers now filter `product ~ bed` (washers were being miscounted as beds); plastic counts **Stretch beds only** (the canonical rule). Applied to BOTH engines (CLI `.mjs` + web `metrics.ts`).
- **Washing-machine numbers** added to the report (was beds-only).
- **3 new narrative beats** — `stage-of-growth`, `focus-area`, `ignition` (the "how your support ignites change" arc). New section templates + wired into both engines + the type system.
- `\$550/bed` hardcode → canon `\$534.79 direct / \$684.79 marginal`.
- Snow config financials **flagged, not changed**: paid/to-be-paid are superseded by the live ~\$493K; FY26 carve-out pending.

## Verification

- `tsc --noEmit` clean (0 errors).
- Snow Q2 regenerates: 11 → 14 sections; the 3 beats + washer line render.

## Needs review before sending to Snow

The Snow stage/focus/ignition content is **PROPOSED** (grounded in canon + the Snow catch-up email, clearly marked in `snow.ts`). Confirm: stage = "Scaling"; the ignition chain (anchor capital → plant → Alice Springs jobs → next 1,000 beds local); the two focus areas.

## Not in this PR

Supporter-tier (lighter) page + milestone-triggered runs; the Notion-publish wrapper + per-section quarterly review state. Full design: `wiki/outputs/funder-reports/2026-06-09-impact-report-alignment-and-automation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)