### PR TITLE
fix(consent): gate /stories /community /gallery to cleared voices

### DIFF
--- a/v2/src/app/community/page.tsx
+++ b/v2/src/app/community/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { empathyLedger } from '@/lib/empathy-ledger';
 import { communityPartnerships } from '@/lib/data/content';
 import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
+import { isClearedForExternal } from '@/lib/data/cleared-voices';
 import type { SyndicationStoryteller, ProjectInsights } from '@/lib/empathy-ledger/types';
 
 export const metadata = {
@@ -43,8 +44,17 @@ async function getProjectData() {
     empathyLedger.getProjectInsights(),
     empathyLedger.getMedia({ type: 'image', elderApproved: true, limit: 12 }),
   ]);
-  const storytellers = storytellersRaw.filter(isRealPerson);
-  return { storytellers, insights, photos };
+  // Consent gate (default-deny): isRealPerson removes team/system accounts, then the
+  // cleared-voices allowlist limits the open web to externally-cleared voices only.
+  const storytellers = storytellersRaw
+    .filter(isRealPerson)
+    .filter((s) => isClearedForExternal(s.name));
+  // Same gate on the ungated top-quotes path: drop any quote attributed to a voice
+  // not cleared for external display (unattributed quotes are dropped too — safe direction).
+  const gatedInsights = insights
+    ? { ...insights, topQuotes: insights.topQuotes.filter((q) => isClearedForExternal(q.storytellerName)) }
+    : insights;
+  return { storytellers, insights: gatedInsights, photos };
 }
 
 // ─── Server components ──────────────────────────────────────

--- a/v2/src/app/gallery/page.tsx
+++ b/v2/src/app/gallery/page.tsx
@@ -6,6 +6,7 @@ import {
   videoGallery,
 } from '@/lib/data/content';
 import { media } from '@/lib/data/media';
+import { isClearedForExternal } from '@/lib/data/cleared-voices';
 import GalleryClient from '@/components/gallery-client';
 import type { GalleryPhoto, GalleryStoryteller, GalleryVideo } from '@/components/gallery-client';
 import type { SyndicationStoryteller } from '@/lib/empathy-ledger/types';
@@ -259,6 +260,8 @@ export default async function GalleryPage() {
   } else {
     storytellers = mapFallbackStorytellers();
   }
+  // Consent gate (default-deny): only voices cleared for external/open-web use.
+  storytellers = storytellers.filter((s) => isClearedForExternal(s.name));
 
   const photos = buildPhotos(storytellers);
   const videos = mapVideos();

--- a/v2/src/app/stories/page.tsx
+++ b/v2/src/app/stories/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { storytellerProfiles, storytellerEnrichment, videoGallery } from '@/lib/data/content';
 import { curatedQuotes } from '@/lib/data/curated-quotes';
 import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
+import { isClearedForExternal } from '@/lib/data/cleared-voices';
 import type { SyndicationStoryteller } from '@/lib/empathy-ledger/types';
 import type { Metadata } from 'next';
 
@@ -94,6 +95,8 @@ function isPublicStoryteller(p: StorytellerGridProfile) {
   // Every public storyteller card needs at least one related quote.
   // Profiles without any quote are placeholder rows; hide them.
   if (!p.keyQuote || p.keyQuote.trim() === '') return false;
+  // Consent gate (default-deny): only voices cleared for external/open-web use.
+  if (!isClearedForExternal(p.name)) return false;
   return true;
 }
 
@@ -204,9 +207,15 @@ export default async function StoriesPage() {
     hasStorytellerVideo: resolveStorytellerVideo(s.storytellerName ?? s.authorName ?? null),
   }));
 
+  // Consent gate (default-deny): a published story renders only if its storyteller
+  // (or author) is cleared for external display.
+  const clearedStories = enrichedStories.filter((s) =>
+    isClearedForExternal(s.storytellerName ?? s.authorName ?? null),
+  );
+
   // Split into text and video stories — only stories with usable media survive.
-  const textStories = enrichedStories.filter((s) => !s.videoLink && s.heroImage);
-  const videoStoryLinks = enrichedStories.filter((s) => s.videoLink);
+  const textStories = clearedStories.filter((s) => !s.videoLink && s.heroImage);
+  const videoStoryLinks = clearedStories.filter((s) => s.videoLink);
 
   // Live counts for the stats bar (replace stale hardcoded values).
   const storytellerCount = allStorytellers.length;

