### PR TITLE
Partner dashboard: gated, always-live partner page (Snow)

### DIFF
--- a/v2/src/app/api/partners/[slug]/auth/route.ts
+++ b/v2/src/app/api/partners/[slug]/auth/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getPartnerDashboard } from '@/lib/data/partner-dashboards';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const { password } = await request.json();
+
+  const partner = getPartnerDashboard(slug);
+  if (!partner) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  if (password === partner.password) {
+    const response = NextResponse.json({ ok: true });
+    response.cookies.set(`partner_${slug}`, password, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 60 * 60 * 24 * 30, // 30 days
+    });
+    return response;
+  }
+
+  return NextResponse.json({ error: 'Invalid password' }, { status: 401 });
+}

--- a/v2/src/app/partners/[slug]/dashboard/page.tsx
+++ b/v2/src/app/partners/[slug]/dashboard/page.tsx
@@ -1,0 +1,179 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import { getPartnerDashboard } from '@/lib/data/partner-dashboards';
+import { getCanonicalAssetRollup } from '@/lib/data/impact-fetcher';
+
+// Always live: read the asset register fresh each request.
+export const dynamic = 'force-dynamic';
+
+const CREAM = '#FDF8F3';
+const RUST = '#C45C3E';
+const CHARCOAL = '#2E2E2E';
+const SAGE = '#8B9D77';
+
+type Props = { params: Promise<{ slug: string }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const p = getPartnerDashboard(slug);
+  return {
+    title: p ? `${p.partnerName} — Goods on Country partner dashboard` : 'Partner dashboard',
+    robots: { index: false, follow: false },
+  };
+}
+
+function Stat({ value, label, sub }: { value: string; label: string; sub?: string }) {
+  return (
+    <div className="rounded-lg p-5" style={{ backgroundColor: '#FFFFFF', border: '1px solid #E8DED4' }}>
+      <p className="font-display text-3xl sm:text-4xl leading-none mb-2" style={{ color: RUST }}>{value}</p>
+      <p className="text-sm font-semibold" style={{ color: CHARCOAL }}>{label}</p>
+      {sub ? <p className="text-xs mt-1" style={{ color: `${CHARCOAL}99` }}>{sub}</p> : null}
+    </div>
+  );
+}
+
+export default async function PartnerDashboardPage({ params }: Props) {
+  const { slug } = await params;
+  const partner = getPartnerDashboard(slug);
+  if (!partner) notFound();
+
+  // Live metrics from the asset register (canonical rollup).
+  let rollup: Awaited<ReturnType<typeof getCanonicalAssetRollup>> | null = null;
+  try {
+    rollup = await getCanonicalAssetRollup();
+  } catch {
+    rollup = null;
+  }
+
+  const beds = rollup ? rollup.bedsDeployed.toLocaleString() : '—';
+  const communities = rollup ? String(rollup.communitiesServed) : '—';
+  const plasticT = rollup ? `${(rollup.plasticKg / 1000).toFixed(2)} t` : '—';
+  const washers = rollup ? `${rollup.washersWorking} / ${rollup.washersDeployed}` : '—';
+
+  return (
+    <main className="min-h-screen" style={{ backgroundColor: CREAM, color: CHARCOAL }}>
+      <section className="px-5 sm:px-8 pt-12 sm:pt-16 pb-10 max-w-5xl mx-auto">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6 mb-10">
+          <Link href="/" className="inline-flex flex-col leading-none">
+            <span className="font-display text-3xl sm:text-4xl" style={{ color: CHARCOAL }}>Goods</span>
+            <span className="text-[10px] sm:text-xs uppercase mt-1" style={{ color: `${CHARCOAL}99` }}>On Country · Partner dashboard</span>
+          </Link>
+          <div className="rounded-lg bg-white px-4 py-3 shadow-sm" style={{ border: '1px solid #E8DED4' }}>
+            <Image src="/images/partners/snow-foundation.png" alt={partner.partnerName} width={400} height={160} priority className="h-12 w-auto" />
+          </div>
+        </div>
+
+        <p className="text-xs uppercase mb-4" style={{ color: RUST }}>{partner.partnerName}</p>
+        <h1 className="font-display text-4xl sm:text-5xl leading-[1.05] mb-5" style={{ color: CHARCOAL }}>{partner.heroLine}</h1>
+        <p className="text-base sm:text-lg leading-relaxed max-w-3xl" style={{ color: `${CHARCOAL}cc` }}>{partner.intro}</p>
+      </section>
+
+      {/* Live trajectory */}
+      <section className="px-5 sm:px-8 pb-14 max-w-5xl mx-auto">
+        <div className="flex items-center gap-2 mb-4">
+          <span className="inline-block h-2 w-2 rounded-full" style={{ backgroundColor: SAGE }} />
+          <p className="text-xs uppercase" style={{ color: RUST }}>The trajectory, live from the field</p>
+        </div>
+        <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
+          <Stat value={beds} label="Beds in community" sub={rollup ? `${rollup.stretchBedsDeployed} recycled-plastic Stretch Beds` : undefined} />
+          <Stat value={communities} label="Communities" />
+          <Stat value={plasticT} label="Plastic diverted" sub="~20 kg per Stretch Bed" />
+          <Stat value={washers} label="Washing machines" sub="live / deployed" />
+          <Stat value={partner.facilities.value} label="Production facilities" sub={partner.facilities.note} />
+        </div>
+        <p className="text-xs mt-3" style={{ color: `${CHARCOAL}80` }}>
+          Beds, communities, plastic and washers read live from the Goods asset register. Production facilities are a curated count.
+        </p>
+      </section>
+
+      {/* Kanban: what we're working towards */}
+      <section className="px-5 sm:px-8 py-14" style={{ backgroundColor: '#FFFFFF' }}>
+        <div className="max-w-5xl mx-auto">
+          <p className="text-xs uppercase mb-6" style={{ color: RUST }}>What we are working towards</p>
+          <div className="grid md:grid-cols-3 gap-4">
+            {partner.kanban.map((col) => (
+              <div key={col.heading} className="rounded-lg p-5" style={{ backgroundColor: CREAM, border: '1px solid #E8DED4' }}>
+                <p className="text-sm font-semibold uppercase mb-4" style={{ color: SAGE }}>{col.heading}</p>
+                <ul className="space-y-3">
+                  {col.items.map((it) => (
+                    <li key={it.title}>
+                      <p className="text-sm font-medium leading-snug" style={{ color: CHARCOAL }}>{it.title}</p>
+                      {it.note ? <p className="text-xs mt-0.5" style={{ color: `${CHARCOAL}99` }}>{it.note}</p> : null}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Engagement history */}
+      <section className="px-5 sm:px-8 py-14 max-w-3xl mx-auto">
+        <p className="text-xs uppercase mb-6" style={{ color: RUST }}>Where we have come from, and where we are going</p>
+        <ol className="relative border-l pl-6 space-y-7" style={{ borderColor: '#E8DED4' }}>
+          {partner.history.map((h) => (
+            <li key={h.date + h.title} className="relative">
+              <span className="absolute -left-[31px] top-1 h-3 w-3 rounded-full" style={{ backgroundColor: RUST }} />
+              <p className="text-xs uppercase mb-1" style={{ color: SAGE }}>{h.date}</p>
+              <p className="text-base font-medium" style={{ color: CHARCOAL }}>{h.title}</p>
+              {h.detail ? <p className="text-sm mt-1 leading-relaxed" style={{ color: `${CHARCOAL}bf` }}>{h.detail}</p> : null}
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* Traffic / airport */}
+      <section className="px-5 sm:px-8 py-14" style={{ backgroundColor: CREAM }}>
+        <div className="max-w-5xl mx-auto">
+          <p className="text-xs uppercase mb-3" style={{ color: RUST }}>Out in the world</p>
+          <p className="text-base leading-relaxed max-w-2xl mb-6" style={{ color: `${CHARCOAL}cc` }}>{partner.traffic.intro}</p>
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            {partner.traffic.snapshots.map((s) => (
+              <Stat key={s.label} value={s.value} label={s.label} sub={s.note} />
+            ))}
+          </div>
+          <p className="text-xs mt-3" style={{ color: `${CHARCOAL}80` }}>{partner.traffic.asOf}</p>
+          {partner.traffic.reactions.length > 0 ? (
+            <div className="mt-6 flex flex-wrap gap-3">
+              {partner.traffic.reactions.map((r) => (
+                <a key={r.href} href={r.href} className="text-sm underline" style={{ color: RUST }}>{r.label}</a>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      {/* Links */}
+      <section className="px-5 sm:px-8 py-14 max-w-5xl mx-auto">
+        <p className="text-xs uppercase mb-6" style={{ color: RUST }}>Go deeper</p>
+        <div className="grid sm:grid-cols-2 gap-4">
+          {partner.links.map((l) => {
+            const inner = (
+              <>
+                <p className="text-base font-medium" style={{ color: CHARCOAL }}>{l.label} →</p>
+                {l.note ? <p className="text-sm mt-1" style={{ color: `${CHARCOAL}99` }}>{l.note}</p> : null}
+              </>
+            );
+            const cls = 'block rounded-lg p-5 transition hover:opacity-90';
+            const style = { backgroundColor: '#FFFFFF', border: '1px solid #E8DED4' };
+            return l.external ? (
+              <a key={l.href} href={l.href} className={cls} style={style}>{inner}</a>
+            ) : (
+              <Link key={l.href} href={l.href} className={cls} style={style}>{inner}</Link>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="px-5 sm:px-8 py-12 text-center max-w-3xl mx-auto">
+        <p className="text-sm leading-relaxed" style={{ color: `${CHARCOAL}bf` }}>
+          Goods on Country acknowledges the Traditional Owners of the lands on which we work, and pays respect to
+          Elders past, present and emerging. This work is done on country, with country, for country.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/v2/src/app/partners/[slug]/dashboard/page.tsx
+++ b/v2/src/app/partners/[slug]/dashboard/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { getPartnerDashboard } from '@/lib/data/partner-dashboards';
-import { getCanonicalAssetRollup } from '@/lib/data/impact-fetcher';
+import { getAssetStats } from '@/lib/data/impact-fetcher';
 
 // Always live: read the asset register fresh each request.
 export const dynamic = 'force-dynamic';
@@ -39,18 +39,24 @@ export default async function PartnerDashboardPage({ params }: Props) {
   const partner = getPartnerDashboard(slug);
   if (!partner) notFound();
 
-  // Live metrics from the asset register (canonical rollup).
-  let rollup: Awaited<ReturnType<typeof getCanonicalAssetRollup>> | null = null;
+  // Live metrics from the asset register.
+  let stats: Awaited<ReturnType<typeof getAssetStats>> | null = null;
   try {
-    rollup = await getCanonicalAssetRollup();
+    stats = await getAssetStats();
   } catch {
-    rollup = null;
+    stats = null;
   }
 
-  const beds = rollup ? rollup.bedsDeployed.toLocaleString() : '—';
-  const communities = rollup ? String(rollup.communitiesServed) : '—';
-  const plasticT = rollup ? `${(rollup.plasticKg / 1000).toFixed(2)} t` : '—';
-  const washers = rollup ? `${rollup.washersWorking} / ${rollup.washersDeployed}` : '—';
+  const beds = stats ? stats.totalBeds.toLocaleString() : '—';
+  const communities = stats ? String(stats.communitiesServed) : '—';
+  // Plastic = STRETCH beds only (recycled HDPE), ~20 kg each.
+  const plasticT = stats ? `${((stats.stretchBedsDeployed * 20) / 1000).toFixed(2)} t` : '—';
+  const washers = stats ? `${stats.washersWorking} / ${stats.washersDeployed}` : '—';
+  const communityList = stats
+    ? stats.communityBreakdown
+        .map((c) => c.community)
+        .filter((c) => c && c !== 'Unknown' && c !== 'Pending Delivery')
+    : [];
 
   return (
     <main className="min-h-screen" style={{ backgroundColor: CREAM, color: CHARCOAL }}>
@@ -77,14 +83,20 @@ export default async function PartnerDashboardPage({ params }: Props) {
           <p className="text-xs uppercase" style={{ color: RUST }}>The trajectory, live from the field</p>
         </div>
         <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
-          <Stat value={beds} label="Beds in community" sub={rollup ? `${rollup.stretchBedsDeployed} recycled-plastic Stretch Beds` : undefined} />
+          <Stat value={beds} label="Beds in community" sub={stats ? `${stats.stretchBedsDeployed} recycled-plastic Stretch Beds` : undefined} />
           <Stat value={communities} label="Communities" />
           <Stat value={plasticT} label="Plastic diverted" sub="~20 kg per Stretch Bed" />
           <Stat value={washers} label="Washing machines" sub="live / deployed" />
           <Stat value={partner.facilities.value} label="Production facilities" sub={partner.facilities.note} />
         </div>
+        {communityList.length > 0 ? (
+          <p className="text-sm mt-4 leading-relaxed" style={{ color: `${CHARCOAL}b3` }}>
+            <span className="font-semibold" style={{ color: CHARCOAL }}>The {communityList.length} communities: </span>
+            {communityList.join('  ·  ')}
+          </p>
+        ) : null}
         <p className="text-xs mt-3" style={{ color: `${CHARCOAL}80` }}>
-          Beds, communities, plastic and washers read live from the Goods asset register. Production facilities are a curated count.
+          Beds, communities, plastic (Stretch Beds only) and washing machines read live from the Goods asset register. Production facilities are a curated count.
         </p>
       </section>
 
@@ -124,6 +136,24 @@ export default async function PartnerDashboardPage({ params }: Props) {
           ))}
         </ol>
       </section>
+
+      {/* Photo gallery */}
+      {partner.gallery.length > 0 ? (
+        <section className="px-5 sm:px-8 py-14" style={{ backgroundColor: '#FFFFFF' }}>
+          <div className="max-w-5xl mx-auto">
+            <p className="text-xs uppercase mb-6" style={{ color: RUST }}>From the field</p>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+              {partner.gallery.map((g) => (
+                <figure key={g.src} className="overflow-hidden rounded-lg bg-white" style={{ border: '1px solid #E8DED4' }}>
+                  <div className="relative aspect-[4/3]">
+                    <Image src={g.src} alt={g.alt} fill className="object-cover" sizes="(max-width: 768px) 50vw, 320px" />
+                  </div>
+                </figure>
+              ))}
+            </div>
+          </div>
+        </section>
+      ) : null}
 
       {/* Traffic / airport */}
       <section className="px-5 sm:px-8 py-14" style={{ backgroundColor: CREAM }}>

--- a/v2/src/app/partners/[slug]/login/page.tsx
+++ b/v2/src/app/partners/[slug]/login/page.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useState, use, Suspense } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface LoginPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+function LoginForm({ slug }: { slug: string }) {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(false);
+    setLoading(true);
+
+    const res = await fetch(`/api/partners/${slug}/auth`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+    });
+
+    if (res.ok) {
+      router.push(`/partners/${slug}/dashboard`);
+      router.refresh();
+    } else {
+      setError(true);
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center px-4" style={{ backgroundColor: '#FDF8F3' }}>
+      <div className="w-full max-w-sm">
+        <div className="text-center mb-8">
+          <p className="text-sm uppercase tracking-widest mb-3" style={{ color: '#8B9D77' }}>
+            Goods on Country
+          </p>
+          <h1 className="text-3xl font-light mb-2" style={{ color: '#2E2E2E', fontFamily: 'Georgia, serif' }}>
+            Partner Dashboard
+          </h1>
+          <p className="text-sm" style={{ color: '#5E5E5E' }}>
+            Enter the access code to view your partner dashboard.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                setError(false);
+              }}
+              placeholder="Access code"
+              autoFocus
+              className="w-full px-4 py-3 rounded-lg border text-sm outline-none transition-colors"
+              style={{ borderColor: error ? '#C45C3E' : '#E8DED4', backgroundColor: 'white', color: '#2E2E2E' }}
+            />
+            {error && (
+              <p className="text-xs mt-2" style={{ color: '#C45C3E' }}>
+                Incorrect code. Please try again.
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading || !password}
+            className="w-full py-3 rounded-lg text-sm font-medium text-white transition-opacity disabled:opacity-50"
+            style={{ backgroundColor: '#C45C3E' }}
+          >
+            {loading ? 'Checking...' : 'View dashboard'}
+          </button>
+        </form>
+
+        <p className="text-xs text-center mt-6" style={{ color: '#8B9D77' }}>
+          Contact{' '}
+          <a href="mailto:hi@act.place" className="underline">
+            hi@act.place
+          </a>{' '}
+          for access.
+        </p>
+      </div>
+    </main>
+  );
+}
+
+export default function PartnerLoginPage({ params }: LoginPageProps) {
+  const { slug } = use(params);
+  return (
+    <Suspense>
+      <LoginForm slug={slug} />
+    </Suspense>
+  );
+}

--- a/v2/src/lib/data/partner-dashboards.ts
+++ b/v2/src/lib/data/partner-dashboards.ts
@@ -1,0 +1,140 @@
+/**
+ * Partner dashboards. Password-gated, always-live partner status pages.
+ *
+ * Live metrics (beds / communities / plastic / washers) come from the asset
+ * register at request time via getCanonicalAssetRollup() in the page itself.
+ * The CURATED content below (kanban, engagement history, links, traffic
+ * snapshot) is the "editable" layer.
+ *
+ * HYBRID UPGRADE PATH (Notion-backed editing):
+ *   This config is the content source AND the fallback. When a NOTION_TOKEN is
+ *   added to v2/.env.local and a `notionDbId` is set on a partner below, swap
+ *   getPartnerContent() to read those sections live from Notion (so Ben edits
+ *   in Notion, the page reads it), falling back to this config on any error.
+ *   The page + types stay the same — only the content fetch changes.
+ *
+ * To add a partner: add an entry with a unique slug + password, share
+ * `/partners/<slug>/dashboard` and the password. Gated in src/proxy.ts.
+ */
+
+export interface KanbanItem {
+  title: string;
+  note?: string;
+}
+export interface KanbanColumn {
+  heading: string; // e.g. "Up next", "In progress", "Done"
+  items: KanbanItem[];
+}
+export interface TimelineItem {
+  date: string; // e.g. "2024" or "May 2026"
+  title: string;
+  detail?: string;
+}
+export interface DashboardLink {
+  label: string;
+  href: string;
+  note?: string;
+  external?: boolean;
+}
+export interface TrafficSnapshot {
+  value: string; // e.g. "73"
+  label: string; // e.g. "/canberra airport page views"
+  note?: string;
+}
+
+export interface PartnerDashboard {
+  slug: string;
+  password: string;
+  partnerName: string;
+  heroLine: string;
+  intro: string;
+  /** Curated count — production facilities are not (yet) in the asset register. */
+  facilities: { value: string; note: string };
+  kanban: KanbanColumn[];
+  history: TimelineItem[];
+  links: DashboardLink[];
+  traffic: {
+    intro: string;
+    asOf: string;
+    snapshots: TrafficSnapshot[];
+    reactions: DashboardLink[]; // positive-reaction links Ben adds
+  };
+  /** Future: when set + NOTION_TOKEN present, curated sections read from Notion. */
+  notionDbId?: string;
+}
+
+const snow: PartnerDashboard = {
+  slug: 'snow',
+  password: 'snow2026',
+  partnerName: 'The Snow Foundation',
+  heroLine: 'What your backing is making possible on country',
+  intro:
+    'A live view of where Goods on Country is at, built for The Snow Foundation. The numbers below update on their own from the field. The rest is what we are working on, where we have come from, and what is next.',
+  facilities: {
+    value: '1 + 1',
+    note: 'One containerised plant being commissioned; a second, community-owned facility in Alice Springs with Oonchiumpa is in a federal funding submission (decision pending).',
+  },
+  kanban: [
+    {
+      heading: 'Up next',
+      items: [
+        { title: 'Community siting decision for the plant', note: 'Tennant Creek or Mparntwe' },
+        { title: 'Katrina: train-the-trainer at Witta', note: 'Skills travel home to run the Alice Springs build' },
+        { title: 'QBE Catalysing Impact, Stage 2', note: 'September; could bring matched catalytic capital' },
+        { title: 'Impact-investment scoping with Bhanvi', note: 'Intro via Snow' },
+      ],
+    },
+    {
+      heading: 'In progress',
+      items: [
+        { title: 'Commission the on-country production plant', note: '~85% complete' },
+        { title: 'Alice Springs facility with Oonchiumpa', note: 'REAL Innovation Fund submission lodged, decision pending' },
+        { title: 'Washing machine prototype iteration', note: 'Pakkimjalki Kari line' },
+        { title: 'The Butterfly Movement charity transition', note: 'Goods’ DGR home; Aboriginal-led board forming' },
+      ],
+    },
+    {
+      heading: 'Done',
+      items: [
+        { title: '496 beds delivered across 9 communities' },
+        { title: 'Containerised production plant built (recycled-plastic line)' },
+        { title: '28 washing machines deployed, 14 reporting live' },
+        { title: 'Utopia + Alice Springs trip, May 2026', note: '87 beds that trip' },
+      ],
+    },
+  ],
+  history: [
+    { date: '2023', title: 'Snow becomes an anchor backer', detail: 'Support before the proof was in the houses.' },
+    { date: '2024', title: 'Grant 2024/OC0014', detail: 'Multi-year support across beds, the production facility, and the team.' },
+    { date: 'Jan 2026', title: 'First washing machine built with the Bloomfield family', detail: 'In Tennant Creek; named Pakkimjalki Kari by Elder Dianne Stokes.' },
+    { date: 'May 2026', title: 'Central Australia deployment', detail: 'Utopia + Alice Springs; 87 beds that trip, with Centrecorp as delivery partner.' },
+    { date: 'Jun 2026', title: 'Oonchiumpa REAL Innovation Fund submission', detail: 'A community-owned Alice Springs facility + jobs pathway, decision pending.' },
+    { date: 'To date', title: '~$493K invested by Snow over three years', detail: 'Fully received. The anchor that makes the blended raise credible.' },
+  ],
+  links: [
+    { label: 'The Utopia trip, in full', href: '/field-notes/utopia-may-2026', note: 'Photos + story from the May run' },
+    { label: 'How the Stretch Bed works', href: '/stretch-bed' },
+    { label: 'How it is made', href: '/process' },
+    { label: 'Live impact dashboard', href: '/impact', note: 'The full public impact view' },
+  ],
+  traffic: {
+    intro:
+      'The Goods display at Canberra Airport drives people to a dedicated page. A snapshot of the response:',
+    asOf: 'Last 30 days, to 9 June 2026 (Vercel Analytics)',
+    snapshots: [
+      { value: '73', label: 'visits to the /canberra airport page' },
+      { value: '318', label: 'total website visitors', note: 'A step-change once the display went up' },
+      { value: 'LinkedIn', label: 'top referrer (41 visitors)' },
+      { value: '44', label: 'reads of the Utopia trip story' },
+    ],
+    reactions: [
+      // Add links to positive reactions found online (posts, mentions) here.
+    ],
+  },
+};
+
+export const PARTNER_DASHBOARDS: PartnerDashboard[] = [snow];
+
+export function getPartnerDashboard(slug: string): PartnerDashboard | undefined {
+  return PARTNER_DASHBOARDS.find((p) => p.slug === slug);
+}

--- a/v2/src/lib/data/partner-dashboards.ts
+++ b/v2/src/lib/data/partner-dashboards.ts
@@ -107,7 +107,8 @@ const snow: PartnerDashboard = {
   history: [
     { date: '2023', title: 'Snow becomes an anchor backer', detail: 'Support before the proof was in the houses.' },
     { date: '2024', title: 'Grant 2024/OC0014', detail: 'Multi-year support across beds, the production facility, and the team.' },
-    { date: '[confirm date]', title: 'Snow visits Tennant Creek with us', detail: 'Sally Grimsley-Ballard on country, seeing the work first-hand.' },
+    { date: 'Apr 2025', title: 'Snow visits Tennant Creek with us', detail: 'Sally Grimsley-Ballard on country on 2 April 2025, seeing the work first-hand.' },
+    { date: 'Aug 2025', title: 'Deadly Heart Trek, Katherine', detail: 'Out on the Katherine visit, 8 August 2025.' },
     { date: 'Jan 2026', title: 'First washing machine given to Dianne Stokes', detail: 'In Tennant Creek. She named it Pakkimjalki Kari in Warumungu.' },
     { date: 'Early 2026', title: 'Selected into QBE Catalysing Impact 2026', detail: 'Blended-finance accelerator run by the Social Impact Hub. Stage 2 in September could bring matched catalytic capital.' },
     { date: 'May 2026', title: 'Central Australia deployment', detail: 'Utopia + Alice Springs; 87 beds that trip, with Centrecorp as delivery partner.' },
@@ -115,9 +116,11 @@ const snow: PartnerDashboard = {
     { date: 'To date', title: '~$493K invested by Snow over three years', detail: 'Fully received. The anchor that makes the blended raise credible.' },
   ],
   links: [
+    { label: 'The Snow Foundation on Empathy Ledger', href: 'https://www.empathyledger.com/organisations/snow-foundation', note: 'Your stories, quotes and photos, gathered with consent, yours to revisit anytime', external: true },
+    { label: 'Snow + Goods at Tennant Creek', href: 'https://photos.google.com/share/AF1QipMM88kHBqqUV-udXeHpTB0FjhY8my5_dNWw7CeSphrsq20wt4BlLTmy9O-QoRfBwQ?key=TkY0VHA3cVVKR3V1T0NqOHFBSUpXZ0pGX01WSkNR', note: 'Photo album, 2 April 2025', external: true },
+    { label: 'Deadly Heart Trek, Katherine', href: 'https://photos.google.com/share/AF1QipNbosyzxtrQ0jy240fbDj6Bc58GrvH3dcxBsIfPfX9XMOk8v58MWIRKbA5xxV1KRw?key=dnlaTFhkb2llNHFqSXlWRnBUUy15X1VhSTVZZ1JR', note: 'Photo album, 8 August 2025', external: true },
     { label: 'The Utopia trip, in full', href: '/field-notes/utopia-may-2026', note: 'Photos + story from the May run' },
     { label: 'How the Stretch Bed works', href: '/stretch-bed' },
-    { label: 'How it is made', href: '/process' },
     { label: 'Live impact dashboard', href: '/impact', note: 'The full public impact view' },
   ],
   traffic: {

--- a/v2/src/lib/data/partner-dashboards.ts
+++ b/v2/src/lib/data/partner-dashboards.ts
@@ -59,6 +59,7 @@ export interface PartnerDashboard {
     snapshots: TrafficSnapshot[];
     reactions: DashboardLink[]; // positive-reaction links Ben adds
   };
+  gallery: { src: string; alt: string }[];
   /** Future: when set + NOTION_TOKEN present, curated sections read from Notion. */
   notionDbId?: string;
 }
@@ -81,7 +82,7 @@ const snow: PartnerDashboard = {
         { title: 'Community siting decision for the plant', note: 'Tennant Creek or Mparntwe' },
         { title: 'Katrina: train-the-trainer at Witta', note: 'Skills travel home to run the Alice Springs build' },
         { title: 'QBE Catalysing Impact, Stage 2', note: 'September; could bring matched catalytic capital' },
-        { title: 'Impact-investment scoping with Bhanvi', note: 'Intro via Snow' },
+        { title: 'Investment + loan opportunity with Snow', note: 'Exploring recoverable / impact-investment finance; intro to Bhanvi via Snow' },
       ],
     },
     {
@@ -89,7 +90,7 @@ const snow: PartnerDashboard = {
       items: [
         { title: 'Commission the on-country production plant', note: '~85% complete' },
         { title: 'Alice Springs facility with Oonchiumpa', note: 'REAL Innovation Fund submission lodged, decision pending' },
-        { title: 'Washing machine prototype iteration', note: 'Pakkimjalki Kari line' },
+        { title: 'New washing machine prototype', note: 'Next-generation build in development now' },
         { title: 'The Butterfly Movement charity transition', note: 'Goods’ DGR home; Aboriginal-led board forming' },
       ],
     },
@@ -106,7 +107,9 @@ const snow: PartnerDashboard = {
   history: [
     { date: '2023', title: 'Snow becomes an anchor backer', detail: 'Support before the proof was in the houses.' },
     { date: '2024', title: 'Grant 2024/OC0014', detail: 'Multi-year support across beds, the production facility, and the team.' },
-    { date: 'Jan 2026', title: 'First washing machine built with the Bloomfield family', detail: 'In Tennant Creek; named Pakkimjalki Kari by Elder Dianne Stokes.' },
+    { date: '[confirm date]', title: 'Snow visits Tennant Creek with us', detail: 'Sally Grimsley-Ballard on country, seeing the work first-hand.' },
+    { date: 'Jan 2026', title: 'First washing machine given to Dianne Stokes', detail: 'In Tennant Creek. She named it Pakkimjalki Kari in Warumungu.' },
+    { date: 'Early 2026', title: 'Selected into QBE Catalysing Impact 2026', detail: 'Blended-finance accelerator run by the Social Impact Hub. Stage 2 in September could bring matched catalytic capital.' },
     { date: 'May 2026', title: 'Central Australia deployment', detail: 'Utopia + Alice Springs; 87 beds that trip, with Centrecorp as delivery partner.' },
     { date: 'Jun 2026', title: 'Oonchiumpa REAL Innovation Fund submission', detail: 'A community-owned Alice Springs facility + jobs pathway, decision pending.' },
     { date: 'To date', title: '~$493K invested by Snow over three years', detail: 'Fully received. The anchor that makes the blended raise credible.' },
@@ -131,6 +134,14 @@ const snow: PartnerDashboard = {
       // Add links to positive reactions found online (posts, mentions) here.
     ],
   },
+  gallery: [
+    { src: '/images/community/tennant-creek.jpg', alt: 'Tennant Creek community' },
+    { src: '/images/media-pack/community-bed-assembly.jpg', alt: 'Community members assembling a bed' },
+    { src: '/images/media-pack/nic-with-elder-on-verandah.jpg', alt: 'Nic with an Elder on a verandah' },
+    { src: '/images/product/stretch-bed-community.jpg', alt: 'A Stretch Bed in a remote community home' },
+    { src: '/images/product/washing-machine-community.jpg', alt: 'A washing machine deployed in community' },
+    { src: '/images/media-pack/community-testing-bed-golden-hour.jpg', alt: 'A family testing a bed at golden hour' },
+  ],
 };
 
 export const PARTNER_DASHBOARDS: PartnerDashboard[] = [snow];

--- a/v2/src/proxy.ts
+++ b/v2/src/proxy.ts
@@ -1,6 +1,7 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 import { FUNDER_PAGES } from '@/lib/data/funder-pages'
+import { PARTNER_DASHBOARDS } from '@/lib/data/partner-dashboards'
 
 // Routes that require user authentication (phone-based)
 const protectedUserRoutes = ['/my-items', '/community', '/production']
@@ -85,6 +86,21 @@ export async function proxy(request: NextRequest) {
         if (authCookie !== funder.password) {
           return NextResponse.redirect(new URL(`/funders/${slug}/login`, request.url))
         }
+      }
+    }
+  }
+
+  // Partner dashboards — per-slug password gate. Only /partners/<slug>/dashboard
+  // is gated; the public partner pages (/partners/centrecorp etc.) stay open.
+  // Login at /partners/<slug>/login, auth at /api/partners/<slug>/auth.
+  const partnerDashMatch = pathname.match(/^\/partners\/([^/]+)\/dashboard/)
+  if (partnerDashMatch) {
+    const slug = partnerDashMatch[1]
+    const partner = PARTNER_DASHBOARDS.find((p) => p.slug === slug)
+    if (partner) {
+      const authCookie = request.cookies.get(`partner_${slug}`)?.value
+      if (authCookie !== partner.password) {
+        return NextResponse.redirect(new URL(`/partners/${slug}/login`, request.url))
       }
     }
   }


### PR DESCRIPTION
## What

A per-partner, password-gated, **always-live** dashboard at `/partners/<slug>/dashboard`. First partner: **Snow** (`goodsoncountry.com/partners/snow/dashboard`). Reuses the existing per-slug gate pattern, so every partner gets their own URL + password.

## What's on the Snow page
- **Live trajectory strip** — beds (496), communities (9), plastic (2.66 t), washing machines (14/28), read live from the asset register via `getCanonicalAssetRollup()`, plus a curated production-facility count.
- **Kanban** — Up next / In progress / Done.
- **Engagement history** — a Snow timeline (2023 → ~$493K to date).
- **Out in the world** — the real `/canberra` airport traffic snapshot (73 page views, 318 visitors, LinkedIn top referrer, 44 Utopia-story reads) + a slot for positive-reaction links.
- **Go-deeper links** — Utopia trip, Stretch Bed, process, live impact.

## How it's built (5 files)
- `partner-dashboards.ts` — config + content + getter. Structured so the curated sections (kanban/history/links) swap to a **live Notion read** once a `NOTION_TOKEN` is added (graceful fallback); config-driven for now.
- `/partners/[slug]/dashboard/page.tsx` — server component (`force-dynamic`, always fresh).
- `/partners/[slug]/login` + `/api/partners/[slug]/auth` — mirror the funder gate; set `partner_<slug>` cookie.
- `proxy.ts` — gates **only** `/partners/<slug>/dashboard`; public partner pages (`/partners/centrecorp` etc.) stay open.

## Verification (local)
- Unauthed `/partners/snow/dashboard` → 307 → login ✓
- With cookie → 200, live metrics render (496 / 14-28 / 2.66 t) ✓
- Public partner pages still 200 ✓
- `tsc --noEmit` clean ✓

## Notes
- Snow password is `snow2026` (hardcoded in config, same pattern as funder pages). Can move to an env var.
- Notion-backed editing of the curated sections is the next step (needs a `NOTION_TOKEN` in v2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)