### PR TITLE
chore(content): align storyteller counts + drop stale staticBedCount flags

### DIFF
--- a/v2/src/app/page.tsx
+++ b/v2/src/app/page.tsx
@@ -487,7 +487,7 @@ export default async function HomePage() {
       {/* 5. Community Voices: from Empathy Ledger */}
       <FeaturedStories
         title="Community Voices"
-        subtitle="33 storytellers across 8 communities have shaped and validated the Goods approach"
+        subtitle="32 storytellers across remote Australia have shaped and validated the Goods approach"
         maxStories={3}
       />
 

--- a/v2/src/components/empathy-ledger/featured-stories.tsx
+++ b/v2/src/components/empathy-ledger/featured-stories.tsx
@@ -27,7 +27,7 @@ const themeStyles: Record<string, { label: string; className: string }> = {
 
 export async function FeaturedStories({
   title = 'Community Voices',
-  subtitle = '15 storytellers across 6 communities have shaped and validated the Goods approach',
+  subtitle = '32 storytellers across remote Australia have shaped and validated the Goods approach',
   showViewAll = true,
   viewAllLink = '/stories',
   maxStories = 3,
@@ -146,7 +146,7 @@ export async function FeaturedStories({
 // Loading state
 export function FeaturedStoriesSkeleton({
   title = 'Community Voices',
-  subtitle = '15 storytellers across 6 communities have shaped and validated the Goods approach',
+  subtitle = '32 storytellers across remote Australia have shaped and validated the Goods approach',
   count = 3,
 }: {
   title?: string;

--- a/v2/src/lib/data/content.ts
+++ b/v2/src/lib/data/content.ts
@@ -758,8 +758,8 @@ export type CommunityLocation = {
   /**
    * When true, the live-map resolver does NOT override `bedsDelivered`
    * with the count from the QR-tagged assets register. Use for hand-
-   * curated entries that aren't yet fully tracked in the register
-   * (e.g. Mount Isa, Kalgoorlie) so the map reflects ground truth.
+   * curated entries not yet tracked in the register, so the map can
+   * reflect a confirmed on-ground number ahead of full QR registration.
    */
   staticBedCount?: boolean;
 };
@@ -829,7 +829,6 @@ export const communityLocations: CommunityLocation[] = [
     description: 'Northwest Queensland mining town and service centre for surrounding communities. Goods has begun seeding beds here as a stepping stone to further Queensland deployments.',
     highlight: 'Stepping stone for Queensland deployments beyond Palm Island',
     tooltipDirection: 'right',
-    staticBedCount: true,
   },
   {
     id: 'kalgoorlie',
@@ -842,7 +841,6 @@ export const communityLocations: CommunityLocation[] = [
     description: "Goldfields region of Western Australia. Goods' first Western Australia deployment, seeding beds with community partners in and around Kalgoorlie.",
     highlight: "First Western Australia deployment for Goods on Country",
     tooltipDirection: 'right',
-    staticBedCount: true,
   },
   {
     id: 'maningrida',

--- a/v2/src/lib/field-notes/resolve-live-map.ts
+++ b/v2/src/lib/field-notes/resolve-live-map.ts
@@ -64,8 +64,8 @@ async function fetchCounts(): Promise<Map<string, number>> {
 
 function mergeLocations(counts: Map<string, number>): CommunityLocation[] {
   return communityLocations.map((loc) => {
-    // Hand-curated entries stay static (e.g. Mount Isa, Kalgoorlie where
-    // the user has set the on-ground number ahead of full QR registration).
+    // Hand-curated entries stay static (where the user has set the
+    // on-ground number ahead of full QR registration).
     if (loc.staticBedCount) return loc;
     const live = counts.get(loc.name);
     if (live === undefined) return loc;


### PR DESCRIPTION
## What

Two small content tidy-ups surfaced during the impact-map reconciliation (#132). Copy/docs only, no logic or figure changes.

## 1. Storyteller subtitles aligned

The homepage and the FeaturedStories/CommunityGallery defaults claimed different, both-wrong storyteller counts:

| Where | Before | After |
|---|---|---|
| `page.tsx` (Community Voices) | 33 storytellers across 8 communities | 32 storytellers across remote Australia |
| `featured-stories.tsx` (FeaturedStories + CommunityGallery defaults) | 15 storytellers across 6 communities | 32 storytellers across remote Australia |

- **32** = the canonical cleared-voice pool (`check-story-coverage.mjs`: "Cleared-voice pool: 32 named"), i.e. the display tier shown on `/stories`.
- **"across remote Australia"** matches the grounded phrasing `community/page.tsx` already uses (`{storytellers.length} storytellers across remote Australia`), and drops the two unverifiable community numbers (8, 6).
- Note: `canon cleared-voices = 6` is a deliberately narrower "weave into narrative" tier, not the public storyteller count. If you'd prefer a different tier/number in the subtitle, it's a one-line change.

## 2. Stale staticBedCount flags dropped

Mount Isa and Kalgoorlie carried `staticBedCount: true` ("hand-curated, not yet QR-tracked"). The register now tracks both and the live counts match the static values (Mount Isa 2, Kalgoorlie 20). Dropping the flags lets the trip-story live-map track them live; the two comments that cited them as untracked are refreshed.

- **No displayed count changes.** The only consumer is `resolve-live-map.ts` (trip-story live-map blocks); its live override computes deployed+allocated = 2/20 (identical), and falls back to the static value if the live fetch fails. `/communities` and the homepage use the static `bedsDelivered` directly and are unaffected.

## Gates

`tsc --noEmit` clean · `check:community-copy` OK · `check:story-coverage` roster integrity clean · content.ts build-time assertion unaffected (no `bedsDelivered` changed, locations total stays 496). The Vercel preview build runs the full build + assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
