### PR TITLE
fix(map): add Darwin + Canberra so the impact map shows all 9 served communities

### DIFF
--- a/v2/src/lib/data/content.ts
+++ b/v2/src/lib/data/content.ts
@@ -855,6 +855,29 @@ export const communityLocations: CommunityLocation[] = [
     description: 'On the banks of the Liverpool River in Arnhem Land. A diverse community of over 2,500 people from multiple language groups.',
     highlight: 'Serving multiple language groups across Arnhem Land',
   },
+  {
+    id: 'darwin',
+    name: 'Darwin',
+    region: 'Northern Territory',
+    lat: -12.4634,
+    lng: 130.8456,
+    storytellerCount: 0,
+    bedsDelivered: 1,
+    description: 'Top End deployment. One bed delivered in the Darwin region as Goods extends across the north.',
+    highlight: 'First Darwin-region deployment',
+  },
+  {
+    id: 'canberra',
+    name: 'Canberra',
+    region: 'Australian Capital Territory',
+    lat: -35.2809,
+    lng: 149.13,
+    storytellerCount: 0,
+    bedsDelivered: 2,
+    description: 'Two beds delivered in the Canberra region.',
+    highlight: 'First beds in the Canberra region',
+    tooltipDirection: 'left',
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -865,12 +888,14 @@ export const communityLocations: CommunityLocation[] = [
 // (sums to EXPECTED_DEPLOYED_BEDS = 496; the live Supabase register is
 // authoritative, this is the labelled static fallback).
 //
-// `communityPartnerships` (narrative subset) and `communityLocations` (heatpost-
-// map baselines, live-overridden except where staticBedCount=true) are
-// INTENTIONALLY NARROWER scopes than the full register — they omit communities
-// that have no map pin / no narrative partner (e.g. Darwin 1, Canberra 2 in the
-// canonical list have neither). So we do NOT force their sums to equal 496;
-// inventing pins/partners for them would be fabrication. Instead we assert that
+// `communityLocations` (heatpost-map baselines, live-overridden except where
+// staticBedCount=true) now covers all 9 deployed communities, including the
+// single-bed capital-city deployments Darwin (1) and Canberra (2), so the map
+// matches the published "9 communities / 496 beds". `communityPartnerships`
+// (narrative subset) stays INTENTIONALLY NARROWER: it lists only communities
+// with a real narrative partner, so it still omits Darwin/Canberra (a bare
+// deployment is not a partnership story, and inventing one would be fabrication).
+// So we do NOT force either array's sum to equal 496. Instead we assert that
 // (a) no single community's static count EXCEEDS the canonical register value,
 // and (b) neither array's total exceeds EXPECTED_DEPLOYED_BEDS. This catches the
 // previous divergence (139/141/60/96 baselines that overstated some communities)


### PR DESCRIPTION
## What

The interactive impact map (`communityLocations`) showed **7 communities / 493 beds**, but the site publishes **"9 communities / 496 beds"** in ~10 places (press release, pitch deck, about page, parliament follow-up) via `CANONICAL_ASSETS.communitiesServed`. The map silently undercounted the figure you publish to funders.

This adds the two missing deployments so **map = register = the published figure**.

## Changes (1 file: `src/lib/data/content.ts`)

- Add **Darwin** (1 deployed bed, NT) and **Canberra** (2 deployed beds, ACT) to `communityLocations` as minimal factual pins: real register counts, no invented partner, quote, or story.
- Map now: 7 -> **9 communities**, 493 -> **496 beds** (493 + 1 + 2).
- Rewrite the build-time reconciliation comment, which previously documented Darwin/Canberra as intentionally omitted.

## Reverses a documented decision (deliberately)

The code previously documented (in the build-time assertion comment) that Darwin/Canberra were **intentionally omitted**, calling invented pins "fabrication." This reverses that **at Ben's explicit request**, to make the map match the "9 communities" already published everywhere else. The fabrication concern is respected: the pins carry only real register bed counts and a factual one-liner, no invented narrative. `communityPartnerships` (the narrative array) still omits them.

## Gates

- `tsc --noEmit` clean.
- Build-time assertion holds: `communityLocations` total = 496 (not `> 496`); per-community Darwin 1 <= canonical 1, Canberra 2 <= canonical 2. Confirmed against `compendium.ts` deployments + `EXPECTED_DEPLOYED_BEDS = 496`.
- `check:community-copy` OK, `check:asset-drift` OK (communitiesServed still 9, canonical unchanged).
- A full local `next build` could not run in the throwaway worktree (Turbopack rejects the symlinked node_modules); the Vercel preview build runs the real build + assertion.

## Corrections to the prior ledger

- Canberra is **2 deployed beds**, not 1 (+2 more in `demo`, excluded).
- Mount Isa / Kalgoorlie `staticBedCount` flags are now stale (the register tracks them and the counts match) - left as-is, separate cleanup.

## Deploy

Merging to `main` triggers the production Vercel deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