--- a/v2/src/lib/data/cleared-voices.ts
+++ b/v2/src/lib/data/cleared-voices.ts
@@ -1,0 +1,73 @@
+// Canonical consent allowlist for community storyteller VOICES on EXTERNAL surfaces
+// (the open web: /stories, /community, /gallery, plus funder material).
+//
+// Source of truth: the `cleared-voices` canon fact in `./canon.ts` (the 32 voices Ben
+// cleared for external use in the 2026-06-17 consent pass) and the Goods Storyteller
+// Library "Cleared for external" view. The broader `display-storyteller-pool` is a
+// coverage queue, NOT a clearance list, so it is deliberately NOT used here.
+//
+// Posture: DEFAULT-DENY. A voice renders externally only if its name matches this
+// list. Empathy Ledger exposes no per-storyteller consent flag to the syndication
+// client, so the canon name-list is the gate. Matching is name-normalised and
+// tolerant (case, whitespace, parentheticals, punctuation, "&"/"and"), but if a
+// cleared person's EL name differs from every spelling here they are hidden. That is
+// the safe direction for consent; add the spelling here to surface them.
+//
+// Keep in sync with `cleared-voices` in canon.ts. Practitioner voices (Dr Boe
+// Remenyi, Chloe, Wayne Glenn) must still be LABELLED as practitioners in the UI,
+// not as community recipients; this list only governs whether they may appear.
+
+const CLEARED_VOICES_EXTERNAL: string[] = [
+  'Ivy Johnson', 'Ivy',
+  'Dianne Stokes',
+  'Ray Nelson',
+  'Mykel',
+  'Kristy Bloomfield',
+  'Norman Frank', // EL may append "(Jupurrurla)"; parentheticals are stripped on match
+  'Linda Turner',
+  'Alfred Johnson',
+  'Brian Russell',
+  'Karen Liddle',
+  'Katrina Bloomfield',
+  'Annie Morrison',
+  'Heather Mundo',
+  'Fred Campbell',
+  'Gloria Turner',
+  'Carmelita & Colette', 'Carmelita and Colette',
+  'Daniel Patrick Noble',
+  'Shayne Bloomfield',
+  'Jason',
+  'Gary',
+  'Dorrie Jones',
+  'Cliff Plummer',
+  'Mark',
+  'Melissa Jackson',
+  'Patricia Frank',
+  'Risilda Hogan',
+  'Tracy McCartney',
+  'Jimmy Frank',
+  'Xavier',
+  'Dr Boe Remenyi', 'Boe Remenyi',
+  'Chloe',
+  'Wayne Glenn',
+];
+
+function normaliseVoiceName(name: string): string {
+  return (name ?? '')
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, ' ') // drop parentheticals e.g. "(Jupurrurla)"
+    .replace(/[.,]/g, ' ')       // drop punctuation e.g. "Dr."
+    .replace(/\s+/g, ' ')        // collapse whitespace (handles "Alfred  Johnson")
+    .trim();
+}
+
+const ALLOWED = new Set(CLEARED_VOICES_EXTERNAL.map(normaliseVoiceName));
+
+/**
+ * True if this storyteller name is cleared for EXTERNAL display (open web).
+ * Default-deny: unknown or empty names return false.
+ */
+export function isClearedForExternal(name: string | null | undefined): boolean {
+  if (!name) return false;
+  return ALLOWED.has(normaliseVoiceName(name));
+}


### PR DESCRIPTION
## Why

Prod (`main`) was serving **pre-gate code**. Non-cleared Empathy Ledger storytellers rendered as **visible cards on the open web**:

- `/gallery` — **Walter** (Kalgoorlie), **Nicholas Marchesi** (Brisbane), **Accounts ACT** (old `/gallery` had no filtering at all)
- `/stories` — **Walter** (Kalgoorlie)

The default-deny `cleared-voices` allowlist (the 32 voices cleared in the 2026-06-17 consent pass) existed only on `docs/snow-onepager-assets`, so it never reached prod. This is a live consent exposure of identifiable community members' names + photos without clearance.

## What

Brings the consent gate onto `main` and extends it to **all three name-bearing EL paths**:

- `cleared-voices.ts` — default-deny allowlist + name-normalised `isClearedForExternal()`
- storyteller grids on `/stories`, `/community`, `/gallery`
- `/community` top-quotes attribution (`getProjectInsights().topQuotes`) — *defense-in-depth*
- `/stories` published-story bylines (`getProjectStories()`) — *defense-in-depth*

Scope is consent-only: 4 files, no unrelated copy/number edits.

## Verification (against LIVE Empathy Ledger)

Ran every name the live syndication API returns through the real `isClearedForExternal`:

- **Grid:** 26 storytellers returned → **23 cleared render**, **3 correctly denied** (Walter, Nicholas Marchesi, Accounts ACT)
- **Top-quotes:** `topQuotes = 0` live → section renders nothing today
- **Published stories:** EL `stories` table returns `401` → `getProjectStories` returns `[]` today

The two extra path gates are defense-in-depth: empty now only by accident, so a future EL publish/quote can't leak a non-cleared name.

`npm run build` green.

## Note

`Walter` is intentionally excluded (not in the cleared-32; his only EL quote was a dedup of Fred Campbell's). Default-deny handles it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)