### PR TITLE
fix(copy): "Assembled on Country" - drop present-tense manufacturing claims

### DIFF
--- a/v2/src/app/page.tsx
+++ b/v2/src/app/page.tsx
@@ -200,7 +200,7 @@ export default async function HomePage() {
               /* eslint-disable-next-line @next/next/no-img-element */
               <img
                 src={overrideImage}
-                alt="Beds being made on country"
+                alt="Beds assembled on Country"
                 className="absolute inset-0 h-full w-full object-cover opacity-70"
               />
             ) : (
@@ -229,13 +229,13 @@ export default async function HomePage() {
             <div className="relative container mx-auto px-4 py-24 md:py-32">
               <div className="max-w-3xl mx-auto text-center text-background">
                 <p className="text-xs uppercase tracking-[0.25em] text-background/70 mb-4">
-                  On-Country manufacturing
+                  Toward manufacturing on Country
                 </p>
                 <h2
                   className="text-3xl md:text-5xl font-light leading-tight"
                   style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
                 >
-                  Beds being made by the people who&rsquo;ll sleep on them.
+                  Beds assembled by the people who&rsquo;ll sleep on them.
                 </h2>
               </div>
             </div>
@@ -261,7 +261,7 @@ export default async function HomePage() {
         <div className="container mx-auto px-4">
           <div className="max-w-5xl mx-auto">
             <p className="text-sm uppercase tracking-widest text-background/40 mb-4">
-              On-Country Manufacturing
+              Toward On-Country Manufacturing
             </p>
             <h2
               className="text-3xl md:text-4xl font-light mb-4 leading-snug"
@@ -498,7 +498,7 @@ export default async function HomePage() {
             {brand.oneLiner}
           </h2>
           <p className="mx-auto mt-4 max-w-2xl text-lg text-accent-foreground/80">
-            Community-designed. Manufactured On-Country. Built to last more than ten years in remote Australia.
+            Community-designed. Assembled on Country. Built to last more than ten years in remote Australia.
           </p>
           <div className="mt-8 flex justify-center">
             <Button size="lg" className="bg-accent-foreground text-accent hover:bg-accent-foreground/90" asChild>

--- a/v2/src/components/layout/site-footer.tsx
+++ b/v2/src/components/layout/site-footer.tsx
@@ -120,7 +120,7 @@ export function SiteFooter() {
               />
             </Link>
             <p className="mt-4 text-sm text-muted-foreground">
-              Community-designed health hardware. Manufactured On-Country. Made by community, made for community.
+              Community-designed health hardware. Assembled on Country. Made by community, made for community.
             </p>
             {/* Social Links */}
             <div className="mt-4 flex gap-4">


### PR DESCRIPTION
## What

Replaces present-tense "manufacturing" claims on the homepage and footer with accurate "assembled" language, and reframes the two manufacturing section eyebrows as aspirational.

Goods **assembles** beds on Country today; component **manufacturing** is the goal this raise funds. The public site should not claim manufacturing it is not doing yet.

## Changes (6 strings, 2 files)

| Where | Before | After |
|---|---|---|
| Hero eyebrow | On-Country manufacturing | Toward manufacturing on Country |
| Hero h2 | Beds being made by the people... | Beds assembled by the people... |
| Video alt-text | Beds being made on country | Beds assembled on Country |
| "From rubbish to bed" eyebrow | On-Country Manufacturing | Toward On-Country Manufacturing |
| Final CTA one-liner | ...Manufactured On-Country. Built... | ...Assembled on Country. Built... |
| Footer | ...Manufactured On-Country. Made by... | ...Assembled on Country. Made by... |

## Not included

- **Impact map (Darwin/Canberra) held** pending a framing decision. This PR is copy-only.
- No data or figure changes.

## Gates

`tsc --noEmit` clean, `check:community-copy` OK, `check:qbe-guardrails` OK, `check:asset-drift` green (register: 9 communities / 496 beds, unchanged).

## Deploy

Merging to `main` triggers the production Vercel deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)