### PR TITLE
Supabase-backed roadmap: live kanban + timeline + drag-drop admin

### DIFF
--- a/v2/src/app/admin/roadmap/page.tsx
+++ b/v2/src/app/admin/roadmap/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { createServiceClient } from '@/lib/supabase/server';
+import { RoadmapBoard, type RoadmapCard } from './roadmap-board';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = { title: 'Roadmap — Goods admin', robots: { index: false, follow: false } };
+
+export default async function AdminRoadmapPage() {
+  let items: RoadmapCard[] = [];
+  try {
+    const supabase = createServiceClient();
+    const { data } = await supabase
+      .from('roadmap_items')
+      .select('id, title, note, status, position')
+      .eq('show_in_kanban', true)
+      .order('position');
+    items = (data ?? []) as RoadmapCard[];
+  } catch {
+    items = [];
+  }
+
+  return (
+    <main className="min-h-screen px-5 sm:px-8 py-10" style={{ backgroundColor: '#FFFFFF', color: '#2E2E2E' }}>
+      <div className="max-w-5xl mx-auto">
+        <Link href="/admin" className="text-xs uppercase" style={{ color: '#8B9D77' }}>← Admin</Link>
+        <h1 className="font-display text-3xl sm:text-4xl mt-3 mb-2" style={{ color: '#2E2E2E' }}>Roadmap board</h1>
+        <p className="text-sm mb-8" style={{ color: '#2E2E2Ebf' }}>
+          The shared Goods roadmap. Drag cards to move and reorder; it updates the partner dashboards live.
+        </p>
+        {items.length === 0 ? (
+          <p className="text-sm" style={{ color: '#C45C3E' }}>
+            No roadmap items found (or the table is unavailable). Check the roadmap_items table on the Goods project.
+          </p>
+        ) : (
+          <RoadmapBoard initialItems={items} />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/v2/src/app/admin/roadmap/roadmap-board.tsx
+++ b/v2/src/app/admin/roadmap/roadmap-board.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useState } from 'react';
+
+export interface RoadmapCard {
+  id: string;
+  title: string;
+  note: string | null;
+  status: string;
+  position: number;
+}
+
+const COLUMNS: { key: string; heading: string }[] = [
+  { key: 'up-next', heading: 'Up next' },
+  { key: 'in-progress', heading: 'In progress' },
+  { key: 'done', heading: 'Done' },
+];
+
+const CREAM = '#FDF8F3';
+const RUST = '#C45C3E';
+const CHARCOAL = '#2E2E2E';
+const SAGE = '#8B9D77';
+
+export function RoadmapBoard({ initialItems }: { initialItems: RoadmapCard[] }) {
+  const [items, setItems] = useState<RoadmapCard[]>(initialItems);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [overCol, setOverCol] = useState<string | null>(null);
+
+  const colItems = (status: string) =>
+    items.filter((i) => i.status === status).sort((a, b) => a.position - b.position);
+
+  async function persist(id: string, status: string, position: number) {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/roadmap/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status, position }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || 'Save failed');
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Save failed');
+      setItems(initialItems); // revert optimistic move
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function move(draggedId: string, targetStatus: string, beforeId: string | null) {
+    const dragged = items.find((i) => i.id === draggedId);
+    if (!dragged || dragged.id === beforeId) return;
+    const col = items
+      .filter((i) => i.status === targetStatus && i.id !== draggedId)
+      .sort((a, b) => a.position - b.position);
+    let newPos: number;
+    if (beforeId) {
+      const idx = col.findIndex((i) => i.id === beforeId);
+      const prev = col[idx - 1];
+      const next = col[idx];
+      newPos = prev ? (prev.position + next.position) / 2 : next ? next.position - 5 : 10;
+    } else {
+      const last = col[col.length - 1];
+      newPos = last ? last.position + 10 : 10;
+    }
+    if (dragged.status === targetStatus && dragged.position === newPos) return;
+    setItems((prev) =>
+      prev.map((i) => (i.id === draggedId ? { ...i, status: targetStatus, position: newPos } : i)),
+    );
+    persist(draggedId, targetStatus, newPos);
+  }
+
+  const onCardDrop = (e: React.DragEvent, targetStatus: string, beforeId: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setOverCol(null);
+    const id = e.dataTransfer.getData('text/plain');
+    if (id) move(id, targetStatus, beforeId);
+  };
+  const onColDrop = (e: React.DragEvent, status: string) => {
+    e.preventDefault();
+    setOverCol(null);
+    const id = e.dataTransfer.getData('text/plain');
+    if (id) move(id, status, null);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-5 h-5">
+        {saving ? <span className="text-xs" style={{ color: SAGE }}>Saving…</span> : null}
+        {error ? <span className="text-xs" style={{ color: RUST }}>{error} (reverted)</span> : null}
+      </div>
+      <div className="grid md:grid-cols-3 gap-4 items-start">
+        {COLUMNS.map((col) => (
+          <div
+            key={col.key}
+            onDragOver={(e) => {
+              e.preventDefault();
+              setOverCol(col.key);
+            }}
+            onDragLeave={() => setOverCol((c) => (c === col.key ? null : c))}
+            onDrop={(e) => onColDrop(e, col.key)}
+            className="rounded-lg p-4 min-h-[160px] transition-colors"
+            style={{
+              backgroundColor: overCol === col.key ? '#F6ECE2' : CREAM,
+              border: `1px solid ${overCol === col.key ? RUST : '#E8DED4'}`,
+            }}
+          >
+            <p className="text-sm font-semibold uppercase mb-4 flex items-center justify-between" style={{ color: SAGE }}>
+              {col.heading}
+              <span className="text-xs font-normal" style={{ color: `${CHARCOAL}80` }}>{colItems(col.key).length}</span>
+            </p>
+            <div className="space-y-3">
+              {colItems(col.key).map((item) => (
+                <div
+                  key={item.id}
+                  draggable
+                  onDragStart={(e) => {
+                    e.dataTransfer.setData('text/plain', item.id);
+                    e.dataTransfer.effectAllowed = 'move';
+                  }}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => onCardDrop(e, col.key, item.id)}
+                  className="rounded-md p-3 cursor-move bg-white shadow-sm"
+                  style={{ border: '1px solid #E8DED4' }}
+                >
+                  <p className="text-sm font-medium leading-snug" style={{ color: CHARCOAL }}>{item.title}</p>
+                  {item.note ? <p className="text-xs mt-1" style={{ color: `${CHARCOAL}99` }}>{item.note}</p> : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs mt-5" style={{ color: `${CHARCOAL}80` }}>
+        Drag cards between columns or reorder within a column. Changes save to the live roadmap and show on the partner dashboards.
+      </p>
+    </div>
+  );
+}

--- a/v2/src/app/api/admin/roadmap/[id]/route.ts
+++ b/v2/src/app/api/admin/roadmap/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth/admin';
+
+// Move / reorder a roadmap card (status + position). Admin-gated, service-role write.
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const guard = await requireAdmin(request);
+  if (guard) return guard;
+
+  const { id } = await params;
+  const body = await request.json();
+
+  const update: Record<string, unknown> = {};
+  if (typeof body.status === 'string') {
+    if (!['up-next', 'in-progress', 'done'].includes(body.status)) {
+      return NextResponse.json({ error: 'Invalid status' }, { status: 400 });
+    }
+    update.status = body.status;
+  }
+  if (typeof body.position === 'number' && Number.isFinite(body.position)) {
+    update.position = body.position;
+  }
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json({ error: 'Nothing to update' }, { status: 400 });
+  }
+
+  const supabase = createServiceClient();
+  const { error } = await supabase.from('roadmap_items').update(update).eq('id', id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/v2/src/app/partners/[slug]/dashboard/page.tsx
+++ b/v2/src/app/partners/[slug]/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { getPartnerDashboard } from '@/lib/data/partner-dashboards';
 import { getAssetStats } from '@/lib/data/impact-fetcher';
+import { getRoadmap } from '@/lib/data/roadmap';
 
 // Always live: read the asset register fresh each request.
 export const dynamic = 'force-dynamic';
@@ -58,6 +59,12 @@ export default async function PartnerDashboardPage({ params }: Props) {
         .filter((c) => c && c !== 'Unknown' && c !== 'Pending Delivery')
     : [];
 
+  // Kanban + timeline live from roadmap_items; fall back to config if the table
+  // is unavailable/empty during the switch-over.
+  const roadmap = await getRoadmap();
+  const kanban = roadmap?.kanban ?? partner.kanban;
+  const timeline = roadmap?.timeline ?? partner.history;
+
   return (
     <main className="min-h-screen" style={{ backgroundColor: CREAM, color: CHARCOAL }}>
       <section className="px-5 sm:px-8 pt-12 sm:pt-16 pb-10 max-w-5xl mx-auto">
@@ -105,7 +112,7 @@ export default async function PartnerDashboardPage({ params }: Props) {
         <div className="max-w-5xl mx-auto">
           <p className="text-xs uppercase mb-6" style={{ color: RUST }}>What we are working towards</p>
           <div className="grid md:grid-cols-3 gap-4">
-            {partner.kanban.map((col) => (
+            {kanban.map((col) => (
               <div key={col.heading} className="rounded-lg p-5" style={{ backgroundColor: CREAM, border: '1px solid #E8DED4' }}>
                 <p className="text-sm font-semibold uppercase mb-4" style={{ color: SAGE }}>{col.heading}</p>
                 <ul className="space-y-3">
@@ -126,7 +133,7 @@ export default async function PartnerDashboardPage({ params }: Props) {
       <section className="px-5 sm:px-8 py-14 max-w-3xl mx-auto">
         <p className="text-xs uppercase mb-6" style={{ color: RUST }}>Where we have come from, and where we are going</p>
         <ol className="relative border-l pl-6 space-y-7" style={{ borderColor: '#E8DED4' }}>
-          {partner.history.map((h) => (
+          {timeline.map((h) => (
             <li key={h.date + h.title} className="relative">
               <span className="absolute -left-[31px] top-1 h-3 w-3 rounded-full" style={{ backgroundColor: RUST }} />
               <p className="text-xs uppercase mb-1" style={{ color: SAGE }}>{h.date}</p>

--- a/v2/src/lib/data/roadmap.ts
+++ b/v2/src/lib/data/roadmap.ts
@@ -1,0 +1,62 @@
+/**
+ * Roadmap reader. Pulls the shared Goods roadmap live from `roadmap_items`
+ * (Supabase) and shapes it into the kanban + timeline the partner dashboard
+ * renders. Returns null on any error / empty table so the caller can fall back
+ * to the static config during the switch-over.
+ */
+import { createClient } from '@/lib/supabase/server';
+import type { KanbanColumn, TimelineItem } from './partner-dashboards';
+
+interface RoadmapRow {
+  title: string;
+  note: string | null;
+  status: string;
+  position: number;
+  event_date: string | null;
+  date_label: string | null;
+  show_in_kanban: boolean;
+  show_in_timeline: boolean;
+}
+
+const STATUS_ORDER: { key: string; heading: string }[] = [
+  { key: 'up-next', heading: 'Up next' },
+  { key: 'in-progress', heading: 'In progress' },
+  { key: 'done', heading: 'Done' },
+];
+
+export async function getRoadmap(): Promise<{ kanban: KanbanColumn[]; timeline: TimelineItem[] } | null> {
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from('roadmap_items')
+      .select('title, note, status, position, event_date, date_label, show_in_kanban, show_in_timeline')
+      .eq('is_public', true);
+    if (error || !data || data.length === 0) return null;
+    const rows = data as unknown as RoadmapRow[];
+
+    const kanban: KanbanColumn[] = STATUS_ORDER.map(({ key, heading }) => ({
+      heading,
+      items: rows
+        .filter((r) => r.show_in_kanban && r.status === key)
+        .sort((a, b) => a.position - b.position)
+        .map((r) => ({ title: r.title, note: r.note ?? undefined })),
+    })).filter((col) => col.items.length > 0);
+
+    const timeline: TimelineItem[] = rows
+      .filter((r) => r.show_in_timeline)
+      .sort((a, b) => {
+        if (a.event_date && b.event_date) {
+          return a.event_date < b.event_date ? -1 : a.event_date > b.event_date ? 1 : a.position - b.position;
+        }
+        if (a.event_date) return -1; // dated before undated
+        if (b.event_date) return 1;
+        return a.position - b.position;
+      })
+      .map((r) => ({ date: r.date_label ?? r.event_date ?? '', title: r.title, detail: r.note ?? undefined }));
+
+    if (kanban.length === 0 && timeline.length === 0) return null;
+    return { kanban, timeline };
+  } catch {
+    return null;
+  }
+}

--- a/v2/supabase/migrations/20260609120000_roadmap_items.sql
+++ b/v2/supabase/migrations/20260609120000_roadmap_items.sql
@@ -1,0 +1,72 @@
+-- Shared Goods roadmap. Powers the partner-dashboard kanban (group by status)
+-- AND the engagement timeline (rows with show_in_timeline, ordered by event_date).
+-- One source, two views. Cards "move" by updating status + position (drag-drop admin).
+--
+-- Apply with the Supabase CLI (`supabase db push`) or the SQL editor, targeting
+-- the Goods project (cwsyhpiuepvdjtxaozwf). Writes happen via the service-role
+-- key in admin API routes (bypasses RLS); public read is for the dashboards.
+
+create table if not exists public.roadmap_items (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  note text,
+  status text not null default 'up-next' check (status in ('up-next','in-progress','done')),
+  position double precision not null default 0,   -- fractional index for drag-drop reorder
+  event_date date,                                -- for chronological timeline sort
+  date_label text,                                -- friendly timeline label, e.g. "Apr 2025", "To date"
+  show_in_kanban boolean not null default true,
+  show_in_timeline boolean not null default false,
+  partner_slug text,                              -- null = shown on all partner dashboards
+  is_public boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.roadmap_items enable row level security;
+
+-- Partner dashboards render server-side with the anon key; allow read of public rows.
+drop policy if exists "roadmap public read" on public.roadmap_items;
+create policy "roadmap public read" on public.roadmap_items
+  for select using (is_public = true);
+
+create or replace function public.set_roadmap_updated_at() returns trigger as $$
+begin new.updated_at = now(); return new; end;
+$$ language plpgsql;
+drop trigger if exists roadmap_items_set_updated_at on public.roadmap_items;
+create trigger roadmap_items_set_updated_at before update on public.roadmap_items
+  for each row execute function public.set_roadmap_updated_at();
+
+-- Seed: the current Goods roadmap (matches the dashboard config as of 2026-06-09).
+-- Guarded so re-applying the migration never double-seeds.
+do $seed$
+begin
+  if not exists (select 1 from public.roadmap_items) then
+    insert into public.roadmap_items
+      (title, note, status, position, event_date, date_label, show_in_kanban, show_in_timeline) values
+      -- Kanban: Up next
+      ('Community siting decision for the plant','Tennant Creek or Mparntwe','up-next',10,null,null,true,false),
+      ('Katrina: train-the-trainer at Witta','Skills travel home to run the Alice Springs build','up-next',20,null,null,true,false),
+      ('QBE Catalysing Impact, Stage 2','September; could bring matched catalytic capital','up-next',30,null,null,true,false),
+      ('Investment + loan opportunity with Snow','Exploring recoverable / impact-investment finance; intro to Bhanvi via Snow','up-next',40,null,null,true,false),
+      -- Kanban: In progress
+      ('Commission the on-country production plant','~85% complete','in-progress',10,null,null,true,false),
+      ('Alice Springs facility with Oonchiumpa','REAL Innovation Fund submission lodged, decision pending','in-progress',20,null,null,true,false),
+      ('New washing machine prototype','Next-generation build in development now','in-progress',30,null,null,true,false),
+      ('The Butterfly Movement charity transition','Goods DGR home; Aboriginal-led board forming','in-progress',40,null,null,true,false),
+      -- Kanban: Done
+      ('496 beds delivered across 9 communities',null,'done',10,null,null,true,false),
+      ('Containerised production plant built','Recycled-plastic line','done',20,null,null,true,false),
+      ('28 washing machines deployed, 14 reporting live',null,'done',30,null,null,true,false),
+      ('Utopia + Alice Springs trip, May 2026','87 beds that trip','done',40,null,null,true,false),
+      -- Timeline (where we have come from, and where we are going)
+      ('Snow becomes an anchor backer','Support before the proof was in the houses','done',100,'2023-01-01','2023',false,true),
+      ('Grant 2024/OC0014','Multi-year support across beds, the production facility, and the team','done',110,'2024-01-01','2024',false,true),
+      ('Snow visits Tennant Creek with us','Sally Grimsley-Ballard on country on 2 April 2025, seeing the work first-hand','done',120,'2025-04-02','Apr 2025',false,true),
+      ('Deadly Heart Trek, Katherine','Out on the Katherine visit, 8 August 2025','done',130,'2025-08-08','Aug 2025',false,true),
+      ('First washing machine given to Dianne Stokes','In Tennant Creek. She named it Pakkimjalki Kari in Warumungu','done',140,'2026-01-15','Jan 2026',false,true),
+      ('Selected into QBE Catalysing Impact 2026','Blended-finance accelerator run by the Social Impact Hub','done',150,'2026-03-01','Early 2026',false,true),
+      ('Central Australia deployment','Utopia + Alice Springs; 87 beds that trip, with Centrecorp','done',160,'2026-05-21','May 2026',false,true),
+      ('Oonchiumpa REAL Innovation Fund submission','A community-owned Alice Springs facility + jobs pathway, decision pending','done',170,'2026-06-02','Jun 2026',false,true),
+      ('~$493K invested by Snow over three years','Fully received. The anchor that makes the blended raise credible','done',900,null,'To date',false,true);
+  end if;
+end $seed$;


### PR DESCRIPTION
## What

The shared Goods roadmap now lives in a Supabase table (`roadmap_items`) instead of static config. One source powers two views on the partner dashboard: the **kanban** (grouped by status) and the **engagement timeline** (ordered by date). Plus a **drag-and-drop admin** to move cards.

Builds on the partner dashboard (#107).

## Pieces
- **Migration** `roadmap_items` (status, fractional `position` for reorder, `event_date` + `date_label`, `show_in_kanban`/`show_in_timeline`, RLS public read). Seeded with the current Goods roadmap (idempotent). **Already applied to the Goods project** via the Management API.
- **`roadmap.ts` / `getRoadmap()`** — reads the table live; the dashboard renders kanban + timeline from it, **falling back to the static config** on error/empty (safe switch-over).
- **`/admin/roadmap`** — gated drag-and-drop board (native HTML5 DnD, no new deps) to move cards between Up next / In progress / Done and reorder. Optimistic UI, reverts on error.
- **`PATCH /api/admin/roadmap/[id]`** — `requireAdmin` + service-role write of `status` + `position`.

## Verified (local)
- Dashboard reads kanban + timeline from the table (DB-only content renders; config path not used) ✓
- `/admin/roadmap` renders the board with all cards ✓
- PATCH persists to the DB and reverts cleanly (`{"ok":true}` → DB updated → reverted) ✓
- `tsc --noEmit` clean ✓

## Notes
- The migration was applied to prod already; this PR commits the file as the record. The seed is idempotent + guarded.
- Timeline-only items (`show_in_kanban=false`) aren't shown on the drag board (it manages the kanban cards); they still render in the dashboard timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)