### PR TITLE
fix(pitch): remove stale $600/$850/$1,200 price widget

### DIFF
--- a/v2/src/app/pitch/document/page.tsx
+++ b/v2/src/app/pitch/document/page.tsx
@@ -217,21 +217,6 @@ export default function PitchDocumentPage() {
             ))}
           </div>
 
-          <div className="grid grid-cols-3 gap-4 mb-10">
-            <div className="border border-neutral-200 rounded-lg p-4 text-center">
-              <p className="text-xl font-bold text-black">$600</p>
-              <p className="text-xs text-neutral-500">Production cost</p>
-            </div>
-            <div className="border border-neutral-200 rounded-lg p-4 text-center">
-              <p className="text-xl font-bold text-black">$850</p>
-              <p className="text-xs text-neutral-500">Sponsored</p>
-            </div>
-            <div className="border border-neutral-200 rounded-lg p-4 text-center">
-              <p className="text-xl font-bold text-black">$1,200</p>
-              <p className="text-xs text-neutral-500">Retail</p>
-            </div>
-          </div>
-
           {/* Product photo — /public/images/product/stretch-bed-hero.jpg */}
           {media.product.stretchBedHero ? (
             <div className="aspect-video rounded-lg overflow-hidden relative">

--- a/v2/src/app/pitch/page.tsx
+++ b/v2/src/app/pitch/page.tsx
@@ -129,20 +129,6 @@ export default function PitchPage() {
               {/* Right: Assembly sequence animation */}
               <div>
                 <AssemblySequence />
-                <div className="grid grid-cols-3 gap-3 mt-8">
-                  <div className="text-center p-3 rounded-xl border border-border">
-                    <div className="text-xl font-bold text-primary">$600</div>
-                    <div className="text-xs text-muted-foreground mt-0.5">production cost</div>
-                  </div>
-                  <div className="text-center p-3 rounded-xl border border-border">
-                    <div className="text-xl font-bold text-primary">$850</div>
-                    <div className="text-xs text-muted-foreground mt-0.5">sponsored</div>
-                  </div>
-                  <div className="text-center p-3 rounded-xl border border-border">
-                    <div className="text-xl font-bold text-primary">$1,200</div>
-                    <div className="text-xs text-muted-foreground mt-0.5">retail</div>
-                  </div>
-                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## What
Removes the 3-box price widget (`$600 production cost / $850 sponsored / $1,200 retail`) from `/pitch` and `/pitch/document`.

## Why
It contradicted canon. The Stretch Bed has **one price ($750)** and costs **~$685 to make today, ~$421 on Country**. The widget's `$600` matched no real cost figure, and `$850`/`$1,200` both exceeded the stated `$750` maximum price — so the investor pitch page told a different pricing story than the cost model (Area 03/04), the shop, `products.ts`, and `/cost-story`.

Per Ben's call: remove it. The price + cost-down story is told properly on `/cost-story`, the dedicated page for it.

## Changes
- `pitch/page.tsx` — drop the price grid (the assembly animation stays)
- `pitch/document/page.tsx` — drop the price grid

`npx tsc --noEmit` clean. Vercel preview will build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)