### PR TITLE
feat(centrecorp): cross-link partner page and Utopia field note

### DIFF
--- a/v2/src/app/partners/centrecorp/centrecorp-story.tsx
+++ b/v2/src/app/partners/centrecorp/centrecorp-story.tsx
@@ -321,7 +321,8 @@ export default function CentrecorpStory() {
           ))}
         </div>
         <div className="cc-links cc-reveal cc-d2">
-          <Link href="/shop/stretch-bed-single" className="cc-btn cc-btn-solid">The Stretch Bed</Link>
+          <Link href="/field-notes/utopia-may-2026" className="cc-btn cc-btn-solid">Read the full field story</Link>
+          <Link href="/shop/stretch-bed-single" className="cc-btn">The Stretch Bed</Link>
           <a href="/docs/partners/centrecorp/utopia-outcomes-one-pager.pdf" className="cc-btn">Outcomes one-pager</a>
           <a href="https://www.centrecorpfoundation.com.au/" target="_blank" rel="noopener" className="cc-btn">Visit Centrecorp Foundation</a>
           <Link href="/contact" className="cc-btn">Contact Goods</Link>

--- a/v2/src/lib/data/trip-stories.ts
+++ b/v2/src/lib/data/trip-stories.ts
@@ -456,7 +456,7 @@ const utopia: TripStory = {
       logo: '/images/partners/centrecorp-foundation.jpg',
       url: '/partners/centrecorp',
       body: 'Centrecorp paid for the materials for this build, the ones the young people in Alice put together and the local team delivered to Utopia. They also funded the first batch of beds we delivered to Utopia in October 2025. They are an Aboriginal Trust based in the Northern Territory.',
-      cta: 'Read the story of the first Utopia delivery, October 2025',
+      cta: 'See the Centrecorp Foundation partnership story',
       metrics: [
         { value: '107', label: 'beds delivered to Utopia Homelands on this trip' },
       ],


### PR DESCRIPTION
Connects the two live Utopia surfaces shipped/published this week.

- **/partners/centrecorp → field note:** adds a primary "Read the full field story" link to `/field-notes/utopia-may-2026`.
- **field note → /partners/centrecorp:** updates the Centrecorp back-CTA label from the stale "Read the story of the first Utopia delivery, October 2025" to "See the Centrecorp Foundation partnership story" (the page now tells the full two-round partnership, not just October).

3-line diff. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)