### PR TITLE
fix(titles): drop doubled site-name suffix on gated pages, title the investor login

### DIFF
--- a/v2/src/app/investors/login/layout.tsx
+++ b/v2/src/app/investors/login/layout.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Investor access',
+  robots: { index: false, follow: false },
+};
+
+export default function InvestorsLoginLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/v2/src/app/investors/page.tsx
+++ b/v2/src/app/investors/page.tsx
@@ -17,7 +17,7 @@ import { Suspense } from 'react';
 import { CostModelWorkspace } from '@/app/admin/cost-model/cost-model-workspace';
 
 export const metadata = {
-  title: 'Investor Cockpit — Goods on Country',
+  title: 'Investor Cockpit',
   description:
     'Interactive verified bed cost model + investment view. Marginal-cost-first, QBE-ready capital case.',
 };

--- a/v2/src/app/sites/cost-lab/page.tsx
+++ b/v2/src/app/sites/cost-lab/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { CostLabWorkspace } from './cost-lab-workspace';
 
 export const metadata: Metadata = {
-  title: 'Cost Lab · Goods on Country',
+  title: 'Cost Lab',
   description:
     'Internal first-principles cost working room: raw component amounts, container build coster, funding alignment and compounding growth math.',
   robots: {

--- a/v2/src/app/sites/cost-lab/playbook/page.tsx
+++ b/v2/src/app/sites/cost-lab/playbook/page.tsx
@@ -5,7 +5,7 @@ import { ArticleRenderer } from '@/components/insiders/article-renderer';
 import { PLAYBOOK_MD } from '../playbook-content';
 
 export const metadata: Metadata = {
-  title: 'Cost Lab Playbook · Goods on Country',
+  title: 'Cost Lab Playbook',
   description:
     'Analogies, audience one-liners, set plays and the first working-session agenda for the Goods Cost Lab.',
   robots: {

--- a/v2/src/app/sites/qbe-readiness/page.tsx
+++ b/v2/src/app/sites/qbe-readiness/page.tsx
@@ -38,7 +38,7 @@ import {
 import { Badge } from '@/components/ui/badge';
 
 export const metadata: Metadata = {
-  title: 'QBE Readiness One-Pager · Goods on Country',
+  title: 'QBE Readiness One-Pager',
   description:
     'The simple version: one goal, five proofs, and the program timeline for the Goods on Country QBE capital pathway.',
   robots: { index: false, follow: false },

--- a/v2/src/app/sites/qbe/page.tsx
+++ b/v2/src/app/sites/qbe/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { QbeSiteWorkspace } from './qbe-site-workspace';
 
 export const metadata: Metadata = {
-  title: 'QBE Capital Evidence · Goods on Country',
+  title: 'QBE Capital Evidence',
   description:
     'Investor-facing evidence for the Goods on Country QBE capital pathway, cost model, pricing, impact proof, and readiness gates.',
   robots: {


### PR DESCRIPTION
## Summary
- The root layout applies the title template `%s · Goods on Country`, but five gated pages hardcoded the suffix in their own metadata, so browser tabs rendered "Cost Lab · Goods on Country · Goods on Country". Strips the suffix from: `/sites/cost-lab`, `/sites/cost-lab/playbook`, `/sites/qbe`, `/sites/qbe-readiness`, `/investors`.
- The investor cockpit title also drops its em dash ("Investor Cockpit — Goods on Country" becomes just "Investor Cockpit").
- `/investors/login` had no title at all (bare "Goods on Country"). Adds a metadata-only `layout.tsx` giving it "Investor access" plus `noindex`, since the page itself is a client component.

Found during a live route review of `/sites/cost-lab` and everything it links to (21 routes, all 200, images and Notion links verified).

## Test plan
- [x] `npm run build` clean on this branch (worktree off origin/main)
- [x] ESLint clean on the six changed files
- [ ] After deploy: curl the five pages and confirm single-suffix titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)