### PR TITLE
fix(brand): canon palette + softer home + AA contrast + canon impact band

### DIFF
--- a/v2/src/app/cost-story/page.tsx
+++ b/v2/src/app/cost-story/page.tsx
@@ -387,7 +387,7 @@ export default function CostStoryPage() {
           <div className="mt-8 flex flex-wrap justify-center gap-4">
             <Button
               size="lg"
-              className="bg-accent-foreground text-accent hover:bg-accent-foreground/90"
+              className="bg-background text-foreground hover:bg-background/90"
               asChild
             >
               <Link href="/partner">Explore the capital stack</Link>

--- a/v2/src/app/globals.css
+++ b/v2/src/app/globals.css
@@ -48,39 +48,59 @@
 
 :root {
   --radius: 0.625rem;
-  /* Goods brand - warm, earthy palette */
-  --background: oklch(0.99 0.005 80); /* Warm off-white */
-  --foreground: oklch(0.2 0.02 50); /* Warm dark brown */
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.2 0.02 50);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.2 0.02 50);
-  --primary: oklch(0.55 0.15 45); /* Terracotta/ochre - earthy orange-brown */
-  --primary-foreground: oklch(0.99 0.005 80);
-  --secondary: oklch(0.85 0.04 85); /* Warm sand */
-  --secondary-foreground: oklch(0.2 0.02 50);
-  --muted: oklch(0.95 0.02 80); /* Light cream */
-  --muted-foreground: oklch(0.45 0.02 50);
-  --accent: oklch(0.65 0.12 140); /* Sage green - connection to country */
-  --accent-foreground: oklch(0.99 0.005 80);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.88 0.03 80);
-  --input: oklch(0.92 0.02 80);
-  --ring: oklch(0.55 0.15 45);
-  /* Chart colors - earthy tones */
-  --chart-1: oklch(0.55 0.15 45); /* Terracotta */
-  --chart-2: oklch(0.65 0.12 140); /* Sage */
-  --chart-3: oklch(0.7 0.1 85); /* Gold/sand */
-  --chart-4: oklch(0.5 0.08 30); /* Clay */
-  --chart-5: oklch(0.6 0.1 180); /* Teal */
-  --sidebar: oklch(0.97 0.01 80);
-  --sidebar-foreground: oklch(0.2 0.02 50);
-  --sidebar-primary: oklch(0.55 0.15 45);
-  --sidebar-primary-foreground: oklch(0.99 0.005 80);
-  --sidebar-accent: oklch(0.92 0.02 80);
-  --sidebar-accent-foreground: oklch(0.2 0.02 50);
-  --sidebar-border: oklch(0.88 0.03 80);
-  --sidebar-ring: oklch(0.55 0.15 45);
+
+  /* ── Canonical Goods brand palette ──────────────────────────────────────
+     Mirrored from design/brand/tokens.css (the single source of truth for the
+     Goods brand). Keep these hex values in sync with that file; the shadcn
+     theme below derives from them via var(), so a brand colour is defined in
+     exactly one place. Reconciled to canon 2026-06-19 (was a more saturated
+     OKLCH set; the softer hex palette is canonical, anchored on the logo). */
+  --goods-cream:        #FBF8F1; /* primary warm surface */
+  --goods-cream-muted:  #F1ECE4; /* muted section surface */
+  --goods-sand:         #E8DCC8; /* warm sand, subtle surfaces */
+  --goods-card:         #FFFFFF;
+  --goods-grid:         #E6DFD1; /* hairlines, borders, dividers */
+  --goods-ink:          #2B2A26; /* body text */
+  --goods-sub:          #7A7363; /* captions, muted text */
+  --goods-terracotta:   #C45C3E; /* brand primary (logo terracotta) */
+  --goods-clay:         #A8643F; /* HDPE / chart anchor */
+  --goods-sage:         #8B9D77; /* secondary accent, connection to Country */
+  --goods-gold:         #BBA255; /* steel / chart */
+  --goods-teal:         #5C8A86; /* canvas / chart */
+
+  /* ── shadcn/Tailwind theme, derived from the brand palette above ──────── */
+  --background: var(--goods-cream);
+  --foreground: var(--goods-ink);
+  --card: var(--goods-card);
+  --card-foreground: var(--goods-ink);
+  --popover: var(--goods-card);
+  --popover-foreground: var(--goods-ink);
+  --primary: var(--goods-terracotta);
+  --primary-foreground: var(--goods-cream);
+  --secondary: var(--goods-sand);
+  --secondary-foreground: var(--goods-ink);
+  --muted: var(--goods-cream-muted);
+  --muted-foreground: var(--goods-sub);
+  --accent: var(--goods-sage);
+  --accent-foreground: var(--goods-ink); /* dark text on the muted sage; passes AA (cream was ~2.6:1) */
+  --destructive: oklch(0.577 0.245 27.325); /* functional error red, not a brand colour */
+  --border: var(--goods-grid);
+  --input: var(--goods-grid);
+  --ring: var(--goods-terracotta);
+  /* Chart colours, earthy tones */
+  --chart-1: var(--goods-terracotta);
+  --chart-2: var(--goods-sage);
+  --chart-3: var(--goods-gold);
+  --chart-4: var(--goods-clay);
+  --chart-5: var(--goods-teal);
+  --sidebar: var(--goods-cream-muted);
+  --sidebar-foreground: var(--goods-ink);
+  --sidebar-primary: var(--goods-terracotta);
+  --sidebar-primary-foreground: var(--goods-cream);
+  --sidebar-accent: var(--goods-sand);
+  --sidebar-accent-foreground: var(--goods-ink);
+  --sidebar-border: var(--goods-grid);
+  --sidebar-ring: var(--goods-terracotta);
 }
 
 .dark {

--- a/v2/src/app/page.tsx
+++ b/v2/src/app/page.tsx
@@ -53,45 +53,6 @@ export default async function HomePage() {
         imageAlt="A young man lying full-length on a Stretch Bed on country: recycled plastic legs, galvanised steel poles, heavy-duty canvas"
       />
 
-      {/* 1b. Philanthropist pathway: visible immediately after the hero. */}
-      <section className="border-b border-border bg-background py-10 md:py-12">
-        <div className="container mx-auto px-4">
-          <div className="mx-auto grid max-w-6xl gap-8 md:grid-cols-[1.15fr_0.85fr] md:items-center">
-            <div>
-              <p className="mb-3 text-xs uppercase tracking-[0.25em] text-accent">
-                Back the work
-              </p>
-              <h2
-                className="mb-4 text-2xl font-light leading-tight text-foreground md:text-4xl"
-                style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
-              >
-                Philanthropic and patient capital can move the making to Country.
-              </h2>
-              <p className="max-w-3xl text-base leading-relaxed text-muted-foreground md:text-lg">
-                Goods on Country builds essential health hardware with remote First Nations
-                communities. Beds now. Washing machines next. Community-owned production over time.
-              </p>
-            </div>
-            <div className="rounded-xl border border-border bg-muted/30 p-5 md:p-6">
-              <p className="text-sm leading-relaxed text-muted-foreground">
-                A Curious Tractor Pty Ltd is the trading company behind Goods on Country. The
-                Butterfly Movement Ltd is the DGR pathway for eligible giving while the long-term
-                structure is being designed to protect enterprise discipline and community
-                ownership.
-              </p>
-              <div className="mt-5 flex flex-col gap-3 sm:flex-row md:flex-col lg:flex-row">
-                <Button asChild>
-                  <Link href="/partner">Explore the capital stack</Link>
-                </Button>
-                <Button variant="outline" asChild>
-                  <Link href="/process">See how it is made</Link>
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
       {/* 2. The Stretch Bed: Materials + Assembly + Price comparison */}
       <section className="py-16 md:py-20 bg-background">
         <div className="container mx-auto px-4">
@@ -478,7 +439,7 @@ export default async function HomePage() {
       </section>
 
       {/* 4. Impact Stats */}
-      <ImpactStats fetchLive={true} />
+      <ImpactStats />
 
       {/* 4b. Field notes — most recent published scrollytelling story.
           Self-hides until at least one story has published: true. */}
@@ -501,7 +462,7 @@ export default async function HomePage() {
             Community-designed. Assembled on Country. Built to last more than ten years in remote Australia.
           </p>
           <div className="mt-8 flex justify-center">
-            <Button size="lg" className="bg-accent-foreground text-accent hover:bg-accent-foreground/90" asChild>
+            <Button size="lg" className="bg-background text-foreground hover:bg-background/90" asChild>
               <Link href="/shop/stretch-bed-single">Shop the Stretch Bed</Link>
             </Button>
           </div>

--- a/v2/src/components/marketing/impact-stats.tsx
+++ b/v2/src/components/marketing/impact-stats.tsx
@@ -1,7 +1,3 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import { createClient } from '@/lib/supabase/client';
 import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
 
 interface ImpactStat {
@@ -15,65 +11,24 @@ interface ImpactStatsProps {
   stats?: ImpactStat[];
   title?: string;
   subtitle?: string;
-  fetchLive?: boolean;
 }
 
+// Canon quartet. Single source of truth: asset-canonical.ts. These are CURATED
+// figures, deliberately NOT raw register row counts (the register holds more
+// rows than the curated totals, e.g. washers). Claim ceiling: we show what we
+// have placed, never a claimed health outcome such as "lives impacted".
 const defaultStats: ImpactStat[] = [
-  { value: CANONICAL_ASSETS.bedsDeployed, label: 'Beds Delivered' },
-  { value: CANONICAL_ASSETS.communitiesServed, label: 'Communities Served' },
-  { value: 1500, label: 'Lives Impacted', prefix: '~' },
-  { value: 100, label: 'Community Designed & Led', suffix: '%' },
+  { value: CANONICAL_ASSETS.bedsDeployed, label: 'Beds delivered' },
+  { value: CANONICAL_ASSETS.communitiesServed, label: 'Communities' },
+  { value: CANONICAL_ASSETS.washersInCommunity, label: 'Washing machines in community' },
+  { value: CANONICAL_ASSETS.plasticKg, label: 'Plastic diverted', suffix: 'kg' },
 ];
 
 export function ImpactStats({
-  stats: propStats,
+  stats = defaultStats,
   title = 'Our Impact',
-  subtitle = 'Every bed tells a story of comfort, dignity, and care.',
-  fetchLive = false,
+  subtitle = 'Beds and washing machines in homes across remote Australia.',
 }: ImpactStatsProps) {
-  const [stats, setStats] = useState<ImpactStat[]>(propStats || defaultStats);
-  const [loading, setLoading] = useState(fetchLive);
-
-  useEffect(() => {
-    if (!fetchLive) return;
-
-    async function fetchStats() {
-      try {
-        const supabase = createClient();
-
-        // Fetch total assets
-        const { count: totalAssets } = await supabase
-          .from('assets')
-          .select('*', { count: 'exact', head: true });
-
-        // Fetch unique communities
-        const { data: communities } = await supabase
-          .from('assets')
-          .select('community')
-          .not('community', 'is', null);
-
-        const uniqueCommunities = new Set(communities?.map((a) => a.community)).size;
-
-        // Estimate lives impacted (avg 4 people per household)
-        const livesImpacted = (totalAssets || 0) * 4;
-
-        setStats([
-          { value: totalAssets || 0, label: 'Beds Delivered' },
-          { value: uniqueCommunities, label: 'Communities Served' },
-          { value: livesImpacted, label: 'Lives Impacted', prefix: '~' },
-          { value: 100, label: 'Community Designed & Led', suffix: '%' },
-        ]);
-      } catch (error) {
-        console.error('Error fetching impact stats:', error);
-        // Keep default stats on error
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchStats();
-  }, [fetchLive]);
-
   return (
     <section className="bg-primary py-16 md:py-20">
       <div className="container mx-auto px-4">
@@ -88,17 +43,9 @@ export function ImpactStats({
           {stats.map((stat, index) => (
             <div key={index} className="text-center">
               <div className="text-4xl font-bold text-primary-foreground md:text-5xl">
-                {loading ? (
-                  <span className="inline-block h-12 w-24 animate-pulse rounded bg-primary-foreground/20" />
-                ) : (
-                  <>
-                    {stat.prefix}
-                    {typeof stat.value === 'number'
-                      ? stat.value.toLocaleString()
-                      : stat.value}
-                    {stat.suffix}
-                  </>
-                )}
+                {stat.prefix}
+                {typeof stat.value === 'number' ? stat.value.toLocaleString() : stat.value}
+                {stat.suffix}
               </div>
               <div className="mt-2 text-sm font-medium text-primary-foreground/80 md:text-base">
                 {stat.label}


### PR DESCRIPTION
Brings the design-system reconciliation to prod (web surfaces only; the repo tooling — `design/brand/tokens.css`, the ToC generator + outputs — stays on the design branch for now).

## What changes on the live site
- **Palette → canon.** `globals.css` gains a `--goods-*` brand layer (canon hex, mirrors `design/brand/tokens.css`) and the shadcn theme derives from it via `var()`. The live palette shifts from the more-saturated OKLCH set to the softer, logo-anchored canon (terracotta `#C45C3E`, sage `#8B9D77`, teal/clay/gold + neutrals). Dark theme, `--destructive`, and the cost-model slider skins are untouched.
- **AA contrast.** `--accent-foreground` is now ink, so text on the muted sage bands passes AA (cream-on-sage was ~2.6:1). The two solid sage-band CTA buttons (home final CTA, cost-story closing CTA) get an explicit light style so they stay light.
- **Impact band → canon + claim ceiling.** `ImpactStats` renders `asset-canonical.ts` (496 / 9 / 16 / 2,660kg). Drops the live raw-`assets`-row-count fetch (was showing 561 beds / 10 communities) and the claim-ceiling "lives impacted" metric (was rows × 4 = ~2,244).
- **Softer home.** Removes the post-hero company/capital-stack section so the home flows hero → product/community. Entity + DGR info stays in the footer "DGR pathway" box, on `/partner`, and in the "Back the work" nav/hero CTA.

## Preview
Verified on the branch preview (`docs/snow-onepager-assets`, build green). Re-applied surgically onto `main` so #131 ("Assembled on Country") and #133 (storyteller counts) are preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)