### PR TITLE
Washing machines: single canonical figure of 16 in community

### DIFF
--- a/v2/scripts/check-asset-drift.mjs
+++ b/v2/scripts/check-asset-drift.mjs
@@ -22,14 +22,14 @@ import { createClient } from '@supabase/supabase-js';
 // Mirror of CANONICAL_ASSETS in src/lib/data/asset-canonical.ts. The .ts file
 // is the single source of truth; this is the guard's expected snapshot. Keep
 // the two in lockstep — that lockstep is exactly what this script enforces.
-// NOTE: the register can only yield PHYSICALLY-DEPLOYED washers (28); the
-// public "working" figure (14) is a telemetry call, not derivable here — so we
-// compare washers against washersDeployed.
+// NOTE: washing machines are intentionally NOT drift-checked. The public count
+// (washersInCommunity = 16) is a CURATED, Ben-confirmed figure that supersedes
+// the raw register deployed-row count pending a status cleanup, so it cannot be
+// validated against the register here. Re-confirm it manually.
 const CANONICAL_ASSETS = {
   bedsDeployed: 496,
   stretchBedsDeployed: 133,
   basketBedsDeployed: 363,
-  washersDeployed: 28,
   communitiesServed: 9,
   plasticKg: 2660,
 };

--- a/v2/scripts/generate-funder-report.mjs
+++ b/v2/scripts/generate-funder-report.mjs
@@ -171,8 +171,8 @@ const RESOLVERS = {
       .ilike('product', '%wash%').gte('supply_date', period.start).lte('supply_date', period.end).in('status', ['deployed', 'allocated']);
     return String(res.count ?? 0);
   },
