### PR TITLE
Snow dashboard: real EL storyteller portraits + bios

### DIFF
--- a/v2/next.config.ts
+++ b/v2/next.config.ts
@@ -15,6 +15,12 @@ const nextConfig: NextConfig = {
   outputFileTracingIncludes: {
     '/admin/photo-review/raw': ['src/app/admin/photo-review/raw/photo-review.html'],
   },
+  // Public media is served by Vercel as static assets. Do not trace it into
+  // serverless functions; large photo/video folders can push admin routes over
+  // Vercel's function bundle limit.
+  outputFileTracingExcludes: {
+    '/*': ['public/**/*'],
+  },
   images: {
     // Next 16 enforces a fixed quality allowlist; default is just [75].
     // The field-notes before-after split uses quality:90 for sharper
@@ -55,6 +61,14 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 's3-us-west-2.amazonaws.com',
         pathname: '/public.notion-static.com/**',
+      },
+      {
+        // Empathy Ledger media proxy — storyteller avatars. 302-redirects to a
+        // signed Supabase URL (next/image follows it server-side and caches the
+        // optimised result, so the signed-URL expiry never reaches the browser).
+        protocol: 'https',
+        hostname: 'www.empathyledger.com',
+        pathname: '/api/media/**',
       },
     ],
   },

--- a/v2/src/app/partners/[slug]/dashboard/page.tsx
+++ b/v2/src/app/partners/[slug]/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { getPartnerDashboard, type OwnershipStage } from '@/lib/data/partner-dashboards';
 import { getDashboardImageOverrides, resolveDashImg } from '@/lib/data/partner-dashboard-images';
+import { safeImageUrl } from '@/lib/empathy-ledger/media-tier';
 import { getAssetStats } from '@/lib/data/impact-fetcher';
 import { getRoadmap } from '@/lib/data/roadmap';
 import { verifiedFinancials } from '@/lib/data/compendium';
@@ -157,16 +158,18 @@ export default async function PartnerDashboardPage({ params }: Props) {
   const quotes = (insights?.topQuotes ?? []).slice(0, 3);
   const featuredVoices = partner.featuredVoices ?? [];
   // More community voices, pulled live from Empathy Ledger's public syndication
-  // API (no login). Text-only by design: EL avatar URLs live on a host we do not
-  // proxy, so we showcase name + place + theme rather than risk a broken portrait.
-  // The named featured voices above are excluded so nobody appears twice.
+  // API (no login): real profile image + bio per storyteller, each portrait
+  // passed through the media privacy gate. EL has no published quotes for these
+  // storytellers yet (only the named featured voices above carry quotes), so we
+  // show their bio. The featured voices are excluded so nobody appears twice.
   const featuredNames = new Set(featuredVoices.map((v) => v.name.toLowerCase()));
   const ledgerVoices = (await empathyLedger.getProjectStorytellers({ limit: 24 }).catch(() => []))
     .map((s) => ({
       name: s.name,
       location: s.location,
       isElder: s.isElder,
-      theme: s.themes?.[0]?.displayName || s.themes?.[0]?.name || null,
+      avatar: safeImageUrl(s.avatarUrl),
+      bio: s.bio?.trim() || null,
     }))
     .filter((s) => Boolean(s.name && !featuredNames.has(s.name.toLowerCase())))
     .slice(0, 6);
@@ -712,12 +715,19 @@ export default async function PartnerDashboardPage({ params }: Props) {
                 <p className="mb-3 text-[11px] font-semibold uppercase tracking-wide" style={{ color: RUST }}>More voices from the community ledger</p>
                 <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
                   {ledgerVoices.map((v) => (
-                    <figure key={v.name} className="flex flex-col rounded-lg bg-white p-5" style={{ border: '1px solid #E8DED4' }}>
-                      <p className="font-display text-lg leading-snug" style={{ color: CHARCOAL }}>
-                        {v.name}{v.isElder ? <span className="text-sm" style={{ color: SAGE }}> · Elder</span> : null}
-                      </p>
-                      {v.location ? <p className="mt-1 text-xs" style={{ color: `${CHARCOAL}99` }}>{v.location}</p> : null}
-                      {v.theme ? <p className="mt-3 text-xs leading-relaxed" style={{ color: `${CHARCOAL}80` }}>In their story: {v.theme}</p> : null}
+                    <figure key={v.name} className="flex flex-col overflow-hidden rounded-lg bg-white" style={{ border: '1px solid #E8DED4' }}>
+                      {v.avatar ? (
+                        <div className="relative aspect-[4/3]">
+                          <Image src={v.avatar} alt={v.name} fill className="object-cover object-top" sizes="(max-width: 768px) 50vw, 33vw" />
+                        </div>
+                      ) : null}
+                      <div className="flex flex-1 flex-col p-5">
+                        <p className="font-display text-lg leading-snug" style={{ color: CHARCOAL }}>
+                          {v.name}{v.isElder ? <span className="text-sm" style={{ color: SAGE }}> · Elder</span> : null}
+                        </p>
+                        {v.location ? <p className="mt-1 text-xs" style={{ color: `${CHARCOAL}99` }}>{v.location}</p> : null}
+                        {v.bio ? <p className="mt-3 text-xs leading-relaxed" style={{ color: `${CHARCOAL}99` }}>{v.bio.length > 150 ? v.bio.slice(0, 150).trimEnd() + '…' : v.bio}</p> : null}
+                      </div>
                     </figure>
                   ))}
                 </div>


### PR DESCRIPTION
The "More voices from the community ledger" cards now show each storyteller's **real Empathy Ledger profile photo + bio** (was name + theme text only).

- Allows the EL media proxy host (`www.empathyledger.com/api/media`) in `next/image`. The avatar URLs 302-redirect to a signed Supabase URL; `next/image` follows it server-side and caches the optimised result, so the signed-URL expiry never reaches the browser.
- Each card: real portrait + name + place + Elder badge + bio snippet, passed through the media privacy gate (`safeImageUrl`).
- EL has **no published quotes** for these 22 storytellers yet (verified: list, insights, and individual profiles all return 0 quotes) — only the 3 featured voices carry curated quotes — so the bios stand in.

Verified: 6 EL portraits render through Next/Image, 0 broken images, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)