### PR TITLE
Washer price figures: $4,300 / $2,000-$2,500 across all surfaces

### DIFF
--- a/v2/.wiki-content/capital/cost-register.md
+++ b/v2/.wiki-content/capital/cost-register.md
@@ -122,8 +122,8 @@ These are generated from Goods-tagged Xero rows using account codes, vendors and
 | Basket Bed historic price | `$370` | Historic / not current offer | Do not use as current Stretch Bed pricing. |
 | Workshop / corporate build | `$6,000` | Pricing reference | Admin strategy page. |
 | Delivery line item | `$3,000` | Pricing reference | Admin strategy page. |
-| Washing-machine prototype cost | `$4,500-$5,000` per machine | Founder/product estimate | Prototype only. Not resident-scale pricing. |
-| Washing-machine target price | `$1,000-$2,000` per machine | Target | Needs engineering and supplier pathway. |
+| Washing-machine prototype cost | `$4,300` per machine | Founder/product estimate | Prototype only. Not resident-scale pricing. |
+| Washing-machine target price | `$2,000-$2,500` per machine | Target | Needs engineering and supplier pathway. |
 | First production plant investment | `$100,000` | Source-backed estimate | TFN `$80K` plus ACT `$20K` in compendium notes. |
 | Scale-up facility cost | `$600,000` each | Finance model assumption | Used for investment model, not actual invoice total. |
 | Annual operating costs | `$600,000` | Finance model assumption | Needs Goods-specific P&L and Xero reconciliation. |

--- a/v2/.wiki-content/products/washing-machine.md
+++ b/v2/.wiki-content/products/washing-machine.md
@@ -12,7 +12,7 @@ That choice matters for school, work, self-esteem, scabies prevention and househ
 
 The current prototype is based on a commercial-grade Speed Queen.
 
-Nicholas described the approach as taking a strong washing machine and adding the equivalent of bull bars and bash plates for remote conditions. It works as a prototype, but it is expensive. Current units cost roughly $4,500 to $5,000, while the target resident-accessible price is closer to $1,000 to $2,000.
+Nicholas described the approach as taking a strong washing machine and adding the equivalent of bull bars and bash plates for remote conditions. It works as a prototype, but it is expensive. Current units cost roughly $4,300, while the target resident-accessible price is closer to $2,000 to $2,500 depending on community needs.
 
 About 15 machines have been built to date. Most have been purchased or placed through councils or organisations, not directly bought by residents.
 

