### PR TITLE
Snow dashboard: remove all remaining em dashes

### DIFF
--- a/v2/data/partner-dashboard-images.json
+++ b/v2/data/partner-dashboard-images.json
@@ -20,13 +20,13 @@
     },
     "partnership.2": {
       "url": "https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/story-images/trip-may-2026/canon/20260521-1e5a5556.jpg",
-      "alt": "20260521-1E5A5556 — Utopia delivery (May 2026)",
+      "alt": "Beds delivered into community at Utopia, May 2026",
       "elId": "d693e998-a518-4a8e-b8f5-c16928ef2e7a",
       "consent": "el:consent-elder-pending"
     },
     "gallery.5": {
       "url": "https://yvnuayzslukamizrlhwb.supabase.co/storage/v1/object/public/story-images/trip-may-2026/canon/20260521-1e5a5762.jpg",
-      "alt": "20260521-1E5A5762 — Utopia delivery (May 2026)",
+      "alt": "Bed delivery day at Utopia Homelands, May 2026",
       "elId": "3a86ce59-bdf9-4518-a220-f37d7ba83b8f",
       "consent": "el:consent-elder-pending"
     }

--- a/v2/src/app/admin/dashboard-images/picker.tsx
+++ b/v2/src/app/admin/dashboard-images/picker.tsx
@@ -105,7 +105,7 @@ export function DashboardImagePicker({
           : 'community-consent';
     save(slot.key, {
       url: photo.url,
-      alt: photo.title || slot.fallbackAlt,
+      alt: (photo.title || slot.fallbackAlt).replace(/\s*—\s*/g, ', '),
       elId: photo.id,
       consent,
     });
@@ -116,11 +116,11 @@ export function DashboardImagePicker({
   return (
     <div className="space-y-6 p-6 pb-24">
       <header>
-        <h1 className="text-2xl font-bold tracking-tight">Dashboard images — {partnerName}</h1>
+        <h1 className="text-2xl font-bold tracking-tight">Dashboard images: {partnerName}</h1>
         <p className="mt-1 max-w-3xl text-sm text-gray-500">
           Assign an Empathy Ledger photo to any image slot on{' '}
           <code>/partners/{slug}/dashboard</code>. Picks write to{' '}
-          <code>data/partner-dashboard-images.json</code> — they preview live here, and go to prod when the
+          <code>data/partner-dashboard-images.json</code>. They preview live here, and go to prod when the
           file is committed and deployed. Click a photo to see it full size, then assign. Badges show the EL
           consent flag (public / gated-ok / elder review pending / not flagged) as a guide; you hold the call
           on community consent.

--- a/v2/src/app/partners/[slug]/dashboard/page.tsx
+++ b/v2/src/app/partners/[slug]/dashboard/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const p = getPartnerDashboard(slug);
   return {
-    title: p ? `${p.partnerName} — Goods on Country partner dashboard` : 'Partner dashboard',
+    title: p ? `${p.partnerName} partner dashboard` : 'Partner dashboard',
     description: p?.thesisLine,
     robots: { index: false, follow: false },
   };
@@ -132,11 +132,11 @@ export default async function PartnerDashboardPage({ params }: Props) {
     stats = null;
   }
 
-  const beds = stats ? stats.totalBeds.toLocaleString() : '—';
-  const communities = stats ? String(stats.communitiesServed) : '—';
-  const stretch = stats ? stats.stretchBedsDeployed.toLocaleString() : '—';
-  const plasticT = stats ? `${((stats.stretchBedsDeployed * 20) / 1000).toFixed(2)} t` : '—';
-  const washers = stats ? String(stats.washersWorking) : '—';
+  const beds = stats ? stats.totalBeds.toLocaleString() : '–';
+  const communities = stats ? String(stats.communitiesServed) : '–';
+  const stretch = stats ? stats.stretchBedsDeployed.toLocaleString() : '–';
+  const plasticT = stats ? `${((stats.stretchBedsDeployed * 20) / 1000).toFixed(2)} t` : '–';
+  const washers = stats ? String(stats.washersWorking) : '–';
   const washersUnconfirmed = stats ? stats.washersDeployed - stats.washersWorking : 0;
   const peopleReached = stats ? Math.round(stats.totalBeds * 2.5) : null;
   const communityList = stats
@@ -472,7 +472,7 @@ export default async function PartnerDashboardPage({ params }: Props) {
               note="Assumes ~20kg HDPE per Stretch Bed. Not weighed per unit."
             />
             <MetricCard
-              value={peopleReached ? `~${peopleReached.toLocaleString()}` : '—'}
+              value={peopleReached ? `~${peopleReached.toLocaleString()}` : '–'}
               label="People reached"
               comparison="Modelled at about 2.5 people per bed."
               grade="modelled"


### PR DESCRIPTION
Final polish so the Snow dashboard is the one clean thing to send. Removes every remaining em dash from rendered surfaces (your #1 brand rule).

- Page `<title>` separator: `partnerName — Goods on Country partner dashboard` → `partnerName partner dashboard` (the layout already appends `· Goods on Country`).
- Data-fallback placeholders (shown only if the asset register fetch fails): em dash → en dash.
- The image picker now **strips em dashes from EL photo titles** when it stores alt text, so future picks stay clean; the two already-picked Utopia delivery alts get proper descriptions.
- Admin picker UI copy de-em-dashed.

Verified: `tsc` + `npm run build` clean; em-dash sweep across the dashboard page, components, config, and override JSON returns nothing in any rendered copy (only code comments + the picker's strip-regex remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)