### PR TITLE
feat(impact): canonical 5-domain impact-model redesign (/impact + /insights)

### DIFF
--- a/v2/src/app/impact/page.tsx
+++ b/v2/src/app/impact/page.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { TheoryOfChange } from '@/components/marketing';
 import { fetchImpactData } from '@/lib/data/impact-fetcher';
+import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
 import {
   MODELLED_LABOUR_HOURS_PER_BED,
   REVENUE_SEGMENTS,
@@ -17,7 +18,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Impact Model: Goods on Country',
   description:
-    'Goods on Country impact model for health, environmental, economic, community ownership and production outcomes from Stretch Beds and practical household infrastructure.',
+    'Goods on Country impact model: five outcome domains (rest and health; dignity and safety; self-determination and community-led design; jobs and ownership; circular and local economy) carried by community voices and canon numbers.',
   alternates: {
     canonical: 'https://www.goodsoncountry.com/impact',
   },
@@ -144,6 +145,7 @@ function DimensionIcon({ icon, color }: { icon: string; color: string }) {
     briefcase: 'M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z',
     users: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z',
     factory: 'M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z',
+    home: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6',
   };
 
   return (
@@ -174,20 +176,20 @@ function LossFunctionSection({ snapshot }: { snapshot: ImpactSnapshot }) {
     <section className="py-12" style={{ backgroundColor: '#C45C3E' }}>
       <div className="container mx-auto px-4">
         <div className="text-center mb-8">
-          <p className="text-sm uppercase tracking-widest text-white/60 mb-2">The Loss Function</p>
+          <p className="text-sm uppercase tracking-widest text-white/60 mb-2">By the numbers</p>
           <h2 className="text-2xl font-light text-white" style={{ fontFamily: 'Georgia, serif' }}>
-            Impact Per Dollar
+            What is deployed, and what it cost
           </h2>
         </div>
 
         <div className="grid grid-cols-3 md:grid-cols-6 gap-4 md:gap-6">
           {[
-            { value: summary.totalAssets, label: 'Assets Deployed', sub: 'beds + washers' },
-            { value: `${(summary.livesImpacted).toLocaleString()}+`, label: 'Lives Impacted', sub: 'avg 2.5 per bed' },
-            { value: `${(summary.plasticDivertedKg / 1000).toFixed(1)}t`, label: 'Plastic Diverted', sub: `${summary.plasticDivertedKg.toLocaleString()}kg` },
-            { value: summary.communitiesServed, label: 'Communities', sub: 'across Australia' },
-            { value: summary.employmentHoursCreated.toLocaleString(), label: 'Employment Hrs', sub: `${MODELLED_LABOUR_HOURS_PER_BED.toFixed(1)}hrs/bed` },
-            { value: `$${(summary.totalInvestment / 1000).toFixed(0)}K`, label: 'Invested', sub: `$${(summary.totalInvestment / summary.totalAssets).toFixed(0)}/asset` },
+            { value: CANONICAL_ASSETS.bedsDeployed, label: 'Beds delivered', sub: 'across Australia' },
+            { value: CANONICAL_ASSETS.washersInCommunity, label: 'Washing machines', sub: 'in community' },
+            { value: `${(CANONICAL_ASSETS.plasticKg / 1000).toFixed(2)}t`, label: 'Plastic diverted', sub: `${CANONICAL_ASSETS.plasticKg.toLocaleString()}kg` },
+            { value: CANONICAL_ASSETS.communitiesServed, label: 'Communities', sub: 'across Australia' },
+            { value: Math.round(CANONICAL_ASSETS.bedsDeployed * MODELLED_LABOUR_HOURS_PER_BED).toLocaleString(), label: 'Employment hrs', sub: `${MODELLED_LABOUR_HOURS_PER_BED.toFixed(1)}hrs/bed, modelled` },
+            { value: `$${(summary.totalInvestment / 1000).toFixed(0)}K`, label: 'Invested', sub: 'to date' },
           ].map((stat) => (
             <div key={stat.label} className="text-center">
               <p className="text-2xl md:text-4xl font-light text-white mb-1">{stat.value}</p>
@@ -262,23 +264,86 @@ function DimensionCard({ dimension }: { dimension: ImpactDimension }) {
   );
 }
 
-function FiveDimensionsSection({ dimensions }: { dimensions: ImpactDimension[] }) {
+// The top line: three shifts (the elevator version). Each shift gathers outcome
+// domains beneath it (framework §2). This is the headline; the five domains carry
+// the evidence underneath.
+function ThreeShiftsSection() {
+  const shifts = [
+    {
+      label: 'Material shift',
+      color: '#8B9D77',
+      text: 'Waste plastic becomes a durable, washable, repairable good, made On Country.',
+    },
+    {
+      label: 'Economic shift',
+      color: '#5E7D9A',
+      text: 'The freight tax puts a basic good out of reach, so the bed is built to beat the true remote cost. Value, jobs and the making stay local, and the in-house cost-down moves Goods from grant-funded toward an enterprise communities can own.',
+    },
+    {
+      label: 'Story shift',
+      color: '#C45C3E',
+      text: 'Communities name it (Pakkimjalki Kari, named in Warumungu), design it, and own the record of it, on their terms. This is Indigenous self-determination.',
+    },
+  ];
+
   return (
-    <section className="py-16 md:py-20" style={{ backgroundColor: '#FDF8F3' }}>
+    <section className="py-16 md:py-20 bg-white">
       <div className="container mx-auto px-4">
         <div className="text-center mb-12">
           <p className="text-sm uppercase tracking-widest mb-4" style={{ color: '#8B9D77' }}>
-            Five Dimensions
+            The top line
           </p>
           <h2
             className="text-3xl font-light mb-2"
             style={{ color: '#2E2E2E', fontFamily: 'Georgia, serif' }}
           >
-            How We Measure Impact
+            Three shifts
           </h2>
           <p className="text-sm max-w-xl mx-auto" style={{ color: '#5E5E5E' }}>
-            Each dimension tracks current metrics from our asset register, fleet telemetry, and community
-            engagement — with clear targets for Year 1, Year 3, and 2030.
+            In one breath, the change is three shifts. The five domains beneath them carry the evidence:
+            a community voice, a counted number, and an honest label, on the same beat.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-3 max-w-5xl mx-auto">
+          {shifts.map((s) => (
+            <div
+              key={s.label}
+              className="rounded-lg p-6 border-l-4"
+              style={{ borderColor: s.color, backgroundColor: '#FDF8F3' }}
+            >
+              <p className="text-sm font-medium uppercase tracking-wide mb-2" style={{ color: s.color }}>
+                {s.label}
+              </p>
+              <p className="text-sm" style={{ color: '#5E5E5E' }}>
+                {s.text}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function FiveDomainsSection({ dimensions }: { dimensions: ImpactDimension[] }) {
+  return (
+    <section className="py-16 md:py-20" style={{ backgroundColor: '#FDF8F3' }}>
+      <div className="container mx-auto px-4">
+        <div className="text-center mb-12">
+          <p className="text-sm uppercase tracking-widest mb-4" style={{ color: '#8B9D77' }}>
+            Five domains
+          </p>
+          <h2
+            className="text-3xl font-light mb-2"
+            style={{ color: '#2E2E2E', fontFamily: 'Georgia, serif' }}
+          >
+            How the change shows up
+          </h2>
+          <p className="text-sm max-w-xl mx-auto" style={{ color: '#5E5E5E' }}>
+            Five outcome domains, each pairing a cleared community voice with a canon number from our
+            asset register, fleet telemetry and community engagement. Every number carries an honest
+            label and a target for Year 1, Year 3 and 2030.
           </p>
         </div>
 
@@ -294,6 +359,71 @@ function FiveDimensionsSection({ dimensions }: { dimensions: ImpactDimension[] }
   );
 }
 
+// The two through-lines that run across all five domains (framework §6): the
+// economics story and Indigenous sovereignty. Not separate domains; the spine that
+// connects them.
+function ThroughLinesSection() {
+  const lines = [
+    {
+      label: 'The economics are the impact',
+      color: '#5E7D9A',
+      text: 'A basic good is out of reach in remote communities because of the freight tax and goods that fail in months. Goods answers with a durable, washable, repairable bed built to beat the true remote cost, made On Country so the value and the jobs stay local, with an in-house cost-down that moves the work from grant-funded toward a community-owned enterprise that can stand on its own.',
+    },
+    {
+      label: 'Indigenous sovereignty',
+      color: '#C45C3E',
+      text: 'Self-determination runs through every layer: cultural (the washing machine named Pakkimjalki Kari in Warumungu), design (named and tested in community), data (consent travels with the story), and economic (jobs, then ownership of the making). Sovereignty is what "become unnecessary" means in practice.',
+    },
+  ];
+
+  return (
+    <section className="py-16 md:py-20 bg-white">
+      <div className="container mx-auto px-4">
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-10">
+            <p className="text-sm uppercase tracking-widest mb-4" style={{ color: '#8B9D77' }}>
+              Two through-lines
+            </p>
+            <h2
+              className="text-3xl font-light mb-2"
+              style={{ color: '#2E2E2E', fontFamily: 'Georgia, serif' }}
+            >
+              What runs across all five
+            </h2>
+            <p className="text-sm max-w-xl mx-auto" style={{ color: '#5E5E5E' }}>
+              Two lines connect the domains. They are the spine of the story, not a footnote to the product.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-2">
+            {lines.map((l) => (
+              <div
+                key={l.label}
+                className="rounded-lg p-6 border-l-4"
+                style={{ borderColor: l.color, backgroundColor: '#FDF8F3' }}
+              >
+                <p className="text-base font-medium mb-2" style={{ color: l.color, fontFamily: 'Georgia, serif' }}>
+                  {l.label}
+                </p>
+                <p className="text-sm" style={{ color: '#5E5E5E' }}>
+                  {l.text}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// CLAIM CEILING (P0, 2026-06-18): this section is the WHY (the reason a bed and a
+// washing machine are health hardware), never a claimed outcome. The "INTERRUPTED"
+// badges, the interrupted-step colouring, the "RHD Is Entirely Preventable" header
+// and the "beds interrupting floor sleeping / wash cycles breaking scabies chain"
+// labels were removed: each implied a prevented health outcome we cannot stand
+// behind. A health outcome only returns when a partner clinical method (Miwatj)
+// produces it, attributed to that partner.
 function HealthCascadeSection({ cascade }: { cascade: ImpactSnapshot['healthCascade'] }) {
   return (
     <section className="py-16 md:py-20" style={{ backgroundColor: '#2E2E2E' }}>
@@ -301,23 +431,24 @@ function HealthCascadeSection({ cascade }: { cascade: ImpactSnapshot['healthCasc
         <div className="max-w-3xl mx-auto">
           <div className="text-center mb-12">
             <p className="text-sm uppercase tracking-widest text-white/50 mb-4">
-              The Health Cascade
+              Why this is health hardware
             </p>
             <h2
               className="text-3xl font-light text-white mb-2"
               style={{ fontFamily: 'Georgia, serif' }}
             >
-              RHD Is Entirely Preventable
+              The pathway a bed and a washer sit in
             </h2>
             <p className="text-sm text-white/60">
-              Rheumatic Heart Disease kills children in remote Australia. This is the chain
-              we&apos;re breaking — and where our products intervene.
+              This is why we treat a bed and a washing machine as health hardware, not furniture.
+              Off-the-ground, washable sleep supports the conditions needed to interrupt the
+              scabies to rheumatic heart disease pathway. We do not claim a bed prevents heart
+              disease: that needs a partner clinical method.
             </p>
           </div>
 
           <div className="space-y-0">
             {cascade.steps.map((step, i) => {
-              const isInterrupted = step.interrupted;
               const isLast = i === cascade.steps.length - 1;
 
               return (
@@ -326,44 +457,21 @@ function HealthCascadeSection({ cascade }: { cascade: ImpactSnapshot['healthCasc
                   {!isLast && (
                     <div
                       className="absolute left-5 top-12 w-0.5 h-8"
-                      style={{
-                        backgroundColor: isInterrupted ? '#8B9D77' : '#C45C3E',
-                        opacity: isInterrupted ? 1 : 0.4,
-                      }}
+                      style={{ backgroundColor: '#C45C3E', opacity: 0.4 }}
                     />
                   )}
 
                   <div className="flex items-start gap-4 py-3">
-                    {/* Status indicator */}
+                    {/* Step indicator */}
                     <div
                       className="w-10 h-10 rounded-full flex items-center justify-center shrink-0 mt-0.5"
-                      style={{
-                        backgroundColor: isInterrupted ? '#8B9D77' : 'rgba(196, 92, 62, 0.3)',
-                      }}
+                      style={{ backgroundColor: 'rgba(196, 92, 62, 0.3)' }}
                     >
-                      {isInterrupted ? (
-                        <svg className="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                        </svg>
-                      ) : (
-                        <svg className="w-5 h-5 text-white/60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
-                        </svg>
-                      )}
+                      <span className="text-sm font-medium text-white/70">{i + 1}</span>
                     </div>
 
                     <div className="flex-1">
-                      <p className={`font-medium ${isInterrupted ? 'text-white' : 'text-white/70'}`}>
-                        {step.label}
-                        {isInterrupted && (
-                          <span
-                            className="ml-2 text-xs px-2 py-0.5 rounded-full"
-                            style={{ backgroundColor: '#8B9D77', color: 'white' }}
-                          >
-                            INTERRUPTED
-                          </span>
-                        )}
-                      </p>
+                      <p className="font-medium text-white/80">{step.label}</p>
                       <p className="text-sm text-white/50">{step.description}</p>
                       {step.liveMetric && (
                         <p className="text-sm mt-1" style={{ color: '#8B9D77' }}>
@@ -377,17 +485,17 @@ function HealthCascadeSection({ cascade }: { cascade: ImpactSnapshot['healthCasc
             })}
           </div>
 
-          {/* Summary stats */}
+          {/* Summary stats — counted activity, not a claimed health outcome */}
           <div className="grid grid-cols-3 gap-2 md:gap-4 mt-10 pt-6 border-t border-white/10">
             <div className="text-center">
               <p className="text-xl md:text-2xl font-light text-white">{cascade.bedsDelivered}</p>
-              <p className="text-[10px] md:text-xs text-white/50">Beds interrupting floor sleeping</p>
+              <p className="text-[10px] md:text-xs text-white/50">Beds delivered</p>
             </div>
             <div className="text-center">
               <p className="text-xl md:text-2xl font-light" style={{ color: '#8B9D77' }}>
                 {cascade.totalWashCycles.toLocaleString()}
               </p>
-              <p className="text-[10px] md:text-xs text-white/50">Wash cycles breaking scabies chain</p>
+              <p className="text-[10px] md:text-xs text-white/50">Wash cycles completed</p>
             </div>
             <div className="text-center">
               <p className="text-xl md:text-2xl font-light text-white">{cascade.machinesOnline}</p>
@@ -400,73 +508,11 @@ function HealthCascadeSection({ cascade }: { cascade: ImpactSnapshot['healthCasc
   );
 }
 
-function OptimizationSection({
-  opportunities,
-}: {
-  opportunities: ImpactSnapshot['optimizationOpportunities'];
-}) {
-  const potentialColors = { high: '#C45C3E', medium: '#D4A574', low: '#8B9D77' };
-
-  return (
-    <section className="py-16 md:py-20 bg-white">
-      <div className="container mx-auto px-4">
-        <div className="max-w-4xl mx-auto">
-          <div className="text-center mb-12">
-            <p className="text-sm uppercase tracking-widest mb-4" style={{ color: '#8B9D77' }}>
-              Data-Driven Insights
-            </p>
-            <h2
-              className="text-3xl font-light mb-2"
-              style={{ color: '#2E2E2E', fontFamily: 'Georgia, serif' }}
-            >
-              Optimization Opportunities
-            </h2>
-            <p className="text-sm" style={{ color: '#5E5E5E' }}>
-              Patterns identified from live data — where each improvement dollar has the most impact.
-            </p>
-          </div>
-
-          <div className="space-y-4">
-            {opportunities.slice(0, 6).map((opp) => (
-              <div
-                key={opp.id}
-                className="p-4 rounded-lg border"
-                style={{ borderColor: '#E8DED4', backgroundColor: '#FDF8F3' }}
-              >
-                <div className="flex items-start gap-3">
-                  <div
-                    className="w-2 h-2 rounded-full mt-2 shrink-0"
-                    style={{ backgroundColor: potentialColors[opp.potential] }}
-                  />
-                  <div className="flex-1">
-                    <p className="font-medium text-sm" style={{ color: '#2E2E2E' }}>
-                      {opp.title}
-                    </p>
-                    <p className="text-sm mt-1" style={{ color: '#5E5E5E' }}>
-                      {opp.description}
-                    </p>
-                    <p className="text-xs mt-2" style={{ color: '#8B9D77' }}>
-                      Source: {opp.dataSource}
-                    </p>
-                  </div>
-                  <span
-                    className="text-xs px-2 py-0.5 rounded-full shrink-0"
-                    style={{
-                      backgroundColor: `${potentialColors[opp.potential]}20`,
-                      color: potentialColors[opp.potential],
-                    }}
-                  >
-                    {opp.potential}
-                  </span>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
+// P4 (2026-06-18): the public "Optimization Opportunities" section was removed.
+// "Loss function / optimization / improvement dollar" is internal engineer framing,
+// not a community-outcome surface, and it competes with the five domains. The data
+// (snapshot.optimizationOpportunities) is still computed and exposed via /api/impact
+// for internal and agent use; it just no longer renders on the public page.
 
 function ProductionCostSection() {
   return (
@@ -475,18 +521,20 @@ function ProductionCostSection() {
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-12">
             <p className="text-sm uppercase tracking-widest mb-4" style={{ color: '#8B9D77' }}>
-              Work-Integrated Social Enterprise
+              The economics through-line
             </p>
             <h2
               className="text-3xl font-light mb-2"
               style={{ color: '#2E2E2E', fontFamily: 'Georgia, serif' }}
             >
-              Cost Per Bed &amp; Employment Impact
+              How the cost comes down
             </h2>
             <p className="text-sm" style={{ color: '#5E5E5E' }}>
-              Every bed creates roughly {MODELLED_LABOUR_HOURS_PER_BED.toFixed(1)} modelled hours of
-              employment for at-risk youth and community members. At 1,500 beds/year, that&apos;s
-              about {(1500 * MODELLED_LABOUR_HOURS_PER_BED).toLocaleString()} hours of employment.
+              The freight tax puts a basic good out of reach, so the bed is built to beat the true
+              remote cost, not the sticker price. As the making moves On Country and in-sources, the
+              direct cost per bed comes down and the value stays local. Every bed also creates roughly{' '}
+              {MODELLED_LABOUR_HOURS_PER_BED.toFixed(1)} modelled hours of employment; at 1,500 beds a
+              year that is about {(1500 * MODELLED_LABOUR_HOURS_PER_BED).toLocaleString()} hours of work.
             </p>
           </div>
 
@@ -592,7 +640,7 @@ function HowWeTrackSection() {
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-12">
             <p className="text-sm uppercase tracking-widest mb-4" style={{ color: '#8B9D77' }}>
-              Australian Living Map of Alternatives
+              Measurement &amp; accountability
             </p>
             <h2
               className="text-3xl font-light mb-2"
@@ -601,7 +649,7 @@ function HowWeTrackSection() {
               How We Measure
             </h2>
             <p className="text-sm" style={{ color: '#5E5E5E' }}>
-              Our learning and accountability lens for holding product data, community feedback, consent and practical change together.
+              How we hold product data, community feedback, consent and practical change together.
             </p>
           </div>
 
@@ -882,6 +930,80 @@ function PartnersSection() {
   );
 }
 
+// The single human spine (framework §6): "Mykel's arc is the model in one person:
+// waste, to product, to skill, to work, to ownership." Carries the jobs/ownership
+// and circular domains in one face, with his consent (Ben, 2026-06-18). As a young
+// person his material is handled with Oonchiumpa and guardian in the loop.
+function MykelFeatureSection() {
+  return (
+    <section className="py-16 md:py-24" style={{ backgroundColor: '#2E2E2E' }}>
+      <div className="container mx-auto px-4">
+        <div className="max-w-5xl mx-auto">
+          <div className="text-center mb-10">
+            <p className="text-sm uppercase tracking-widest text-white/50 mb-4">
+              The model in one person
+            </p>
+            <h2
+              className="text-3xl md:text-4xl font-light text-white mb-3"
+              style={{ fontFamily: 'Georgia, serif' }}
+            >
+              Mykel
+            </h2>
+            <p className="text-sm text-white/60 max-w-2xl mx-auto">
+              Waste to product to skill to work to ownership, in one person. Mykel built the bed he
+              slept on that night and kept going: seven beds by the end of the second day, out the
+              back of the Oonchiumpa office in Alice Springs.
+            </p>
+          </div>
+
+          <div className="grid gap-8 md:grid-cols-2 md:items-center">
+            <div className="aspect-video rounded-lg overflow-hidden bg-black/30">
+              <video
+                src="/video/partners/oonchiumpa/mykel-building-the-bed.mp4"
+                poster="/video/partners/oonchiumpa/mykel-building-the-bed-poster.jpg"
+                controls
+                preload="none"
+                className="w-full h-full object-cover"
+              />
+            </div>
+
+            <div>
+              <blockquote className="border-l-2 pl-4 mb-6" style={{ borderColor: '#C45C3E' }}>
+                <p
+                  className="text-2xl font-light text-white mb-2"
+                  style={{ fontFamily: 'Georgia, serif' }}
+                >
+                  &ldquo;I&rsquo;ll be rocking up every day to make them.&rdquo;
+                </p>
+                <p className="text-sm text-white/50">
+                  Mykel, asked whether he would make beds every day if the making moved closer to home
+                </p>
+              </blockquote>
+
+              <p className="text-sm text-white/70 mb-4">
+                He turned the finished bed over in his hands, then explained it was made from bottle
+                lids shredded and pressed into something strong enough to stand on. Fred, his
+                Oonchiumpa support worker, watched him work, called him grandson, and said: &ldquo;That
+                could be a good employment for yourself too, grandson. Later on.&rdquo;
+              </p>
+
+              <p className="text-sm italic text-white/60">
+                &ldquo;Comfortable as. Smooth, tight, hard, fancy.&rdquo;{' '}
+                <span className="not-italic text-white/40">Mykel, on the bed</span>
+              </p>
+
+              <p className="text-xs text-white/30 mt-6">
+                Shared with consent. Mykel is a young person; his material is handled with Oonchiumpa
+                and his guardian in the loop.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Main async component
 // ---------------------------------------------------------------------------
@@ -892,11 +1014,13 @@ async function ImpactDashboard() {
   return (
     <>
       <LossFunctionSection snapshot={snapshot} />
-      <FiveDimensionsSection dimensions={snapshot.dimensions} />
-      <HealthCascadeSection cascade={snapshot.healthCascade} />
+      <ThreeShiftsSection />
+      <FiveDomainsSection dimensions={snapshot.dimensions} />
+      <MykelFeatureSection />
+      <ThroughLinesSection />
       <ProductionCostSection />
+      <HealthCascadeSection cascade={snapshot.healthCascade} />
       <PartnersSection />
-      <OptimizationSection opportunities={snapshot.optimizationOpportunities} />
       <HowWeTrackSection />
     </>
   );
@@ -936,8 +1060,8 @@ export default function ImpactPage() {
               Impact Model
             </h1>
             <p className="text-lg max-w-2xl mx-auto mb-2" style={{ color: '#5E5E5E' }}>
-              Five dimensions of impact, tracked from our asset register, fleet
-              telemetry, and community voices.
+              Three shifts in one breath, five outcome domains underneath. Every claim pairs a
+              community voice with a counted number and an honest label.
             </p>
             <p className="text-sm max-w-xl mx-auto" style={{ color: '#8B9D77' }}>
               Numbers drawn from our asset register and fleet data. Every target is accountable.
@@ -980,10 +1104,10 @@ export default function ImpactPage() {
             className="text-3xl md:text-4xl font-light text-white mb-6"
             style={{ fontFamily: 'Georgia, serif' }}
           >
-            Be Part of This Impact
+            Back the work
           </h2>
           <p className="text-white/80 max-w-xl mx-auto mb-8">
-            Every bed purchased or sponsored adds to these numbers and changes a family&apos;s life.
+            Every bed is built On Country and counted here. Back the making, and follow where it goes.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Button size="lg" className="bg-white hover:bg-white/90" style={{ color: '#C45C3E' }} asChild>

--- a/v2/src/app/insights/page.tsx
+++ b/v2/src/app/insights/page.tsx
@@ -14,7 +14,7 @@ import type { Metadata } from 'next';
 export const metadata: Metadata = {
   title: 'Community Insights',
   description:
-    'Thematic analysis of community voices across health, dignity, community-led design, and basic needs.',
+    'Thematic analysis of community voices, mapped onto the five Goods on Country outcome domains: rest and health, dignity and safety, self-determination and community-led design, jobs and ownership, and circular and local economy.',
 };
 
 export default function InsightsPage() {
@@ -38,37 +38,52 @@ export default function InsightsPage() {
     .filter((c) => c.storytellerCount > 0)
     .sort((a, b) => b.storytellerCount - a.storytellerCount);
 
-  // Impact dimensions stats
-  const impactDimensions = [
+  // The five canonical outcome domains (single impact model). Each maps the quote
+  // THEMES that feed it (themes are the listening layer, not a rival pillar set).
+  // Two domains (jobs/ownership, circular/local economy) are thin or emerging in the
+  // current quote corpus, which is weighted to product, health, dignity and design;
+  // those voices (Mykel, Fred) are carried on /impact and /stories, not yet tagged
+  // as their own quote themes here. Shown honestly rather than padded.
+  const fiveDomains = [
     {
-      id: 'health',
-      title: 'Health',
-      value: themeCounts.health,
-      description: 'Voices connecting beds to health outcomes',
+      id: 'rest-health',
+      title: 'Rest & health',
+      themes: ['health', 'washing-machine', 'product-feedback'] as ThemeId[],
+      description: 'Off-the-ground, washable sleep as health hardware',
       color: 'red',
     },
     {
-      id: 'dignity',
-      title: 'Dignity',
-      value: themeCounts.dignity,
-      description: 'Voices about safety and self-worth',
+      id: 'dignity-safety',
+      title: 'Dignity & safety',
+      themes: ['dignity', 'community-need'] as ThemeId[],
+      description: 'A bed is safety and belonging. A need, not charity',
       color: 'purple',
     },
     {
-      id: 'co-design',
-      title: 'Community-Led Design',
-      value: themeCounts['co-design'],
-      description: 'Voices about community-led design and the solutions that come from it',
+      id: 'self-determination',
+      title: 'Self-determination & community-led design',
+      themes: ['co-design'] as ThemeId[],
+      description: 'Named, tested and owned in community',
       color: 'amber',
     },
     {
-      id: 'need',
-      title: 'Basic Needs',
-      value: themeCounts['community-need'] + themeCounts['freight-tax'],
-      description: 'Voices about essential access',
-      color: 'blue',
+      id: 'circular-economy',
+      title: 'Circular & local economy',
+      themes: ['freight-tax'] as ThemeId[],
+      description: 'Value and the making stay local',
+      color: 'teal',
     },
-  ];
+    {
+      id: 'jobs-ownership',
+      title: 'Jobs, On Country work & ownership',
+      themes: [] as ThemeId[],
+      description: 'Young people building the work, toward ownership',
+      color: 'green',
+    },
+  ].map((d) => ({
+    ...d,
+    value: d.themes.reduce((sum, t) => sum + (themeCounts[t] ?? 0), 0),
+  }));
 
   return (
     <main>
@@ -277,7 +292,7 @@ export default function InsightsPage() {
         </div>
       </section>
 
-      {/* Impact Dimensions */}
+      {/* The five domains */}
       <section className="py-16 md:py-20 bg-foreground text-background">
         <div className="container mx-auto px-4">
           <div className="text-center mb-12">
@@ -285,36 +300,40 @@ export default function InsightsPage() {
               className="text-3xl font-light mb-4"
               style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
             >
-              Impact Dimensions
+              The five domains
             </h2>
             <p className="text-background/60 max-w-xl mx-auto">
-              The four pillars of community feedback
+              How these themed voices map onto our five outcome domains. Jobs and ownership voices
+              (Mykel, Fred) are emerging in this quote set and are carried on the impact page.
             </p>
           </div>
 
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-5xl mx-auto">
-            {impactDimensions.map((dimension) => (
-              <div
-                key={dimension.id}
-                className="text-center p-6 rounded-lg bg-background/5 border border-background/10"
-              >
-                <p
-                  className={`text-4xl font-bold mb-2 ${
-                    dimension.color === 'red'
-                      ? 'text-red-400'
-                      : dimension.color === 'purple'
-                        ? 'text-purple-400'
-                        : dimension.color === 'amber'
-                          ? 'text-amber-400'
-                          : 'text-blue-400'
-                  }`}
+          <div className="grid sm:grid-cols-2 lg:grid-cols-5 gap-4 max-w-6xl mx-auto">
+            {fiveDomains.map((domain) => {
+              const colorClass =
+                {
+                  red: 'text-red-400',
+                  purple: 'text-purple-400',
+                  amber: 'text-amber-400',
+                  teal: 'text-teal-400',
+                  green: 'text-emerald-400',
+                }[domain.color] ?? 'text-blue-400';
+
+              return (
+                <div
+                  key={domain.id}
+                  className="text-center p-6 rounded-lg bg-background/5 border border-background/10"
                 >
-                  {dimension.value}
-                </p>
-                <p className="font-medium text-background mb-1">{dimension.title}</p>
-                <p className="text-xs text-background/50">{dimension.description}</p>
-              </div>
-            ))}
+                  <p className={`text-4xl font-bold mb-2 ${colorClass}`}>
+                    {domain.value > 0 ? domain.value : (
+                      <span className="text-xl font-light text-background/40">Emerging</span>
+                    )}
+                  </p>
+                  <p className="font-medium text-background mb-1 text-sm">{domain.title}</p>
+                  <p className="text-xs text-background/50">{domain.description}</p>
+                </div>
+              );
+            })}
           </div>
         </div>
       </section>

--- a/v2/src/components/marketing/theory-of-change.tsx
+++ b/v2/src/components/marketing/theory-of-change.tsx
@@ -12,18 +12,21 @@ const ALT =
   'face costly, short-lived goods; floor sleeping and dirty bedding feed the scabies to rheumatic ' +
   'heart disease pathway), through inputs and the community-led operating cycle (listen, design, ' +
   'make, deliver and track, learn, improve), to outputs (beds delivered, plastic diverted, wash ' +
-  'cycles, employment hours, consent-led stories, a QR-tracked register), to outcomes grouped by ' +
-  "QBE's two priorities: Inclusion (health, economic inclusion, community ownership) and Climate " +
-  'Resilience (environmental), each over short, medium and long horizons, leading to the impact of ' +
-  'healthier, self-determining communities with locally-owned manufacturing and a circular economy.';
+  'cycles, employment hours, consent-led stories, a QR-tracked register), to outcomes across the ' +
+  'five canonical domains (rest and health; dignity and safety; Indigenous self-determination and ' +
+  'community-led design; jobs, On Country work and the path to ownership; circular and local ' +
+  'economy), each anchored to a canon number. A stated claim ceiling notes that the scabies to ' +
+  'rheumatic heart disease pathway is the why and never a claimed outcome. These roll up to the ' +
+  'three shifts (material, economic, story) and to the impact of healthier, self-determining ' +
+  'communities with locally-owned production and a circular economy that keeps value on Country.';
 
 /**
  * The Goods theory of change diagram (results-chain logic model).
  *
  * Source of truth is scripts/generate_theory_of_change.py, which renders
  * /public/theory-of-change.svg; the .png (web) and .pdf (print) are produced from
- * it with rsvg-convert. Regenerate after editing the script. Companion document:
- * wiki/outputs/2026-05-29-goods-theory-of-change-and-mel.md.
+ * it with rsvg-convert. Regenerate after editing the script. Conforms to the
+ * canonical impact model: wiki/outputs/2026-06-18-goods-impact-framework.md.
  */
 export function TheoryOfChange({ className = '', caption = false }: TheoryOfChangeProps) {
   return (

--- a/v2/src/lib/data/impact-fetcher.ts
+++ b/v2/src/lib/data/impact-fetcher.ts
@@ -24,21 +24,12 @@ import { PLASTIC_KG_PER_BED } from './products';
 /** Average household size used to convert beds → people reached. MODELLED. */
 const AVG_HOUSEHOLD_SIZE = 2.5;
 
-/** Nights per year, for sleep-nights provided. */
-const NIGHTS_PER_YEAR = 365;
-
-/**
- * Cost to the health system per surgical RHD admission, used for the MODELLED
- * government-savings estimate. Source: END RHD 2018 (~$70K per surgical
- * admission). NOTE: this is NOT the older $250K figure (the impact-model
- * sourceDetail explicitly flags $250K as wrong). Reconciled to
- * impact-model.ts `govt-savings` metric sourceDetail. MODELLED, not measured.
- */
-const RHD_SURGICAL_ADMISSION_COST_AUD = 70_000;
-
-/** MODELLED incidence assumptions for the conservative govt-savings estimate. */
-const BEDS_PER_RHD_CASE_PREVENTED = 500; // 1 RHD case prevented per ~500 beds (× household)
-const WASH_CYCLES_PER_RHD_CASE_PREVENTED = 5_000;
+// CLAIM CEILING (P0, 2026-06-18): removed NIGHTS_PER_YEAR (sleep-nights health
+// proxy), RHD_SURGICAL_ADMISSION_COST_AUD, BEDS_PER_RHD_CASE_PREVENTED and
+// WASH_CYCLES_PER_RHD_CASE_PREVENTED. These drove the "sleep-nights" and
+// "govt-savings" metrics, both claimed health outcomes (modelled cases prevented /
+// government savings) that the claim ceiling forbids. A health outcome only returns
+// when a partner clinical method (Miwatj) produces it, attributed to that partner.
 
 /**
  * Washing machines: 16 in community is the canonical, Ben-confirmed figure
@@ -194,9 +185,11 @@ async function getStorytellerStats(): Promise<StorytellerStats> {
 // Compute derived metrics
 // ---------------------------------------------------------------------------
 
-function computeSleepNights(beds: number): number {
-  return Math.round(beds * AVG_HOUSEHOLD_SIZE * NIGHTS_PER_YEAR);
-}
+// CLAIM CEILING (P0, 2026-06-18): computeSleepNights and computeGovtSavings were
+// removed. Both produced claimed health outcomes (sleep-nights as a health proxy;
+// government savings from modelled "RHD cases prevented") that the claim ceiling
+// forbids. They only return when a partner clinical method (Miwatj) produces the
+// figure, attributed to that partner.
 
 /** Plastic diverted (kg). STRETCH beds only — recycled HDPE. Basket Beds are not a plastic product. */
 function computePlasticDiverted(stretchBeds: number): number {
@@ -207,25 +200,8 @@ function computeEmploymentHours(beds: number): number {
   return Math.round(beds * MODELLED_LABOUR_HOURS_PER_BED);
 }
 
-function computeGovtSavings(beds: number, washCycles: number): number {
-  // MODELLED, conservative — not measured. Needs a health-evidence partner
-  // before external use. Uses ~$70K per surgical RHD admission (END RHD 2018),
-  // NOT the discredited $250K figure.
-  // - Each bed serves ~AVG_HOUSEHOLD_SIZE people
-  // - Clean bedding reduces scabies risk → reduces RHD
-  // - Estimate: 1 RHD case prevented per ~500 beds (× household)
-  const rhdCasesPrevented = (beds * AVG_HOUSEHOLD_SIZE) / BEDS_PER_RHD_CASE_PREVENTED;
-  const savingsFromBeds = rhdCasesPrevented * RHD_SURGICAL_ADMISSION_COST_AUD;
-
-  // Wash cycles prevent skin infections; ~1 RHD case prevented per 5000 cycles
-  const rhdFromWashing = washCycles / WASH_CYCLES_PER_RHD_CASE_PREVENTED;
-  const savingsFromWashing = rhdFromWashing * RHD_SURGICAL_ADMISSION_COST_AUD;
-
-  return Math.round(savingsFromBeds + savingsFromWashing);
-}
-
 // ---------------------------------------------------------------------------
-// Build health cascade data
+// Build health cascade data (the WHY, not a claimed outcome)
 // ---------------------------------------------------------------------------
 
 function buildHealthCascade(
@@ -233,42 +209,34 @@ function buildHealthCascade(
   washCycles: number,
   machinesOnline: number,
 ): HealthCascadeData {
+  // CLAIM CEILING (P0, 2026-06-18): the steps describe the pathway as our WHY (the
+  // reason a bed and a washer are health hardware). No step is badged "interrupted"
+  // and no prevented outcome is claimed. Wash cycles are shown as counted activity.
   return {
     totalWashCycles: washCycles,
     machinesOnline,
     bedsDelivered: beds,
-    sleepNightsProvided: computeSleepNights(beds),
     steps: [
       {
-        label: 'No washing machine',
-        description: 'Families can\'t clean bedding regularly',
-        interrupted: machinesOnline > 0,
+        label: 'Washing bedding regularly is hard',
+        description: 'Without a working washing machine, families struggle to clean bedding and clothes',
         liveMetric: { value: washCycles, unit: 'wash cycles completed' },
       },
       {
-        label: 'Dirty bedding',
+        label: 'Bedding stays dirty',
         description: 'Unwashed sheets and blankets harbour scabies mites',
-        interrupted: washCycles > 0,
       },
       {
         label: 'Scabies infection',
         description: '1 in 3 children in remote communities have scabies at any time',
-        interrupted: false,
       },
       {
         label: 'Group A Streptococcus',
         description: 'Scabies sores become infected with Strep A bacteria',
-        interrupted: false,
       },
       {
-        label: 'Rheumatic Heart Disease',
-        description: 'Repeated Strep A infections trigger autoimmune heart damage',
-        interrupted: false,
-      },
-      {
-        label: 'Heart failure & death',
-        description: 'RHD is entirely preventable — yet children are dying from it',
-        interrupted: false,
+        label: 'Rheumatic fever and rheumatic heart disease',
+        description: 'Repeated Strep A infections can trigger autoimmune heart damage',
       },
     ],
   };
@@ -326,15 +294,15 @@ function populateDimensions(
   fleetStats: FleetStats,
   storytellerStats: StorytellerStats,
 ): ImpactDimension[] {
+  // CLAIM CEILING (P0, 2026-06-18): 'sleep-nights' and 'govt-savings' removed (the
+  // metrics themselves were removed from impact-model.ts as claimed health outcomes).
   const liveValues: Record<string, number> = {
     'beds-delivered': assetStats.totalBeds,
-    'sleep-nights': computeSleepNights(assetStats.totalBeds),
     'wash-cycles': fleetStats.totalWashCycles,
     'plastic-diverted': computePlasticDiverted(assetStats.stretchBedsDeployed),
     'employment-hours': computeEmploymentHours(assetStats.totalBeds),
     'storytellers-active': storytellerStats.storytellerCount,
     'communities-served': assetStats.communitiesServed,
-    'govt-savings': computeGovtSavings(assetStats.totalBeds, fleetStats.totalWashCycles),
   };
 
   return dimensions.map((dim) => ({

--- a/v2/src/lib/data/impact-model.ts
+++ b/v2/src/lib/data/impact-model.ts
@@ -77,15 +77,18 @@ export interface OptimizationOpportunity {
   dataSource: string;
 }
 
+// CLAIM CEILING (P0, 2026-06-18): the scabies to RHD pathway is our WHY, never a
+// claimed outcome. The cascade now explains the pathway as rationale (why a bed and
+// a washer are health hardware). The `interrupted` flag and `sleepNightsProvided`
+// proxy were removed: badging a step "INTERRUPTED" claims a prevented health
+// outcome we cannot stand behind.
 export interface HealthCascadeData {
   totalWashCycles: number;
   machinesOnline: number;
   bedsDelivered: number;
-  sleepNightsProvided: number; // beds × avg household × days since delivery
   steps: {
     label: string;
     description: string;
-    interrupted: boolean;
     liveMetric?: { value: number; unit: string };
   }[];
 }
@@ -222,24 +225,44 @@ export const CANONICAL_BUILD_PATHS = _marginGrid;
 export const CANONICAL_FULLY_LOADED_GRID = getFullyLoadedGrid();
 
 // ---------------------------------------------------------------------------
-// 5 Impact Dimensions
+// The five outcome domains (canonical backbone)
 // ---------------------------------------------------------------------------
+//
+// P4 (2026-06-18): these are THE five outcome domains from the canonical impact
+// model (wiki/outputs/2026-06-18-goods-impact-framework.md §3). They supersede the
+// earlier five "dimensions" (Health / Environmental / Economic / Community
+// Ownership / Production Efficiency), which mixed an internal-ops axis (production
+// efficiency) and a through-line (economic) in with the community-outcome domains.
+//
+// Each domain pairs a cleared community VOICE with a canon NUMBER and an honest
+// LABEL (the spine). Voices are verbatim from curated-quotes.ts and every author is
+// on the cleared-for-external list (see cleared-voices.ts). The economics story and
+// Indigenous sovereignty are TWO THROUGH-LINES that run across all five domains
+// (§6), not separate domains; the page carries them as their own band. Production
+// efficiency is internal ops, relocated to PRODUCTION_EFFICIENCY_METRICS below and
+// not rendered as a public outcome domain.
+//
+// Metric IDs are STABLE: impact-fetcher.ts binds live values by metric id, not by
+// domain, so re-bucketing metrics across domains does not break the live fetch.
 
 export const IMPACT_DIMENSIONS: ImpactDimension[] = [
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  // 1. HEALTH & WELLBEING
+  // 1. REST & HEALTH (the core why)
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   {
-    id: 'health',
-    name: 'Health & Wellbeing',
-    description: 'Beds and washing machines as health hardware, interrupting the scabies → Strep A → RHD cascade',
+    id: 'rest-health',
+    name: 'Rest & health',
+    // CLAIM CEILING (P0, 2026-06-18): the scabies to RHD pathway is our WHY, never a
+    // claimed outcome. This describes why a bed and a washer are health hardware; it
+    // does not claim a bed prevents or interrupts heart disease.
+    description: 'Off-the-ground, washable sleep that supports the conditions needed to interrupt the scabies to rheumatic heart disease pathway. This is why a bed and a washing machine are health hardware, not furniture.',
     icon: 'heart',
     color: '#C45C3E',
-    primaryMetricId: 'sleep-nights',
+    primaryMetricId: 'beds-delivered',
     communityQuote: {
-      text: 'Scabies often leads to Rheumatic Heart Disease, so washing machines are essential to be able to clean infected clothing, bedding and towels.',
-      author: 'Jessica Allardyce',
-      context: 'Miwatj Health, Gapuwiyak',
+      text: 'Back pain and all that. You\'re gonna be moving around with problems. That\'s why good beds matter.',
+      author: 'Brian Russell',
+      context: 'Tennant Creek',
     },
     metrics: [
       {
@@ -251,23 +274,14 @@ export const IMPACT_DIMENSIONS: ImpactDimension[] = [
         targets: { year1: 1500, year3: 5000, vision2030: 25000 },
         source: 'supabase',
         sourceDetail: 'assets table: count where product ilike %bed%',
-        proxyFor: 'Households with proper sleeping infrastructure',
+        proxyFor: 'Households with off-the-ground, washable sleeping infrastructure',
         optimizationLevers: ['Production capacity', 'Freight partnerships', 'Community demand pipeline'],
         computeFn: 'getBedsDelivered',
       },
-      {
-        id: 'sleep-nights',
-        confidence: 'modelled',
-        name: 'Sleep Nights Provided',
-        unit: 'nights',
-        current: null,
-        targets: { year1: 1_368_750, year3: 4_562_500, vision2030: 22_812_500 },
-        source: 'computed',
-        sourceDetail: 'beds × 2.5 people × 365 nights',
-        proxyFor: 'Improved health outcomes from proper rest',
-        optimizationLevers: ['More beds delivered', 'Product longevity'],
-        computeFn: 'computeSleepNights',
-      },
+      // CLAIM CEILING (P0, 2026-06-18): the "sleep-nights" metric was removed here.
+      // It was a modelled health proxy ("Improved health outcomes from proper rest")
+      // presented as an outcome, which the claim ceiling forbids. A health outcome
+      // only returns when a partner clinical method (Miwatj) produces it, attributed.
       {
         id: 'wash-cycles',
         confidence: 'verified',
@@ -277,7 +291,9 @@ export const IMPACT_DIMENSIONS: ImpactDimension[] = [
         targets: { year1: 15000, year3: 60000, vision2030: 500000 },
         source: 'supabase',
         sourceDetail: 'usage_logs table: count where event_type = cycle_complete',
-        proxyFor: 'Scabies/RHD prevention through clean bedding',
+        // Counted activity, not a claimed health outcome. Clean washing is part of
+        // why a washer is health hardware; we do not claim it prevents RHD.
+        proxyFor: 'Washable bedding kept clean (the conditions the scabies pathway depends on)',
         optimizationLevers: ['Machine uptime', 'Community adoption', 'Fleet expansion'],
         computeFn: 'getWashCycles',
       },
@@ -290,26 +306,174 @@ export const IMPACT_DIMENSIONS: ImpactDimension[] = [
         targets: { year1: 90, year3: 92, vision2030: 95 },
         source: 'manual',
         sourceDetail: 'Check-in system: % of assets still in use at 12 months',
-        proxyFor: 'Long-term health benefit durability',
+        proxyFor: 'Long-term durability of the health hardware',
         optimizationLevers: ['Material quality', 'Design iteration', 'Repair network'],
       },
     ],
   },
 
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  // 2. ENVIRONMENTAL
+  // 2. DIGNITY & SAFETY
   // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   {
-    id: 'environmental',
-    name: 'Environmental',
-    description: 'Turning community plastic waste into health infrastructure: circular economy at community scale',
+    id: 'dignity-safety',
+    name: 'Dignity & safety',
+    description: 'A bed is safety and belonging, and the freight tax is why a basic good is out of reach. A need, not charity.',
+    icon: 'home',
+    color: '#D4A574',
+    primaryMetricId: 'communities-served',
+    communityQuote: {
+      text: 'Hardly any people around the community have got beds. When they got family members over, there\'s not enough for everyone.',
+      author: 'Ivy',
+      context: 'Palm Island',
+    },
+    metrics: [
+      {
+        id: 'communities-served',
+        confidence: 'verified',
+        name: 'Communities Served',
+        unit: 'communities',
+        current: null,
+        targets: { year1: 12, year3: 25, vision2030: 60 },
+        source: 'supabase',
+        sourceDetail: 'assets table: distinct community values where status in (deployed, allocated). Canonical: 9 communities served (deployed); ~10 distinct incl. allocated/placeholder (2026-05-30).',
+        optimizationLevers: ['Distribution partnerships', 'Freight networks', 'Health org partnerships'],
+        computeFn: 'getCommunitiesServed',
+      },
+    ],
+  },
+
+  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  // 3. INDIGENOUS SELF-DETERMINATION & COMMUNITY-LED DESIGN
+  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  {
+    id: 'self-determination',
+    name: 'Self-determination & community-led design',
+    description: 'Designed in community, with the people who will use it, and owned by them. "Never been asked" becomes "named it, tested it, built what they asked for." Self-determination runs from the design through to who holds the data.',
+    icon: 'users',
+    color: '#7C6F64',
+    primaryMetricId: 'storytellers-active',
+    communityQuote: {
+      text: 'We\'ve never been asked what sort of house we\'d like to live in.',
+      author: 'Linda Turner',
+      context: 'Tennant Creek',
+    },
+    metrics: [
+      {
+        id: 'storytellers-active',
+        confidence: 'verified',
+        name: 'Active Storytellers',
+        unit: 'people',
+        current: null,
+        targets: { year1: 50, year3: 100, vision2030: 300 },
+        source: 'empathy-ledger',
+        sourceDetail: 'Empathy Ledger: storyteller count for goods-on-country project',
+        proxyFor: 'Community engagement depth and voice representation',
+        optimizationLevers: ['Community visits', 'Story gathering events', 'Elder engagement'],
+        computeFn: 'getStorytellerCount',
+      },
+      {
+        id: 'community-production-days',
+        confidence: 'verified',
+        name: 'Community Production Days/Week',
+        unit: 'days/week',
+        current: 0,
+        targets: { year1: 1, year3: 2, vision2030: 3 },
+        source: 'manual',
+        sourceDetail: 'Days per week community operates production without ACT presence',
+        proxyFor: 'Self-determination in manufacturing',
+        optimizationLevers: ['Training programs', 'Documentation', 'Leadership development'],
+      },
+    ],
+  },
+
+  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  // 4. JOBS, ON COUNTRY WORK & THE PATH TO OWNERSHIP (WISE model)
+  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  {
+    id: 'jobs-ownership',
+    name: 'Jobs, On Country work & ownership',
+    description: 'The making moves On Country. Real jobs are created where the plastic, the people and the need are. Young people build the product and, over time, hold the work and the ownership. Jobs and ownership are labelled future or target, never as achieved.',
+    icon: 'briefcase',
+    color: '#5E7D9A',
+    primaryMetricId: 'employment-hours',
+    communityQuote: {
+      text: 'He couldn\'t stop thanking me. The smile on his face all the way back home. He got out showing his family the bag, and he\'s walking around everywhere with those shoes on, running everywhere.',
+      author: 'Fred Campbell',
+      context: 'Xavier, after his first paid build (Oonchiumpa, Alice Springs)',
+    },
+    metrics: [
+      {
+        id: 'employment-hours',
+        confidence: 'modelled',
+        name: 'Employment Hours Created',
+        unit: 'hours',
+        current: null,
+        targets: { year1: 9750, year3: 32500, vision2030: 162500 },
+        source: 'computed',
+        sourceDetail: `MODELLED: ${MODELLED_LABOUR_HOURS_PER_BED.toFixed(1)} labour hours per bed × beds produced`,
+        proxyFor: 'Economic inclusion for at-risk youth and community members',
+        optimizationLevers: ['Production volume', 'Training programs', 'Community facility hosting'],
+        computeFn: 'computeEmploymentHours',
+      },
+      {
+        id: 'fte-jobs',
+        confidence: 'verified',
+        name: 'FTE Jobs',
+        unit: 'FTE',
+        current: 2,
+        targets: { year1: 6, year3: 18, vision2030: 50 },
+        source: 'manual',
+        sourceDetail: 'Direct employment at production facilities',
+        proxyFor: 'Sustainable community employment',
+        optimizationLevers: ['Facility count', 'Production volume', 'Product range expansion'],
+      },
+      {
+        id: 'community-employment-pct',
+        confidence: 'estimate',
+        name: 'Community Member Employment %',
+        unit: '%',
+        current: 30,
+        targets: { year1: 50, year3: 70, vision2030: 90 },
+        source: 'manual',
+        sourceDetail: 'Percentage of production workforce from local community',
+        proxyFor: 'Local economic benefit and ownership pathway',
+        optimizationLevers: ['Training investment', 'Partner org employment programs', 'Youth pathways'],
+      },
+      {
+        id: 'revenue',
+        confidence: 'verified',
+        name: 'Total Revenue Received (cumulative since inception, ~89% grant-funded)',
+        unit: '$',
+        current: verifiedFinancials.revenueReceived, // 741,111 — total received since inception (grant + commercial), restated 2026-06-03 live-Xero reconcile
+        targets: { year1: 1_100_000, year3: 4_000_000, vision2030: 15_000_000 }, // Year-1 TOTAL-revenue target across all 7 segments (not commercial-only)
+        source: 'xero',
+        sourceDetail:
+          'Xero workpaper (verified, not audited): TOTAL revenue received since inception (2023-07-01 → 2026-04-30), ~89% grant-funded (Snow + Centrecorp + VFFF + QIC) and ~11% commercial. This is NOT annual commercial traction — FY26 YTD commercial-only is ~$61K. The target is the Year-1 TOTAL-revenue target across all 7 segments (donor-institutional through adjacent), not a commercial-only target. Do not read cumulative grant-heavy revenue as recurring commercial run-rate.',
+        optimizationLevers: ['B2B pipeline', 'Government procurement', 'E-commerce launch'],
+      },
+      // CLAIM CEILING (P0, 2026-06-18): the "govt-savings" metric (modelled government
+      // health savings from "cases prevented") was removed. A government-savings
+      // dollar figure presented as an outcome is forbidden by the claim ceiling: it
+      // implies a prevented health outcome we cannot stand behind. It only returns
+      // when a partner clinical/evaluation method (Miwatj) produces it, attributed.
+    ],
+  },
+
+  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  // 5. CIRCULAR & LOCAL ECONOMY
+  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  {
+    id: 'circular-economy',
+    name: 'Circular & local economy',
+    description: 'Plastic becomes beds On Country. Value and capability stay local instead of leaving the community: a local enterprise that, over time, funds itself rather than the grant cycle.',
     icon: 'leaf',
     color: '#8B9D77',
     primaryMetricId: 'plastic-diverted',
     communityQuote: {
-      text: 'We don\'t need fancy solutions. We need beds that don\'t break, washing machines that can be fixed here, and people who actually listen.',
-      author: 'Community voice',
-      context: 'Palm Island',
+      text: 'You have to bring them on the barge. You can\'t just take them on the boat. You have to pay for freight. It all adds up.',
+      author: 'Alfred Johnson',
+      context: 'Palm Island, on why local manufacturing matters',
     },
     metrics: [
       {
@@ -349,50 +513,6 @@ export const IMPACT_DIMENSIONS: ImpactDimension[] = [
         proxyFor: 'Community-driven circular economy',
         optimizationLevers: ['Community collection programs', 'Shredder deployment', 'Plastic sorting training'],
       },
-    ],
-  },
-
-  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  // 3. ECONOMIC (includes WISE model from Eloise meeting)
-  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  {
-    id: 'economic',
-    name: 'Economic',
-    description: 'Work-Integrated Social Enterprise (WISE): impact through employing people typically outside the job market',
-    icon: 'briefcase',
-    color: '#D4A574',
-    primaryMetricId: 'employment-hours',
-    communityQuote: {
-      text: 'We\'re setting this up for our kids and grandkids... independence, being in charge of your own destiny.',
-      author: 'Linda Turner',
-      context: 'Tennant Creek',
-    },
-    metrics: [
-      {
-        id: 'employment-hours',
-        confidence: 'modelled',
-        name: 'Employment Hours Created',
-        unit: 'hours',
-        current: null,
-        targets: { year1: 9750, year3: 32500, vision2030: 162500 },
-        source: 'computed',
-        sourceDetail: `MODELLED: ${MODELLED_LABOUR_HOURS_PER_BED.toFixed(1)} labour hours per bed × beds produced`,
-        proxyFor: 'Economic inclusion for at-risk youth and community members',
-        optimizationLevers: ['Production volume', 'Training programs', 'Community facility hosting'],
-        computeFn: 'computeEmploymentHours',
-      },
-      {
-        id: 'fte-jobs',
-        confidence: 'verified',
-        name: 'FTE Jobs',
-        unit: 'FTE',
-        current: 2,
-        targets: { year1: 6, year3: 18, vision2030: 50 },
-        source: 'manual',
-        sourceDetail: 'Direct employment at production facilities',
-        proxyFor: 'Sustainable community employment',
-        optimizationLevers: ['Facility count', 'Production volume', 'Product range expansion'],
-      },
       {
         id: 'cost-per-unit',
         confidence: 'modelled',
@@ -402,162 +522,67 @@ export const IMPACT_DIMENSIONS: ImpactDimension[] = [
         targets: { year1: 275, year3: 200, vision2030: 271 }, // Factory path: 275.74 → ~200 → Community v6 path: 270.74 (fair-wage paid labour)
         source: 'computed',
         sourceDetail: 'MODELLED: current is the Defy Buy-Kit direct cost ($534.79 — what we make a bed for today) from cost-model-scenarios.ts. The trajectory is cost-DOWN as production in-sources to the on-country Factory path (direct $275.74), then scales toward the Community path ($270.74, v6 — fair-wage paid labour at $130/bed, free community-collected plastic). Direct cost only — excludes fixed-cost absorption at pilot volume.',
-        proxyFor: 'Operational efficiency and affordability',
+        proxyFor: 'Cost-down that keeps value local (the economics through-line)',
         optimizationLevers: ['Move from Defy-kit to on-country factory path', 'CNC time reduction', 'Local feedstock + bulk materials'],
       },
-      {
-        id: 'revenue',
-        confidence: 'verified',
-        name: 'Total Revenue Received (cumulative since inception, ~89% grant-funded)',
-        unit: '$',
-        current: verifiedFinancials.revenueReceived, // 741,111 — total received since inception (grant + commercial), restated 2026-06-03 live-Xero reconcile
-        targets: { year1: 1_100_000, year3: 4_000_000, vision2030: 15_000_000 }, // Year-1 TOTAL-revenue target across all 7 segments (not commercial-only)
-        source: 'xero',
-        sourceDetail:
-          'Xero workpaper (verified, not audited): TOTAL revenue received since inception (2023-07-01 → 2026-04-30), ~89% grant-funded (Snow + Centrecorp + VFFF + QIC) and ~11% commercial. This is NOT annual commercial traction — FY26 YTD commercial-only is ~$61K. The target is the Year-1 TOTAL-revenue target across all 7 segments (donor-institutional through adjacent), not a commercial-only target. Do not read cumulative grant-heavy revenue as recurring commercial run-rate.',
-        optimizationLevers: ['B2B pipeline', 'Government procurement', 'E-commerce launch'],
-      },
-      {
-        id: 'govt-savings',
-        confidence: 'modelled',
-        name: 'Government Health Savings (est.)',
-        unit: '$',
-        current: null,
-        targets: { year1: 2_000_000, year3: 10_000_000, vision2030: 50_000_000 },
-        source: 'computed',
-        sourceDetail: 'MODELLED, not measured: ~$70K per surgical RHD admission (END RHD 2018; NOT $250K) × estimated cases prevented. Needs a health-evidence partner before external use.',
-        proxyFor: 'Healthcare system cost reduction from preventive health hardware',
-        optimizationLevers: ['Bed and washer deployment', 'Evidence gathering for health impact'],
-        computeFn: 'computeGovtSavings',
-      },
     ],
   },
+];
 
-  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  // 4. COMMUNITY OWNERSHIP
-  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// ---------------------------------------------------------------------------
+// Production-efficiency metrics (internal ops, NOT a public outcome domain)
+// ---------------------------------------------------------------------------
+//
+// P4 (2026-06-18): these were the old "Production Efficiency" dimension. They are
+// internal operating metrics (the cost-down machinery behind the economics
+// through-line), not a community-outcome domain, so they no longer render as one of
+// the five domains on /impact. Kept here, exported, for internal/admin views and so
+// the data is not lost. None are populated live by impact-fetcher.ts.
+export const PRODUCTION_EFFICIENCY_METRICS: ImpactMetric[] = [
   {
-    id: 'community-ownership',
-    name: 'Community Ownership',
-    description: 'Transfer manufacturing to community-controlled enterprise. Our job is to become unnecessary',
-    icon: 'users',
-    color: '#7C6F64',
-    primaryMetricId: 'storytellers-active',
-    communityQuote: {
-      text: 'Working both ways, cultural side in white society and Indigenous society.',
-      author: 'Dianne Stokes',
-      context: 'Elder, Tennant Creek',
-    },
-    metrics: [
-      {
-        id: 'storytellers-active',
-        confidence: 'verified',
-        name: 'Active Storytellers',
-        unit: 'people',
-        current: null,
-        targets: { year1: 50, year3: 100, vision2030: 300 },
-        source: 'empathy-ledger',
-        sourceDetail: 'Empathy Ledger: storyteller count for goods-on-country project',
-        proxyFor: 'Community engagement depth and voice representation',
-        optimizationLevers: ['Community visits', 'Story gathering events', 'Elder engagement'],
-        computeFn: 'getStorytellerCount',
-      },
-      {
-        id: 'community-production-days',
-        confidence: 'verified',
-        name: 'Community Production Days/Week',
-        unit: 'days/week',
-        current: 0,
-        targets: { year1: 1, year3: 2, vision2030: 3 },
-        source: 'manual',
-        sourceDetail: 'Days per week community operates production without ACT presence',
-        proxyFor: 'Self-determination in manufacturing',
-        optimizationLevers: ['Training programs', 'Documentation', 'Leadership development'],
-      },
-      {
-        id: 'community-employment-pct',
-        confidence: 'estimate',
-        name: 'Community Member Employment %',
-        unit: '%',
-        current: 30,
-        targets: { year1: 50, year3: 70, vision2030: 90 },
-        source: 'manual',
-        sourceDetail: 'Percentage of production workforce from local community',
-        proxyFor: 'Local economic benefit and ownership pathway',
-        optimizationLevers: ['Training investment', 'Partner org employment programs', 'Youth pathways'],
-      },
-      {
-        id: 'communities-served',
-        confidence: 'verified',
-        name: 'Communities Served',
-        unit: 'communities',
-        current: null,
-        targets: { year1: 12, year3: 25, vision2030: 60 },
-        source: 'supabase',
-        sourceDetail: 'assets table: distinct community values where status in (deployed, allocated). Canonical: 9 communities served (deployed); ~10 distinct incl. allocated/placeholder (2026-05-30).',
-        optimizationLevers: ['Distribution partnerships', 'Freight networks', 'Health org partnerships'],
-        computeFn: 'getCommunitiesServed',
-      },
-    ],
+    id: 'units-per-month',
+    confidence: 'estimate',
+    name: 'Units Produced per Month',
+    unit: 'beds/month',
+    current: 15, // estimate during active production runs
+    targets: { year1: 125, year3: 417, vision2030: 1000 },
+    source: 'manual',
+    sourceDetail: 'Production logs: monthly output',
+    optimizationLevers: ['Facility utilisation', 'Second shift', 'Additional facilities'],
   },
-
-  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-  // 5. PRODUCTION EFFICIENCY
-  // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   {
-    id: 'production',
-    name: 'Production Efficiency',
-    description: 'Optimising the path from community plastic waste to deployed health hardware',
-    icon: 'factory',
-    color: '#5E7D9A',
-    primaryMetricId: 'units-per-month',
-    metrics: [
-      {
-        id: 'units-per-month',
-        confidence: 'estimate',
-        name: 'Units Produced per Month',
-        unit: 'beds/month',
-        current: 15, // estimate during active production runs
-        targets: { year1: 125, year3: 417, vision2030: 1000 },
-        source: 'manual',
-        sourceDetail: 'Production logs: monthly output',
-        optimizationLevers: ['Facility utilisation', 'Second shift', 'Additional facilities'],
-      },
-      {
-        id: 'cnc-time',
-        confidence: 'verified',
-        name: 'CNC Cutting Time per Bed',
-        unit: 'hours',
-        current: 3.5,
-        targets: { year1: 3.0, year3: 2.0, vision2030: 1.0 },
-        source: 'manual',
-        sourceDetail: 'Measured at production facility. Largest single time cost',
-        proxyFor: 'Production bottleneck efficiency',
-        optimizationLevers: ['Toolpath optimisation', 'Better tooling', 'Multi-head router'],
-      },
-      {
-        id: 'facility-count',
-        confidence: 'verified',
-        name: 'Production Facilities',
-        unit: 'facilities',
-        current: 1,
-        targets: { year1: 1, year3: 3, vision2030: 8 },
-        source: 'manual',
-        sourceDetail: 'Containerised production units deployed',
-        optimizationLevers: ['Funding for new containers', 'Community hosting agreements'],
-      },
-      {
-        id: 'facility-utilisation',
-        confidence: 'estimate',
-        name: 'Facility Utilisation',
-        unit: '%',
-        current: 30, // intermittent production runs
-        targets: { year1: 60, year3: 75, vision2030: 85 },
-        source: 'manual',
-        sourceDetail: 'Percentage of available production time used',
-        optimizationLevers: ['Demand pipeline', 'Circuit production model', 'Inventory build'],
-      },
-    ],
+    id: 'cnc-time',
+    confidence: 'verified',
+    name: 'CNC Cutting Time per Bed',
+    unit: 'hours',
+    current: 3.5,
+    targets: { year1: 3.0, year3: 2.0, vision2030: 1.0 },
+    source: 'manual',
+    sourceDetail: 'Measured at production facility. Largest single time cost',
+    proxyFor: 'Production bottleneck efficiency',
+    optimizationLevers: ['Toolpath optimisation', 'Better tooling', 'Multi-head router'],
+  },
+  {
+    id: 'facility-count',
+    confidence: 'verified',
+    name: 'Production Facilities',
+    unit: 'facilities',
+    current: 1,
+    targets: { year1: 1, year3: 3, vision2030: 8 },
+    source: 'manual',
+    sourceDetail: 'Containerised production units deployed',
+    optimizationLevers: ['Funding for new containers', 'Community hosting agreements'],
+  },
+  {
+    id: 'facility-utilisation',
+    confidence: 'estimate',
+    name: 'Facility Utilisation',
+    unit: '%',
+    current: 30, // intermittent production runs
+    targets: { year1: 60, year3: 75, vision2030: 85 },
+    source: 'manual',
+    sourceDetail: 'Percentage of available production time used',
+    optimizationLevers: ['Demand pipeline', 'Circuit production model', 'Inventory build'],
   },
 ];
 


### PR DESCRIPTION
Ships the P4 canonical-impact-model redesign from the design branch to prod, reviewed on preview first.

## What changes
- **`/impact`** restructured to the canonical model: three shifts → five outcome domains (each pairing a community voice + counted number + honest label) → the scabies→RHD pathway as the *why* → cost model → measurement.
- **`/insights`** restructured to the five domains (themes mapped onto them; "Jobs & ownership: Emerging").
- **Hero stat band fixed to canon** — was fed by raw `impact-fetcher` counts (`totalAssets` 524 vs canon 496) and carried a **"Lives Impacted"** metric (a claimed outcome). Now pinned to `asset-canonical.ts` (496 beds / 16 washing machines / 2,660kg / 9 communities) + modelled employment hours from canon beds + total invested; **"Lives Impacted" dropped** per the claim ceiling.

Em-dash check: the 3 in `impact/page.tsx` are code/JSX comments (not rendered). Import closure verified (`TheoryOfChange` export already on main). Known pre-existing (both branches): `impact-fetcher` `storytellerCount: 33` fallback baseline (canon 32) — left for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)