### PR TITLE
chore(security): scrub dead legacy Supabase keys, drop broken sitemap story URLs

### DIFF
--- a/cli/goods_tracker.py
+++ b/cli/goods_tracker.py
@@ -831,7 +831,7 @@ def audit_history(limit):
 
     # Try to get Supabase credentials from config or use defaults
     supabase_url = config.get('supabase_url', 'https://cwsyhpiuepvdjtxaozwf.supabase.co')
-    supabase_key = config.get('supabase_anon_key', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw')
+    supabase_key = config.get('supabase_anon_key', 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30')
 
     try:
         response = requests.get(
@@ -885,7 +885,7 @@ def audit_changes(limit, asset):
 
     # Try to get Supabase credentials from config or use defaults
     supabase_url = config.get('supabase_url', 'https://cwsyhpiuepvdjtxaozwf.supabase.co')
-    supabase_key = config.get('supabase_anon_key', 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw')
+    supabase_key = config.get('supabase_anon_key', 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30')
 
     try:
         url = f"{supabase_url}/rest/v1/asset_change_log?select=*&order=change_date.desc&limit={limit}"

--- a/deploy/add-assets.html
+++ b/deploy/add-assets.html
@@ -495,7 +495,7 @@
 
   <script>
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/deploy/admin-ghl-config.html
+++ b/deploy/admin-ghl-config.html
@@ -309,7 +309,7 @@
 
       <div class="form-group">
         <label class="form-label">GHL API Key</label>
-        <input type="password" id="apiKey" class="form-input" placeholder="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...">
+        <input type="password" id="apiKey" class="form-input" placeholder="REDACTED_LEGACY_KEY_ROTATED_2026-06-30">
         <div class="form-hint">Your Go High Level API key (starts with "eyJ...")</div>
       </div>
 

--- a/deploy/assets.html
+++ b/deploy/assets.html
@@ -163,7 +163,7 @@
   <script>
     // Supabase Configuration
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
     let allAssets = [];

--- a/deploy/dashboard.html
+++ b/deploy/dashboard.html
@@ -1317,7 +1317,7 @@
     // CONFIGURATION
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/deploy/deliver.html
+++ b/deploy/deliver.html
@@ -1139,7 +1139,7 @@
     // CONFIGURATION
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/deploy/home.html
+++ b/deploy/home.html
@@ -971,7 +971,7 @@
     // CONFIGURATION
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     let supabaseClient;
     async function loadScript(src) {

--- a/deploy/index.html
+++ b/deploy/index.html
@@ -864,7 +864,7 @@
     // CONFIGURATION
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     let client = null;
 

--- a/deploy/link-qr.html
+++ b/deploy/link-qr.html
@@ -510,7 +510,7 @@
 
   <script>
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/deploy/login.html
+++ b/deploy/login.html
@@ -341,7 +341,7 @@
     // CONFIGURATION
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/deploy/my-items.html
+++ b/deploy/my-items.html
@@ -860,7 +860,7 @@
     // CONFIGURATION
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/deploy/public-home.html
+++ b/deploy/public-home.html
@@ -1274,7 +1274,7 @@
     // CONFIGURATION
     // ================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     let supabaseClient;
 

--- a/deploy/report-machine.html
+++ b/deploy/report-machine.html
@@ -616,7 +616,7 @@
 
   <script>
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/deploy/support.html
+++ b/deploy/support.html
@@ -867,7 +867,7 @@
     // CONFIGURATION
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     let client = null;
 

--- a/deploy/verify-otp.html
+++ b/deploy/verify-otp.html
@@ -275,7 +275,7 @@
     // CONFIGURATION
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -686,7 +686,7 @@
     // CONFIGURATION
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzMwNzY5NTAsImV4cCI6MjA0ODY1Mjk1MH0.FNk8EYYfMi5vwfyRQJqZs5jG5O4k9TzPfCHhQPn1xZA';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/frontend/deliver.html
+++ b/frontend/deliver.html
@@ -729,7 +729,7 @@
     // CONFIGURATION
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzMwNzY5NTAsImV4cCI6MjA0ODY1Mjk1MH0.FNk8EYYfMi5vwfyRQJqZs5jG5O4k9TzPfCHhQPn1xZA';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -301,7 +301,7 @@
     // CONFIGURATION - UPDATE THESE WITH YOUR SUPABASE CREDENTIALS
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzMwNzY5NTAsImV4cCI6MjA0ODY1Mjk1MH0.FNk8EYYfMi5vwfyRQJqZs5jG5O4k9TzPfCHhQPn1xZA';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     // Initialize Supabase client
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/frontend/support-form.html
+++ b/frontend/support-form.html
@@ -301,7 +301,7 @@
     // CONFIGURATION - UPDATE THESE WITH YOUR SUPABASE CREDENTIALS
     // ============================================================================
     const SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co';
-    const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzMwNzY5NTAsImV4cCI6MjA0ODY1Mjk1MH0.FNk8EYYfMi5vwfyRQJqZs5jG5O4k9TzPfCHhQPn1xZA';
+    const SUPABASE_ANON_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30';
 
     // Initialize Supabase client
     const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);

--- a/scripts/qr_audit.py
+++ b/scripts/qr_audit.py
@@ -20,7 +20,7 @@ import requests
 
 # Configuration
 SUPABASE_URL = 'https://cwsyhpiuepvdjtxaozwf.supabase.co'
-SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImN3c3locGl1ZXB2ZGp0eGFvendmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjQ2NTcxODgsImV4cCI6MjA4MDIzMzE4OH0.Pgexh-ff_zU4SsDWV3uGO7foQjCO8xZbWvN_BU6Vxkw'
+SUPABASE_KEY = 'REDACTED_LEGACY_KEY_ROTATED_2026-06-30'
 EXPECTED_DOMAIN = 'goodsoncountry.netlify.app'
 EXPECTED_URL_PATTERN = re.compile(r'^https://goodsoncountry\.netlify\.app/\?asset_id=GB0-[\w-]+$')
 

--- a/v2/src/app/sitemap.ts
+++ b/v2/src/app/sitemap.ts
@@ -135,26 +135,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     console.error('Error fetching products for sitemap:', error);
   }
 
-  // Dynamic story pages
-  let storyPages: MetadataRoute.Sitemap = [];
-  try {
-    const supabase = createServiceClient();
-    const { data: stories } = await supabase
-      .from('stories')
-      .select('slug, updated_at')
-      .eq('is_published', true);
+  // Story detail pages resolve Empathy Ledger story ids (/stories/[id] calls
+  // empathyLedger.getStory), not the local stories table, so local slugs 404.
+  // Re-add story entries here from EL ids once the EL keys are restored.
 
-    if (stories) {
-      storyPages = stories.map((story) => ({
-        url: `${baseUrl}/stories/${story.slug}`,
-        lastModified: new Date(story.updated_at),
-        changeFrequency: 'monthly' as const,
-        priority: 0.6,
-      }));
-    }
-  } catch (error) {
-    console.error('Error fetching stories for sitemap:', error);
-  }
-
-  return [...staticPages, ...productPages, ...storyPages];
+  return [...staticPages, ...productPages];
 }


### PR DESCRIPTION
## Summary
- Replaces the rotated-and-disabled legacy Supabase anon key embedded in 20 legacy files (`deploy/`, `frontend/`, `cli/`, `scripts/`) with a `REDACTED_LEGACY_KEY_ROTATED_2026-06-30` placeholder. The key is dead-confirmed since the June 30 rotation — this closes incident runbook item 4 (repo hygiene), no functional change.
- `sitemap.ts`: stops emitting `/stories/<slug>` URLs from the local `stories` table — the `/stories/[id]` page resolves Empathy Ledger story ids, so both advertised URLs 404 (verified live). Story entries return once EL keys are restored.

## Test plan
- [x] `npm run build` clean in worktree off origin/main
- [x] `grep -rl eyJhbGciOi frontend cli scripts deploy` returns nothing
- [x] ESLint clean on sitemap.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)