--- a/v2/src/components/dashboard/confidence-chip.tsx
+++ b/v2/src/components/dashboard/confidence-chip.tsx
@@ -72,13 +72,16 @@ export function ConfidenceLegend() {
     { grade: 'not-yet', desc: 'We name it honestly. We do not measure this yet.' },
   ];
   return (
-    <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:gap-x-6 sm:gap-y-2">
-      {items.map((it) => (
-        <div key={it.grade} className="flex items-start gap-2">
-          <ConfidenceChip grade={it.grade} />
-          <span className="text-xs leading-snug" style={{ color: `${CHARCOAL}99`, maxWidth: '20rem' }}>{it.desc}</span>
-        </div>
-      ))}
+    <div className="grid grid-cols-1 gap-5 sm:grid-cols-3">
+      {items.map((it) => {
+        const m = GRADE_META[it.grade];
+        return (
+          <div key={it.grade} className="flex flex-col gap-2.5" style={{ borderTop: `2px solid ${m.border}`, paddingTop: '0.75rem' }}>
+            <ConfidenceChip grade={it.grade} />
+            <p className="text-xs leading-relaxed" style={{ color: `${CHARCOAL}99` }}>{it.desc}</p>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/v2/src/components/dashboard/washer-journey.tsx
+++ b/v2/src/components/dashboard/washer-journey.tsx
@@ -26,12 +26,12 @@ const STEPS: { stage: string; title: string; body: string }[] = [
   {
     stage: 'Happening now',
     title: 'R&D to bring the price down',
-    body: 'The next-generation build is in development. V1 works, but at roughly $4,500 to $5,000 a unit it is council and organisation territory. The design problem now is keeping the durability while stripping out cost.',
+    body: 'The next-generation build is in development. V1 works, but at $4,300 a unit it is council and organisation territory. The design problem now is keeping the durability while stripping out cost.',
   },
   {
     stage: 'The destination',
     title: 'A machine a family can buy for home',
-    body: 'The target is a resident-accessible price near $1,000 to $2,000, repairable close to community, so owning a washing machine at home becomes a normal purchase rather than a program.',
+    body: 'The target is $2,000 to $2,500 depending on community needs and conversations, repairable close to community, so owning a washing machine at home becomes a normal purchase rather than a program.',
   },
 ];
 
@@ -62,25 +62,23 @@ export function WasherJourney({ washersLine }: { washersLine: string }) {
       {/* The price path: the one number this section is really about */}
       <div className="mt-6 rounded-lg p-6" style={{ backgroundColor: '#FFFFFF', border: '1px solid #E8DED4' }}>
         <div className="flex flex-wrap items-start justify-between gap-4">
-          <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: RUST }}>The price has to fall by about two-thirds</p>
+          <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: RUST }}>The price has to fall by roughly half</p>
           <ConfidenceChip grade="modelled" note="Founder estimates from the May 2026 working conversation. Unit costs vary with spec and freight; the target is a design goal, not a promise." />
         </div>
         <div className="mt-4 grid gap-6 sm:grid-cols-2">
           <div>
-            <p className="font-display text-3xl leading-none" style={{ color: CHARCOAL }}>$4,500 to $5,000</p>
+            <p className="font-display text-3xl leading-none" style={{ color: CHARCOAL }}>$4,300</p>
             <p className="mt-2 text-xs leading-relaxed" style={{ color: `${CHARCOAL}99` }}>What a V1 unit costs today. Bought by councils and organisations, out of reach for a household.</p>
           </div>
           <div>
-            <p className="font-display text-3xl leading-none" style={{ color: RUST }}>$1,000 to $2,000</p>
-            <p className="mt-2 text-xs leading-relaxed" style={{ color: `${CHARCOAL}99` }}>The resident-accessible target the V2 R&D is designing toward, so families can buy one for home.</p>
+            <p className="font-display text-3xl leading-none" style={{ color: RUST }}>$2,000 to $2,500</p>
+            <p className="mt-2 text-xs leading-relaxed" style={{ color: `${CHARCOAL}99` }}>The target depending on community needs and conversations, so families can buy one for home.</p>
           </div>
         </div>
         <div className="mt-5 h-2 w-full overflow-hidden rounded-full" style={{ backgroundColor: '#EEE9E3' }} aria-hidden>
-          <div className="h-full rounded-full" style={{ width: '33%', backgroundColor: RUST }} />
+          <div className="h-full rounded-full" style={{ width: '50%', backgroundColor: RUST }} />
         </div>
-        <p className="mt-2 text-[11px]" style={{ color: `${CHARCOAL}80` }}>
-          {washersLine} The demand signal is already bigger than the fleet: one Groote Archipelago request alone asked about 300 machines (an enquiry, not an order).
-        </p>
+        <p className="mt-2 text-[11px]" style={{ color: `${CHARCOAL}80` }}>{washersLine}</p>
       </div>
 
       {/* Still being solved: named honestly, same as everywhere else on this page */}


### PR DESCRIPTION
Updates the modelled washing-machine price path to the confirmed figures (V1 ~$4,300; resident-accessible target $2,000-$2,500 depending on community needs), replacing the earlier $4,500-$5,000 / $1,000-$2,000. Swept every rendered surface for consistency.

## Files (4)
- `washer-journey.tsx` (Snow dashboard price-path component): figures, "roughly half" framing, progress bar `33% -> 50%` to match, removed the Groote Archipelago 300-machine enquiry line
- `.wiki-content/products/washing-machine.md` (renders at `/wiki/products/washing-machine`)
- `.wiki-content/capital/cost-register.md` (prototype + target rows)
- `confidence-chip.tsx`: confidence legend layout (flex list -> 3-col grid with graded top borders) for dashboard readability

Figures are modelled founder estimates (labelled as such via the `modelled` confidence chip). Verified no old washer figures remain on any rendered surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)