### PR TITLE
Snow dashboard: reframe 'what your backing built' as % allocation

### DIFF
--- a/v2/src/app/partners/[slug]/dashboard/page.tsx
+++ b/v2/src/app/partners/[slug]/dashboard/page.tsx
@@ -554,7 +554,7 @@ export default async function PartnerDashboardPage({ params }: Props) {
             id="your-part"
             eyebrow="Your part in this"
             title="What your backing has built"
-            confidence={{ grade: 'counted', note: 'The cumulative figure is Xero-reconciled. The split is how the FY25 grant was acquitted.' }}
+            confidence={{ grade: 'counted', note: 'The $493,130 is Xero-reconciled. The split is an indicative allocation across Snow’s support, not a per-dollar acquittal.' }}
           >
             <div className="grid gap-4 lg:grid-cols-[2fr_3fr]">
               <div className="rounded-lg p-6" style={{ backgroundColor: '#FFFFFF', border: '1px solid #E8DED4' }}>
@@ -563,12 +563,27 @@ export default async function PartnerDashboardPage({ params }: Props) {
                 <div className="mt-4"><ConfidenceChip grade="counted" /></div>
               </div>
               <div className="rounded-lg p-6" style={{ backgroundColor: '#FFFFFF', border: '1px solid #E8DED4' }}>
-                <p className="mb-4 text-[11px] font-semibold uppercase tracking-wide" style={{ color: RUST }}>{partner.funderImpact.breakdown.heading}</p>
-                <ul className="space-y-3">
+                <div className="mb-1 flex items-start justify-between gap-3">
+                  <p className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: RUST }}>{partner.funderImpact.breakdown.heading}</p>
+                  <ConfidenceChip grade="modelled" className="shrink-0" />
+                </div>
+                {partner.funderImpact.breakdown.note ? (
+                  <p className="mb-4 text-xs leading-relaxed" style={{ color: `${CHARCOAL}99` }}>{partner.funderImpact.breakdown.note}</p>
+                ) : (
+                  <div className="mb-4" />
+                )}
+                <ul className="space-y-3.5">
                   {partner.funderImpact.breakdown.items.map((it) => (
-                    <li key={it.label} className="flex items-baseline justify-between gap-4">
-                      <span className="text-sm leading-snug" style={{ color: `${CHARCOAL}cc` }}>{it.label}</span>
-                      <span className="shrink-0 font-display text-lg" style={{ color: CHARCOAL }}>{it.value}</span>
+                    <li key={it.label}>
+                      <div className="flex items-baseline justify-between gap-4">
+                        <span className="text-sm leading-snug" style={{ color: `${CHARCOAL}cc` }}>{it.label}</span>
+                        <span className="shrink-0 font-display text-base" style={{ color: CHARCOAL }}>{it.value}</span>
+                      </div>
+                      {typeof it.percent === 'number' ? (
+                        <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full" style={{ backgroundColor: '#EFE7DC' }}>
+                          <div className="h-full rounded-full" style={{ width: `${it.percent}%`, backgroundColor: RUST }} />
+                        </div>
+                      ) : null}
                     </li>
                   ))}
                 </ul>

--- a/v2/src/lib/data/partner-dashboards.ts
+++ b/v2/src/lib/data/partner-dashboards.ts
@@ -78,8 +78,9 @@ export interface FunderImpact {
   thankYou?: { message: string; image?: { src: string; alt: string; caption?: string } };
   /** Cumulative verified backing, e.g. from a Xero reconciliation. */
   total: { value: string; note: string };
-  /** How a recent grant was actually put to work (e.g. the FY25 split). */
-  breakdown: { heading: string; items: { label: string; value: string }[] };
+  /** Indicative allocation of the funder's support across categories. `percent`
+   *  drives the bar width; `value` is the display label (e.g. "~25%"). */
+  breakdown: { heading: string; note?: string; items: { label: string; value: string; percent?: number }[] };
   /** Shared moments on Country: visits, treks, handovers. Kept short. */
   moments: TimelineItem[];
   /** The funder's own words back to them (board-forwardable social proof). */
@@ -228,12 +229,14 @@ const snow: PartnerDashboard = {
       note: 'Cumulative since 2023, Xero-reconciled on 9 June 2026, nothing outstanding.',
     },
     breakdown: {
-      heading: 'How the FY25 Snow grant was put to work',
+      heading: 'Roughly where your support has gone',
+      note: 'An indicative allocation across Snow’s support since 2023, not a per-dollar acquittal.',
       items: [
-        { label: 'Community visits: on Country presence and relationships', value: '$48K' },
-        { label: 'Founder wages and employment pathways', value: '$12K' },
-        { label: 'Bed R&D: Stretch Bed V2 development and prototyping', value: '$20K' },
-        { label: 'Washing machine V1: from idea to working prototype', value: '$20K' },
+        { label: 'Community visits and on-Country presence', value: '~25%', percent: 25 },
+        { label: 'Bed R&D and product development (V1 to V4)', value: '~25%', percent: 25 },
+        { label: 'Washing machine: build, testing and deployment', value: '~20%', percent: 20 },
+        { label: 'Bed production and deployments to communities', value: '~20%', percent: 20 },
+        { label: 'The on-Country production plant', value: '~10%', percent: 10 },
       ],
     },
     moments: [


### PR DESCRIPTION
The "Your part in this" section showed a $493,130 cumulative headline next to a breakdown that only acquitted the $100K FY25 grant ($48K/$12K/$20K/$20K) — mismatched denominators, so it read as incomplete.

## Change
- Replace the per-dollar FY25 split with an **indicative percentage allocation** across all of Snow's support, rendered as bars: community visits 25%, bed R&D 25%, washing machine 20%, production & deployments 20%, the on-Country plant 10%.
- Headline **$493,130 stays Counted**; the split panel now carries a **Modelled** chip and an "indicative allocation, not a per-dollar acquittal" note.
- Extends `FunderImpact.breakdown` with an optional `note` and per-item `percent` (drives bar width).

Allocation weighting confirmed with Ben (the plant is a small slice; the money went to R&D, visits, the washer, and deployments). Dashboard-only: the one-pager uses outcome cards and the Notion partner-update carries no finance breakdown.

## Verification
- `npm run build` clean
- `npm run check:drift:ci` clean
- Rendered + screenshotted locally on the gated dashboard.