-  // Telemetry-working washers — honest number (28 deployed all-time, 14 reporting).
-  'washers-working': async () => '14 telemetry-confirmed working (of 28 deployed to date)',
+  // Washing machines in community — canonical curated figure (Ben, 2026-06-11).
+  'washers-in-community': async () => '16 washing machines in community',
   // Plastic = STRETCH beds only (recycled HDPE). Basket beds are not a plastic product.
   'plastic-kg-transferred': async () => {
     const res = await goods.from('assets').select('unique_id', { count: 'exact', head: true })

--- a/v2/src/app/about/page.tsx
+++ b/v2/src/app/about/page.tsx
@@ -33,7 +33,7 @@ const SAGE = '#8B9D77';
 
 const FACTS = [
   { value: String(CANONICAL_ASSETS.bedsDeployed), label: 'beds across Australia' },
-  { value: String(CANONICAL_ASSETS.washersWorking), label: 'washing machines confirmed on Country' },
+  { value: String(CANONICAL_ASSETS.washersInCommunity), label: 'washing machines in community' },
   { value: String(CANONICAL_ASSETS.communitiesServed), label: 'communities partnered' },
   { value: '20kg', label: 'plastic diverted per bed' },
 ];

--- a/v2/src/app/api/impact-summary/route.ts
+++ b/v2/src/app/api/impact-summary/route.ts
@@ -31,8 +31,7 @@ export async function GET() {
         basket: a.basketBedsDeployed,
       },
       washers: {
-        working: a.washersWorking,
-        deployed: a.washersDeployed,
+        inCommunity: a.washersInCommunity,
       },
       communitiesServed: a.communitiesServed,
       plasticDivertedKg: a.plasticKg,
@@ -40,7 +39,7 @@ export async function GET() {
       livesImpactedModelled: Math.round(a.bedsDeployed * 2.5),
       notes: {
         plastic: 'Stretch beds only (recycled HDPE). Basket beds are not a plastic-diversion product.',
-        washers: '14 telemetry-working of 28 physically deployed.',
+        washers: '16 washing machines in community (curated, Ben-confirmed; supersedes the raw register row count).',
         basis: "status='deployed', summed by quantity; excludes pipeline/requested placeholders.",
       },
     };

--- a/v2/src/app/partners/[slug]/dashboard/page.tsx
+++ b/v2/src/app/partners/[slug]/dashboard/page.tsx
@@ -137,8 +137,7 @@ export default async function PartnerDashboardPage({ params }: Props) {
   const communities = stats ? String(stats.communitiesServed) : '–';
   const stretch = stats ? stats.stretchBedsDeployed.toLocaleString() : '–';
   const plasticT = stats ? `${((stats.stretchBedsDeployed * 20) / 1000).toFixed(2)} t` : '–';
-  const washers = stats ? String(stats.washersWorking) : '–';
-  const washersUnconfirmed = stats ? stats.washersDeployed - stats.washersWorking : 0;
+  const washers = stats ? String(stats.washersInCommunity) : '–';
   const peopleReached = stats ? Math.round(stats.totalBeds * 2.5) : null;
   const communityList = stats
     ? stats.communityBreakdown
@@ -275,7 +274,7 @@ export default async function PartnerDashboardPage({ params }: Props) {
           <div className="mt-8 grid grid-cols-2 gap-3 sm:grid-cols-4">
             <HeroStat value={beds} label="Beds in community" note={stretch ? `${stretch} are Stretch Beds` : undefined} />
             <HeroStat value={communities} label="Communities" />
-            <HeroStat value={washers} label="Washing machines live" />
+            <HeroStat value={washers} label="Washing machines in community" />
             <HeroStat value={fmtAUD(secured)} label="Total grants and support, all sources" />
           </div>
           <div className="mt-3 flex flex-wrap items-center gap-2">
@@ -367,11 +366,11 @@ export default async function PartnerDashboardPage({ params }: Props) {
             />
             <MetricCard
               value={washers}
-              label="Washing machines"
-              comparison={washersUnconfirmed > 0 ? `${washersUnconfirmed} deployed machines are not reporting live. We name them rather than round them into the win.` : 'All deployed machines reporting live.'}
-              pill={{ text: 'live / deployed', live: true }}
+              label="Washing machines in community"
+              comparison="Pakkimjalki Kari units placed through councils and community organisations."
+              pill={{ text: 'in community', live: true }}
               grade="counted"
-              note="Working count is hand-confirmed; telemetry coverage is partial."
+              note="In-community count, hand-confirmed."
             />
             <MetricCard
               value={plasticT}
@@ -541,8 +540,8 @@ export default async function PartnerDashboardPage({ params }: Props) {
             <WasherJourney
               washersLine={
                 stats
-                  ? `${stats.washersWorking} machines in community today, placed through councils and organisations.`
-                  : '14 machines in community today, placed through councils and organisations.'
+                  ? `${stats.washersInCommunity} machines in community today, placed through councils and organisations.`
+                  : '16 machines in community today, placed through councils and organisations.'
               }
             />
           </div>

--- a/v2/src/lib/data/artifact-register.json
+++ b/v2/src/lib/data/artifact-register.json
@@ -166,7 +166,7 @@
       "dataClass": "green",
       "owner": "Ben",
       "qbeAreas": ["02"],
-      "citesCanon": ["beds-deployed", "communities-served", "plastic-kg", "washers-deployed", "washers-working", "revenue-received"],
+      "citesCanon": ["beds-deployed", "communities-served", "plastic-kg", "washers-in-community", "revenue-received"],
       "lastVerified": "2026-06-03"
     },
     {

--- a/v2/src/lib/data/asset-canonical.ts
+++ b/v2/src/lib/data/asset-canonical.ts
@@ -2,5 +2,9 @@
  *  (project cwsyhpiuepvdjtxaozwf), reconciled 2026-05-30. Static surfaces import
  *  THIS; server components prefer getCanonicalAssetRollup() in impact-fetcher.ts
  *  (live). Plastic = Stretch beds only (Basket Beds are not a plastic product).
- *  Drift from the live register is caught by scripts/check-asset-drift.mjs. */
-export const CANONICAL_ASSETS = { bedsDeployed: 496, stretchBedsDeployed: 133, basketBedsDeployed: 363, washersWorking: 14, washersDeployed: 28, communitiesServed: 9, distinctCommunities: 10, plasticKg: 2660 } as const;
+ *  Drift from the live register is caught by scripts/check-asset-drift.mjs.
+ *  washersInCommunity (16) is a CURATED, Ben-confirmed figure (2026-06-11): the
+ *  single in-community washing-machine count. It supersedes the old deployed/
+ *  working split; the register still holds more deployed washer rows pending a
+ *  status cleanup, so washers are NOT drift-checked against the register. */
+export const CANONICAL_ASSETS = { bedsDeployed: 496, stretchBedsDeployed: 133, basketBedsDeployed: 363, washersInCommunity: 16, communitiesServed: 9, distinctCommunities: 10, plasticKg: 2660 } as const;

--- a/v2/src/lib/data/canon.ts
+++ b/v2/src/lib/data/canon.ts
@@ -61,16 +61,10 @@ export const CANON: CanonFact[] = [
     definition: 'Current flagship beds deployed. Drives plastic-kg.',
   },
   {
-    id: 'washers-deployed', label: 'Washing machines deployed', value: CANONICAL_ASSETS.washersDeployed, unit: 'units',
+    id: 'washers-in-community', label: 'Washing machines in community', value: CANONICAL_ASSETS.washersInCommunity, unit: 'units',
     domain: 'assets', claimLabel: 'verified', dataClass: 'green',
-    source: 'v2 Supabase `assets` via asset-canonical.ts', check: 'auto', asAt: '2026-05-30', owner: 'Ben',
-    definition: 'Physically-deployed Pakkimjalki Kari units.',
-  },
-  {
-    id: 'washers-working', label: 'Washing machines working', value: CANONICAL_ASSETS.washersWorking, unit: 'units',
-    domain: 'assets', claimLabel: 'verified', dataClass: 'green',
-    source: 'Washer telemetry (constant, not yet auto-derived from the register)', check: 'manual', asAt: '2026-06-06', owner: 'Ben',
-    definition: '14 working is a telemetry call, not derivable from the register. Re-confirm from pings.',
+    source: 'Curated in-community count (Ben-confirmed 2026-06-11); supersedes the register deployed-row count pending a status cleanup', check: 'manual', asAt: '2026-06-11', owner: 'Ben',
+    definition: '16 Pakkimjalki Kari washing machines in community. Single public figure; not auto-derived from the register.',
   },
   {
     id: 'communities-served', label: 'Communities served', value: CANONICAL_ASSETS.communitiesServed, unit: 'communities',

--- a/v2/src/lib/data/grant-content.ts
+++ b/v2/src/lib/data/grant-content.ts
@@ -101,16 +101,14 @@ export const impactNumbers = {
   asOf: '2026-05-30',
   totalAssetsTracked: 561, // asset table rows: 520 bed rows + 41 washer rows
   bedsDeployed: CANONICAL_ASSETS.bedsDeployed, // deployed bed units tracked (Stretch + legacy Basket)
-  washersDeployed: CANONICAL_ASSETS.washersDeployed, // physically deployed washers
-  washersWorking: CANONICAL_ASSETS.washersWorking, // confirmed working; telemetry is not fleet-wide yet
+  washersInCommunity: CANONICAL_ASSETS.washersInCommunity, // canonical in-community washing-machine count (curated)
   communitiesEngaged: CANONICAL_ASSETS.communitiesServed, // served communities; distinct register names = 10 incl. placeholder/allocated
   livesImpacted: '1,000+',
   plasticDivertedKg: CANONICAL_ASSETS.plasticKg, // Stretch beds only (133 x 20kg HDPE); Basket Beds are not a plastic product
   plasticPerBed: '20kg HDPE',
   verifiedStorytellers: '15+',
   advisoryBoardMembers: 13, // advisory/support network — NOT a fiduciary board
-  // Deployed beds by community. Washer counts omitted here because deployed vs working
-  // status is still being reconciled; see washersDeployed/washersWorking above.
+  // Deployed beds by community. Washer counts omitted here; see washersInCommunity above.
   deployments: [
     { community: 'Tennant Creek', state: 'NT', beds: 159 },
     { community: 'Utopia Homelands', state: 'NT', beds: 147 },
@@ -210,7 +208,7 @@ export const grantAnswers = {
     medium: `Three things differentiate Goods: (1) Community-led design. Every product decision is shaped in community with the people who use the thing. 500+ minutes of recorded community input drove the evolution from V1 Basket Beds to the V4 Stretch Bed. (2) Local production. Our containerised production facility ($100K invested) is being set up to turn waste plastic into bed components On-Country, creating jobs and a circular economy as it comes online. (3) Ownership pathway. The model is built to transfer capability to communities over time, with full training, capability and documentation, rather than a license.`,
   },
   whoDoYouWorkWith: 'We work with 9 remote Indigenous communities across QLD, NT, WA, and SA. Core community partners include Oonchiumpa Consultancy, Wilya Janta, and Palm Island Community Company. Health partners include Anyinginyi Health, Miwatj Health, Purple House, and Red Dust.',
-  howDoYouMeasureImpact: 'We track impact through: (1) Asset Register — 561 asset rows with QR-coded lifecycle monitoring. (2) Telemetry — 28 washing machines deployed, 14 confirmed working, with telemetry not yet fleet-wide. (3) Community feedback — 500+ minutes recorded, 15+ verified storytellers via Empathy Ledger. (4) Environmental metrics — 2,660kg+ plastic diverted (133 Stretch beds x 20kg HDPE; Basket Beds are not a plastic product). (5) Health outcomes — tracking with health partners.',
+  howDoYouMeasureImpact: 'We track impact through: (1) Asset Register — 561 asset rows with QR-coded lifecycle monitoring. (2) Telemetry — 16 washing machines in community, with fleet telemetry not yet fleet-wide. (3) Community feedback — 500+ minutes recorded, 15+ verified storytellers via Empathy Ledger. (4) Environmental metrics — 2,660kg+ plastic diverted (133 Stretch beds x 20kg HDPE; Basket Beds are not a plastic product). (5) Health outcomes — tracking with health partners.',
   whatAreYourFinancials: `~$741.1K ACT-GD ACCREC paid to date, comprising ~$679.7K grant/philanthropic receipts and ~$61.4K commercial/buyer receipts. ~$143K remains outstanding in authorised receivables (Rotary $82.5K, Homeland School $44K, and Regional Arts $16.5K). $100K invested in the production facility. Demand materially exceeds current production capacity. Figures are Xero management data, not audited.`,
   howWillYouUseThisFunding: {
     beds: 'Each $600–850 funds one Stretch Bed deployed to a remote community, diverting 20kg of plastic and providing a 10+ year sleeping surface.',
@@ -326,7 +324,7 @@ export function composeGrantApplication(
         `As of ${impactNumbers.asOf}:`,
         '',
         `- **${impactNumbers.bedsDeployed}** beds deployed across **${impactNumbers.communitiesEngaged}** communities`,
-        `- **${impactNumbers.washersDeployed}** washing machines deployed (**${impactNumbers.washersWorking}** confirmed working)`,
+        `- **${impactNumbers.washersInCommunity}** washing machines in community`,
         `- **${impactNumbers.plasticDivertedKg.toLocaleString()}kg** plastic diverted from landfill`,
         `- **${impactNumbers.livesImpacted}** lives directly impacted`,
         `- **${impactNumbers.totalAssetsTracked}** assets tracked via QR-coded lifecycle monitoring`,

--- a/v2/src/lib/data/impact-fetcher.ts
+++ b/v2/src/lib/data/impact-fetcher.ts
@@ -41,13 +41,13 @@ const BEDS_PER_RHD_CASE_PREVENTED = 500; // 1 RHD case prevented per ~500 beds (
 const WASH_CYCLES_PER_RHD_CASE_PREVENTED = 5_000;
 
 /**
- * Washing machines: the register tracks 28 physically DEPLOYED, but fleet
- * telemetry confirms ~14 actually reporting/working. Public/funder surfaces
- * use the honest WORKING number (Ben, 2026-05-30). Not yet auto-derivable
- * (fleet telemetry unreliable) — wire to fleet KPIs when stable. Never publish
- * 28 (deployed) or 41 (all rows incl. retired) as the working count.
+ * Washing machines: 16 in community is the canonical, Ben-confirmed figure
+ * (2026-06-11). It is the single public count and supersedes the old deployed/
+ * working split. The register still holds more deployed washer rows pending a
+ * status cleanup, so this is a curated constant, not auto-derived from rows.
+ * Never publish the raw register row count (deployed) or 41 (all rows).
  */
-const WASHERS_WORKING = 14;
+const WASHERS_IN_COMMUNITY = 16;
 
 // ---------------------------------------------------------------------------
 // Individual data fetchers
@@ -58,9 +58,7 @@ interface AssetStats {
   totalBeds: number; // deployed beds (Stretch + Basket)
   stretchBedsDeployed: number; // recycled-HDPE beds — the plastic-diversion product
   basketBedsDeployed: number; // archived prototype — NOT a plastic product
-  totalWashingMachines: number; // public figure = telemetry-working washers (14)
-  washersDeployed: number; // physically deployed washers (28)
-  washersWorking: number; // telemetry-confirmed working (14)
+  washersInCommunity: number; // canonical in-community washing-machine count (16, curated)
   communitiesServed: number;
   communityBreakdown: { community: string; count: number }[];
 }
@@ -88,14 +86,12 @@ async function getAssetStats(): Promise<AssetStats> {
   const sum = (arr: AssetRow[]) => arr.reduce((s, r) => s + qty(r), 0);
   const isBed = (p: string | null) => /bed/i.test(p ?? '');
   const isStretch = (p: string | null) => /stretch/i.test(p ?? '');
-  const isWasher = (p: string | null) => /washing|washer/i.test(p ?? '');
 
   const deployed = all.filter((r) => r.status === 'deployed');
   const deployedBeds = deployed.filter((r) => isBed(r.product));
   const totalBeds = sum(deployedBeds);
   const stretchBedsDeployed = sum(deployedBeds.filter((r) => isStretch(r.product)));
   const basketBedsDeployed = totalBeds - stretchBedsDeployed;
-  const washersDeployed = sum(deployed.filter((r) => isWasher(r.product)));
 
   // Community breakdown over DEPLOYED units only (excludes the Centrecorp
   // `requested` placeholder + allocated-only communities like Mutitjulu).
@@ -118,9 +114,7 @@ async function getAssetStats(): Promise<AssetStats> {
     totalBeds,
     stretchBedsDeployed,
     basketBedsDeployed,
-    totalWashingMachines: WASHERS_WORKING,
-    washersDeployed,
-    washersWorking: WASHERS_WORKING,
+    washersInCommunity: WASHERS_IN_COMMUNITY,
     communitiesServed,
     communityBreakdown,
   };
@@ -408,7 +402,7 @@ export async function fetchImpactData(): Promise<ImpactSnapshot> {
 /**
  * Canonical asset rollup — the single source every surface should read for
  * deployment counts. Deployed-only, quantity-summed, Basket/Stretch split,
- * washers = telemetry-working (14). Replaces the per-surface hand-counts that
+ * washers = in-community (16, curated). Replaces the per-surface hand-counts that
  * drift (the 520 / 41 / 10,400 problem). Plastic = Stretch beds only.
  */
 export async function getCanonicalAssetRollup() {
@@ -417,8 +411,7 @@ export async function getCanonicalAssetRollup() {
     bedsDeployed: a.totalBeds,
     stretchBedsDeployed: a.stretchBedsDeployed,
     basketBedsDeployed: a.basketBedsDeployed,
-    washersDeployed: a.washersDeployed,
-    washersWorking: a.washersWorking,
+    washersInCommunity: a.washersInCommunity,
     communitiesServed: a.communitiesServed,
     plasticKg: computePlasticDiverted(a.stretchBedsDeployed),
     deployedUnits: a.totalAssets,

--- a/v2/src/lib/data/partner-dashboards.ts
+++ b/v2/src/lib/data/partner-dashboards.ts
@@ -324,7 +324,7 @@ const snow: PartnerDashboard = {
       items: [
         { title: '496 beds delivered across 9 communities' },
         { title: 'Containerised production plant built (recycled-plastic line)' },
-        { title: '28 washing machines deployed, 14 reporting live' },
+        { title: '16 washing machines in community' },
         { title: 'Utopia + Alice Springs trip, May 2026', note: '107 beds that trip' },
       ],
     },

--- a/v2/src/lib/funders/configs/snow.ts
+++ b/v2/src/lib/funders/configs/snow.ts
@@ -222,7 +222,7 @@ export const snowConfig: FunderConfig = {
     dial: ['Prototype', 'Pilot', 'Scaling', 'On-Country production'],
     currentIndex: 2, // Scaling, building toward on-country production
     stepChange:
-      'This period Goods began crossing from delivering beds to making them on country. The containerised production plant reached roughly 85% complete, the washing-machine line grew to a 28-unit field fleet (14 telemetry-confirmed working), and the first paid local production roles are forming in Alice Springs. The step-change is the shift from beds delivered to community toward beds made by community.',
+      'This period Goods began crossing from delivering beds to making them on country. The containerised production plant reached roughly 85% complete, the washing-machine line grew to 16 machines in community, and the first paid local production roles are forming in Alice Springs. The step-change is the shift from beds delivered to community toward beds made by community.',
   },
   focusAreas: [
     {

--- a/v2/src/lib/funders/metrics.ts
+++ b/v2/src/lib/funders/metrics.ts
@@ -61,9 +61,9 @@ const washersThisPeriod: MetricResolver = async (ctx) => {
   return String(res.count ?? 0);
 };
 
-// Telemetry-working washers — honest number (28 deployed all-time, 14 reporting).
-const washersWorking: MetricResolver = async () =>
-  '14 telemetry-confirmed working (of 28 deployed to date)';
+// Washing machines in community — canonical curated figure (Ben, 2026-06-11).
+const washersInCommunity: MetricResolver = async () =>
+  '16 washing machines in community';
 
 // Plastic = STRETCH beds only (recycled HDPE). Basket beds are not a plastic product.
 const plasticKgTransferred: MetricResolver = async (ctx) => {
@@ -279,7 +279,7 @@ export const MetricResolvers: Record<string, MetricResolver> = {
   'beds-allocated-this-period': bedsAllocatedThisPeriod,
   'beds-total-this-period': bedsThisPeriodAllStatuses,
   'washers-total-this-period': washersThisPeriod,
-  'washers-working': washersWorking,
+  'washers-in-community': washersInCommunity,
   'plastic-kg-transferred': plasticKgTransferred,
   'communities-served': communitiesServed,
   'commitment-progress-bar': commitmentProgressBar,


### PR DESCRIPTION
## What

Retire the **28 deployed / 14 telemetry-working** washing-machine split across every surface in favour of **one curated figure: 16 in community** (Ben-confirmed 2026-06-11).

## Why

One honest, consistent number for funder and public surfaces. The new one-pagers, the dashboard, and the canon were disagreeing (16 vs 28/14). 16 is a curated figure: the live register still holds 28 deployed washer rows, so a row-by-row status cleanup is a separate follow-up.

## Changes

- **Canon:** `CANONICAL_ASSETS.washersInCommunity = 16` (was `washersWorking: 14` / `washersDeployed: 28`); canon id `washers-in-community` (was two entries).
- **Surfaces:** impact fetcher, partner dashboard (HeroStat + MetricCard + washer journey line), grant docs, about page, `/api/impact-summary`, Snow funder config copy, metrics resolver, funder-report script.
- **Drift checker:** now intentionally skips washers (16 is curated, not register-derived); the raw 28 still prints as info only. Comment explains why.
- **artifact-register.json:** citation updated to `washers-in-community`.

## Verification

- `npm run build` clean
- `npm run check:drift:ci` **green**
- asset drift check passes (raw 28 prints as info, not compared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)