### PR TITLE
Footer: point Communities + Impact links at public pages

### DIFF
--- a/v2/src/components/layout/site-footer.tsx
+++ b/v2/src/components/layout/site-footer.tsx
@@ -70,8 +70,8 @@ const footerLinks = {
   about: [
     { name: 'Our Story', href: '/story' },
     { name: 'Community Stories', href: '/stories' },
-    { name: 'Communities', href: '/community' },
-    { name: 'Impact', href: '/impact' },
+    { name: 'Communities', href: '/communities' },
+    { name: 'Impact', href: '/story#impact' },
     { name: 'Centrecorp Partnership', href: '/partners/centrecorp' },
     { name: 'Gallery', href: '/gallery' },
   ],


### PR DESCRIPTION
The public site footer linked to two **gated** pages. This repoints both to their public equivalents so visitors do not hit a login/password wall.

| Link | Was | Now |
|---|---|---|
| Communities | `/community` (gated user dashboard, `protectedUserRoutes`) | `/communities` (public list page) |
| Impact | `/impact` (password-gated, `passwordProtectedRoutes`) | `/story#impact` (public anchor, exists at `story/page.tsx:827`) |

All four targets are real routes; this just stops the footer pointing the public at auth walls. Impact keeps a working link rather than being dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)