### PR TITLE
Snow surfaces: align May-trip count to 107 + reconcile outcomes drawdown

### DIFF
--- a/v2/src/lib/data/partner-dashboards.ts
+++ b/v2/src/lib/data/partner-dashboards.ts
@@ -322,7 +322,7 @@ const snow: PartnerDashboard = {
         { title: '496 beds delivered across 9 communities' },
         { title: 'Containerised production plant built (recycled-plastic line)' },
         { title: '28 washing machines deployed, 14 reporting live' },
-        { title: 'Utopia + Alice Springs trip, May 2026', note: '87 beds that trip' },
+        { title: 'Utopia + Alice Springs trip, May 2026', note: '107 beds that trip' },
       ],
     },
   ],
@@ -333,7 +333,7 @@ const snow: PartnerDashboard = {
     { date: 'Aug 2025', title: 'Deadly Heart Trek, Katherine', detail: 'Out on the Katherine visit, 8 August 2025.' },
     { date: 'Jan 2026', title: 'First washing machine given to Dianne Stokes', detail: 'In Tennant Creek. She named it Pakkimjalki Kari in Warumungu.' },
     { date: 'Early 2026', title: 'Selected into QBE Catalysing Impact 2026', detail: 'Blended-finance accelerator run by the Social Impact Hub. Stage 2 in September could bring matched catalytic capital.' },
-    { date: 'May 2026', title: 'Central Australia deployment', detail: 'Utopia + Alice Springs; 87 beds that trip, with Centrecorp as delivery partner.' },
+    { date: 'May 2026', title: 'Central Australia deployment', detail: 'Utopia + Alice Springs; 107 beds that trip, with Centrecorp as delivery partner.' },
     { date: 'Jun 2026', title: 'Oonchiumpa REAL Innovation Fund submission', detail: 'A community-owned Alice Springs facility + jobs pathway, decision pending.' },
     { date: 'To date', title: 'Nine communities, beds in homes, the first plant being commissioned', detail: 'The base the next stage builds on, with a blended raise now underway to scale it.' },
   ],
@@ -385,7 +385,7 @@ const snow: PartnerDashboard = {
   communityPartnership: {
     name: 'Oonchiumpa Consultancy and Services',
     intro:
-      'Oonchiumpa is a 100 percent Aboriginal-owned consultancy in Alice Springs, owned and run by the Bloomfield family. Two years working together: cultural advice (paid at university research rates), youth programs, and the delivery network into the homelands.',
+      'Oonchiumpa is a 100 percent Aboriginal-owned consultancy in Alice Springs, owned and run by the Bloomfield and Liddle families, chaired by Karen Liddle and led by Kristy Bloomfield. Two years working together: cultural advice (paid at university research rates), youth programs, and the delivery network into the homelands.',
     beats: [
       {
         title: 'Young people built the beds',

--- a/v2/src/lib/funders/configs/snow.ts
+++ b/v2/src/lib/funders/configs/snow.ts
@@ -20,18 +20,18 @@ export const snowConfig: FunderConfig = {
     email: 's.grimsley-ballard@snowfoundation.org.au',
     phone: '0417 851 341',
   },
-  // FINANCIAL DRIFT FLAG (2026-06-09): paidToDate/toBePaid below are STALE.
-  // Live Xero (read-only, contact-level) shows Snow ~$493,129.79 received over 3yr,
-  // $0 outstanding (i.e. the 2025-26 slice is fully PAID, not $275K paid / $120K pending).
-  // totalAud $395,000 is the 2024/OC0014 grant commitment specifically (still valid).
-  // DO NOT trust paidToDate/toBePaid until the FY26-only slice is carved out + the 2
-  // residual checks clear. See wiki/outputs/funder-reports/snow/2026-06-09-snow-figure-reconciliation.md
-  // The report's financials-at-a-glance / commitment-progress also render the LIVE
-  // [METRIC: xero-drawn-aud] resolver, which is the source to prefer.
+  // FINANCIAL RECONCILED (2026-06-11): the 2024/OC0014 grant ($395,000 ex-GST
+  // commitment) is fully drawn. Live Xero (read-only, contact-level) shows Snow
+  // ~$493,129.79 received across 3yr with $0 outstanding, so the grant slice is
+  // fully PAID, not $275K paid / $120K pending. 2 Xero-UI checks still pending
+  // (all Snow invoices Goods-coded; any pre-2023-06-09 revenue). See
+  // wiki/outputs/funder-reports/snow/2026-06-09-snow-figure-reconciliation.md
+  // financials-at-a-glance / commitment-progress also render the LIVE
+  // [METRIC: xero-drawn-aud] resolver, which remains the source to prefer.
   commitment: {
     totalAud: 395000,
-    paidToDateAud: 275000, // STALE — see flag above; slice now fully paid
-    toBePaidAud: 120000, // STALE — see flag above
+    paidToDateAud: 395000, // 2024/OC0014 grant fully drawn (Xero, $0 outstanding)
+    toBePaidAud: 0, // reconciled 2026-06-11: nothing outstanding on the grant
     invoicesRaisedAud: 434500, // inc-GST, across 6 invoices (2 missing)
     reportsSubmitted: '3 of 3 due so far ✓',
     nextReportDue: '31/07/2026 (FY26 Operational acquittal)',


### PR DESCRIPTION
Three-way alignment pass so the Snow surfaces (Notion partner update, the /partners/snow/dashboard page, and the Snow impact one-pager) tell one consistent story on the same canon numbers. This PR is the website slice; the Notion edits and the one-pager re-export were applied/verified out-of-band.

## Changes
- **partner-dashboards.ts**: the dashboard kanban + history said "87 beds that trip" (a stale leftover from the original build, PR #107) while the partnership section and the Oonchiumpa page already said 107. Aligned both to **107 beds that trip**. Partnership intro now names the **Bloomfield and Liddle families, with Karen Liddle as chair and Kristy Bloomfield leading** (was "Bloomfield family"), correcting a who-chairs-Oonchiumpa drift.
- **funders/configs/snow.ts** (the `/partners/snow/outcomes` long-form report): the 2024/OC0014 grant ($395K ex-GST) is fully drawn per the 2026-06-09 Xero reconciliation (~$493,129.79 received, $0 outstanding). Set `paidToDate 275000 -> 395000`, `toBePaid 120000 -> 0`, and updated the in-code drift flag to reconciled (2 Xero-UI checks still noted as pending).

## Verification
- `npm run build` clean
- `npm run check:drift:ci` clean (canon/asset/qbe/story guards)
- Trip count decision (107) and Oonchiumpa roles confirmed with Ben before applying.