### PR TITLE
fix(impact): Centrecorp delivered beds 109 → 107 (match canon)

### DIFF
--- a/v2/src/app/impact/page.tsx
+++ b/v2/src/app/impact/page.tsx
@@ -674,8 +674,8 @@ function PartnersSection() {
       name: 'Centrecorp',
       location: 'Distribution Partner',
       role: 'Grant-Funded Distribution Partner',
-      model: 'Donor and institutional buyer at scale — 109 beds grant-funded for distribution to Utopia Homelands communities. Demonstrates delivery at scale and provides evidence of institutional demand for funding applications.',
-      status: '109 beds delivered — institutional partnership evidence',
+      model: 'Donor and institutional buyer at scale — 107 beds grant-funded for distribution to Utopia Homelands communities. Demonstrates delivery at scale and provides evidence of institutional demand for funding applications.',
+      status: '107 beds delivered — institutional partnership evidence',
       color: '#D4A574',
     },
     {

--- a/v2/src/lib/data/impact-model.ts
+++ b/v2/src/lib/data/impact-model.ts
@@ -110,7 +110,7 @@ export const REVENUE_SEGMENTS: RevenueSegment[] = [
     id: 'donor-institutional',
     name: 'Donor-Funded Institutional',
     description: 'Foundations / philanthropic buyers funding beds for community distribution at scale',
-    currentEvidence: '109 beds to Centrecorp — institutional buyer at scale (income_type=grant, not commercial sale)',
+    currentEvidence: '107 beds to Centrecorp — institutional buyer at scale (income_type=grant, not commercial sale)',
     projectedShare: 44,
   },
   {
@@ -600,7 +600,7 @@ export const DEFAULT_OPPORTUNITIES: OptimizationOpportunity[] = [
   {
     id: 'b2b-pipeline',
     title: 'B2B / institutional channel has strongest commercial evidence',
-    description: '109 beds granted to Centrecorp (an institutional buyer, income_type=grant) demonstrates demand at scale. Emergency services are a natural fit: NT already calls them "cyclone beds." Secure letters of intent from potential B2B/institutional clients.',
+    description: '107 beds granted to Centrecorp (an institutional buyer, income_type=grant) demonstrates demand at scale. Emergency services are a natural fit: NT already calls them "cyclone beds." Secure letters of intent from potential B2B/institutional clients.',
     dimension: 'economic',
     potential: 'high',
     dataSource: 'Revenue segments + meeting notes',


### PR DESCRIPTION
The /impact revenue-segment + insight copy carried 109 beds for the Centrecorp → Utopia delivery; canon is 107 everywhere else (invoice INV-1602 "107 Beds", the May trip stories, dashboards, qbe-readiness, kit, content.ts, compendium). This ships the fix to production surgically, separate from PR #124. Text-only diff (4 lines); same change already built clean on the docs branch.

Cherry-pick of b9a296f.