### PR TITLE
feat(newsletter): default-OFF consent checkbox — close the R8 opt-in gap

### DIFF
--- a/v2/src/components/newsletter-signup.tsx
+++ b/v2/src/components/newsletter-signup.tsx
@@ -18,6 +18,7 @@ export function NewsletterSignup({
   defaultEmail = '',
 }: NewsletterSignupProps) {
   const [email, setEmail] = useState(defaultEmail);
+  const [consent, setConsent] = useState(false);
   const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState('');
 
@@ -29,7 +30,7 @@ export function NewsletterSignup({
       const response = await fetch('/api/newsletter', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, tag }),
+        body: JSON.stringify({ email, tag, consent }),
       });
 
       const data = await response.json();
@@ -65,6 +66,16 @@ export function NewsletterSignup({
         placeholder="your@email.com"
         className="w-full rounded-lg border border-input bg-background px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
       />
+      <label className="flex items-start gap-2 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={consent}
+          onChange={(e) => setConsent(e.target.checked)}
+          required
+          className="mt-0.5 h-4 w-4 shrink-0 rounded border-input accent-primary"
+        />
+        <span>Yes, email me occasional Goods updates. I can unsubscribe anytime.</span>
+      </label>
       <Button type="submit" className="w-full" disabled={status === 'submitting'}>
         {status === 'submitting' ? 'Submitting...' : buttonText}
       </Button>


### PR DESCRIPTION
## What
Adds the explicit, default-OFF, **required** newsletter opt-in checkbox to the shared `NewsletterSignup` component and passes `consent` to `/api/newsletter`.

## Why
The canonical-tags **R8** gate (`grantNewsletterComms`) already only mints `comms:goods-newsletter` when `newsletter_consent==='Yes'` — but the form never rendered a consent checkbox, so **no signup could ever enrol** (lead-only, OCAP-safe but the newsletter couldn't grow). This opens the front door the backend was already waiting on. Submitting now = explicit opt-in (Spam Act 2003 clean).

## Scope
- Covers the shared `NewsletterSignup`: **footer, get-involved, checkout-success**.
- **Sponsor** "not ready today?" and **Canberra follow-form** post to the same route with their own components — left **lead-only by design** (interest-capture, not explicit subscribe). Extend later if those should enrol.

## Verification
- `tsc --noEmit` clean (exit 0).
- Backend unchanged — `consent` is consumed by the existing R8 gate.

## Copy
Consent line is public-facing: *"Yes, email me occasional Goods updates. I can unsubscribe anytime."* — reword if preferred.

Ref: act-global-infrastructure `plans/2026-06-08-whole-system-forms-tag-alignment.md` (R8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)