### PR TITLE
Deck: aligned core messaging + public story page / internal builder split

### DIFF
--- a/v2/src/app/admin/deck-builder/deck-builder-client.tsx
+++ b/v2/src/app/admin/deck-builder/deck-builder-client.tsx
@@ -729,13 +729,13 @@ export function DeckClient() {
       <div className="border-b border-border bg-foreground text-background">
         <div className="container mx-auto px-4 py-8">
           <Link
-            href="/pitch"
+            href="/pitch/deck"
             className="mb-4 inline-flex items-center gap-2 text-sm text-background/70 transition-colors hover:text-background"
           >
             <ArrowLeft className="h-4 w-4" />
-            Back to pitch
+            View the public deck
           </Link>
-          <p className="mb-2 text-sm uppercase tracking-widest text-primary">The deck</p>
+          <p className="mb-2 text-sm uppercase tracking-widest text-primary">Deck builder · internal</p>
           <h1
             className="max-w-3xl text-3xl font-light leading-tight md:text-5xl"
             style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
@@ -743,12 +743,12 @@ export function DeckClient() {
             The whole story, one screen. Edit any slide, then present.
           </h1>
           <p className="mt-3 max-w-2xl text-sm leading-relaxed text-background/70">
-            Ten slides on the signed six-turn spine: the model and the loop, each belief turn with
-            its voices, the truck-test hinge, the ask last. Every slide carries the spoken script.
-            Click any headline, paragraph or script to edit it in place — your changes save in this
-            browser. Hit <span className="font-semibold text-background">Present</span> to open the
-            main deck, and press <span className="font-semibold text-background">N</span> in Present
-            for speaker notes. Updated {deckUpdated}.
+            Ten slides on the signed six-turn spine. Click any headline, paragraph or script to
+            edit it in place — your changes save in this browser; export them for Claude to
+            commit. The public page at /pitch/deck renders the committed version. Hit{' '}
+            <span className="font-semibold text-background">Present</span> to open the main deck,
+            and press <span className="font-semibold text-background">N</span> in Present for
+            speaker notes. Updated {deckUpdated}.
           </p>
 
           <div className="mt-6 flex flex-wrap items-center gap-3">

--- a/v2/src/app/admin/deck-builder/page.tsx
+++ b/v2/src/app/admin/deck-builder/page.tsx
@@ -1,0 +1,11 @@
+import { DeckClient } from './deck-builder-client';
+
+export const metadata = {
+  title: 'Deck builder | Goods admin',
+  description:
+    'Edit the investor deck in place: copy, voices and presenter scripts. The public deck at /pitch/deck renders the committed version.',
+};
+
+export default function DeckBuilderPage() {
+  return <DeckClient />;
+}

--- a/v2/src/app/pitch/deck/deck-client.tsx
+++ b/v2/src/app/pitch/deck/deck-client.tsx
@@ -20,7 +20,7 @@ import { getStoryteller } from '@/lib/data/storyteller-registry';
 
 const STORAGE_KEY = 'goods-deck-v1';
 
-type TextField = 'headline' | 'body';
+type TextField = 'headline' | 'body' | 'script';
 
 /** Consent-safe: primary → approved, never a `hold` quote. */
 function leadQuote(name: string) {
@@ -44,7 +44,7 @@ function initials(name: string) {
 
 function canonical(slideId: string, field: TextField): string {
   const slide = deckSlides.find((s) => s.id === slideId);
-  return slide ? slide[field] : '';
+  return slide ? (slide[field] ?? '') : '';
 }
 
 /** Uncontrolled contentEditable. React owns the text node; caret is preserved
@@ -328,6 +328,20 @@ function SlideCard({
           </div>
         )}
 
+        {slide.script && (
+          <div className="mt-5 rounded-md border border-dashed border-primary/30 bg-primary/[0.03] p-4">
+            <p className="mb-2 text-[11px] font-semibold uppercase tracking-widest text-primary/70">
+              Spoken — presenter script (Present: press N)
+            </p>
+            <Editable
+              ariaLabel={`${slide.eyebrow} presenter script`}
+              value={getText(slide, 'script')}
+              onCommit={(v) => onText(slide.id, 'script', v)}
+              className="text-sm italic leading-relaxed text-foreground/80"
+            />
+          </div>
+        )}
+
         {slide.video && (
           <div className="mt-5 rounded-md border border-border bg-muted/30 p-4">
             <p className="flex items-center gap-2 text-sm font-semibold text-foreground">
@@ -446,6 +460,7 @@ function PresentOverlay({
   getVoice: (slide: DeckSlide, idx: number) => string;
 }) {
   const total = deckSlides.length;
+  const [showNotes, setShowNotes] = useState(false);
   const go = useCallback(
     (delta: number) => setIndex(Math.min(total - 1, Math.max(0, index + delta))),
     [index, setIndex, total],
@@ -459,6 +474,9 @@ function PresentOverlay({
       } else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
         e.preventDefault();
         go(-1);
+      } else if (e.key === 'n' || e.key === 'N') {
+        e.preventDefault();
+        setShowNotes((v) => !v);
       } else if (e.key === 'Escape') {
         onClose();
       }
@@ -468,19 +486,41 @@ function PresentOverlay({
   }, [go, onClose]);
 
   const slide = deckSlides[index];
+  const notes = getText(slide, 'script');
 
   return (
     <div className="fixed inset-0 z-50 bg-black">
       <PresentSlide slide={slide} getText={getText} getVoice={getVoice} />
 
-      <button
-        type="button"
-        onClick={onClose}
-        className="absolute right-4 top-4 z-10 inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1.5 text-xs font-semibold text-white backdrop-blur-sm transition-colors hover:bg-white/25"
-      >
-        <X className="h-4 w-4" />
-        Exit
-      </button>
+      <div className="absolute right-4 top-4 z-10 flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => setShowNotes((v) => !v)}
+          className={[
+            'inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-xs font-semibold backdrop-blur-sm transition-colors',
+            showNotes ? 'bg-white/90 text-black' : 'bg-white/15 text-white hover:bg-white/25',
+          ].join(' ')}
+        >
+          Notes (N)
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1.5 text-xs font-semibold text-white backdrop-blur-sm transition-colors hover:bg-white/25"
+        >
+          <X className="h-4 w-4" />
+          Exit
+        </button>
+      </div>
+
+      {showNotes && notes && (
+        <aside className="absolute right-4 top-16 z-10 max-h-[70vh] w-[22rem] max-w-[calc(100vw-2rem)] overflow-y-auto rounded-lg bg-black/80 p-4 backdrop-blur-md">
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-white/50">
+            {slide.eyebrow} — spoken
+          </p>
+          <p className="text-sm leading-relaxed text-white/90">{notes}</p>
+        </aside>
+      )}
 
       <div className="absolute left-4 top-4 z-10 rounded-full bg-white/15 px-3 py-1.5 text-xs font-semibold text-white backdrop-blur-sm">
         {index + 1} / {total}
@@ -661,8 +701,10 @@ export function DeckClient() {
       const changes: string[] = [];
       const h = overrides[`${slide.id}.headline`];
       const b = overrides[`${slide.id}.body`];
+      const sc = overrides[`${slide.id}.script`];
       if (h !== undefined) changes.push(`- headline → ${h}`);
       if (b !== undefined) changes.push(`- body → ${b}`);
+      if (sc !== undefined) changes.push(`- script → ${sc}`);
       (slide.voiceNames ?? []).forEach((defName, idx) => {
         const picked = voicePicks[`${slide.id}.voice.${idx}`];
         if (picked && picked !== defName) changes.push(`- voice ${idx + 1}: ${defName} → ${picked}`);
@@ -701,10 +743,12 @@ export function DeckClient() {
             The whole story, one screen. Edit any slide, then present.
           </h1>
           <p className="mt-3 max-w-2xl text-sm leading-relaxed text-background/70">
-            Nine slides on the signed six-turn spine: the model and the loop, then each belief turn
-            with its voices, the ask last. Click any headline or paragraph to edit it in place — your
-            changes save in this browser. Hit <span className="font-semibold text-background">Present</span> to
-            open the main deck. Updated {deckUpdated}.
+            Ten slides on the signed six-turn spine: the model and the loop, each belief turn with
+            its voices, the truck-test hinge, the ask last. Every slide carries the spoken script.
+            Click any headline, paragraph or script to edit it in place — your changes save in this
+            browser. Hit <span className="font-semibold text-background">Present</span> to open the
+            main deck, and press <span className="font-semibold text-background">N</span> in Present
+            for speaker notes. Updated {deckUpdated}.
           </p>
 
           <div className="mt-6 flex flex-wrap items-center gap-3">

--- a/v2/src/app/pitch/deck/deck-public.tsx
+++ b/v2/src/app/pitch/deck/deck-public.tsx
@@ -1,0 +1,579 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import {
+  ArrowLeft,
+  ArrowRight,
+  ArrowUpRight,
+  PlayCircle,
+  Presentation,
+  Quote,
+  X,
+} from 'lucide-react';
+import { deckSlides, deckUpdated, type DeckSlide, type GalleryImage } from '@/lib/data/deck';
+import { getStoryteller } from '@/lib/data/storyteller-registry';
+
+/** Consent-safe: primary → approved, never a `hold` quote. */
+function leadQuote(name: string) {
+  const record = getStoryteller(name);
+  if (!record) return null;
+  return (
+    record.quotes.find((q) => q.status === 'primary') ??
+    record.quotes.find((q) => q.status === 'approved') ??
+    null
+  );
+}
+
+function initials(name: string) {
+  return name
+    .split(' ')
+    .filter((part) => part && part[0] === part[0].toUpperCase())
+    .map((part) => part[0])
+    .slice(0, 2)
+    .join('');
+}
+
+function VoiceAvatar({ name, size = 56 }: { name: string; size?: number }) {
+  const record = getStoryteller(name);
+  const px = `${size}px`;
+  if (record?.portrait) {
+    return (
+      <div
+        className="relative flex-shrink-0 overflow-hidden rounded-full border border-border bg-muted"
+        style={{ height: px, width: px }}
+      >
+        <Image src={record.portrait} alt={name} fill sizes={px} className="object-cover" />
+      </div>
+    );
+  }
+  return (
+    <div
+      className="flex flex-shrink-0 items-center justify-center rounded-full border border-dashed border-border bg-muted text-sm font-semibold text-muted-foreground"
+      style={{ height: px, width: px }}
+    >
+      {initials(name)}
+    </div>
+  );
+}
+
+function VoiceCard({ name }: { name: string }) {
+  const record = getStoryteller(name);
+  const quote = leadQuote(name);
+  if (!quote) return null;
+  return (
+    <figure className="rounded-md border border-border bg-card p-4">
+      <div className="flex items-start gap-3">
+        <VoiceAvatar name={name} />
+        <div className="min-w-0 flex-1">
+          <figcaption className="text-sm font-semibold text-foreground">{name}</figcaption>
+          <p className="text-xs leading-relaxed text-muted-foreground">{record?.role}</p>
+        </div>
+      </div>
+      <blockquote className="mt-3 text-sm leading-relaxed text-foreground">
+        &ldquo;{quote.text}&rdquo;
+      </blockquote>
+      {quote.context && <p className="mt-1 text-xs text-muted-foreground">{quote.context}</p>}
+    </figure>
+  );
+}
+
+function SlideMedia({ slide }: { slide: DeckSlide }) {
+  const loop = slide.inlineVideo?.mode === 'loop' ? slide.inlineVideo : null;
+  return (
+    <div className="relative aspect-[16/8] w-full overflow-hidden rounded-t-lg border-b border-border bg-muted">
+      {loop ? (
+        <video
+          className="absolute inset-0 h-full w-full object-cover"
+          src={loop.src}
+          poster={loop.poster}
+          autoPlay
+          muted
+          loop
+          playsInline
+          aria-label={slide.photoAlt}
+        />
+      ) : (
+        <Image
+          src={slide.photo}
+          alt={slide.photoAlt}
+          fill
+          sizes="(max-width: 1024px) 100vw, 900px"
+          className="object-cover"
+        />
+      )}
+    </div>
+  );
+}
+
+function GalleryStrip({
+  images,
+  onOpen,
+}: {
+  images: GalleryImage[];
+  onOpen: (img: GalleryImage) => void;
+}) {
+  return (
+    <div className="mt-5 flex gap-3 overflow-x-auto pb-2">
+      {images.map((img) => (
+        <button
+          key={img.src}
+          type="button"
+          onClick={() => onOpen(img)}
+          className="group relative h-28 w-40 flex-shrink-0 overflow-hidden rounded-md border border-border bg-muted transition-transform hover:scale-[1.02] md:h-32 md:w-48"
+          aria-label={`View larger: ${img.alt}`}
+        >
+          <Image
+            src={img.src}
+            alt={img.alt}
+            fill
+            sizes="192px"
+            className="object-cover transition-opacity group-hover:opacity-90"
+          />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function FeatureVideo({ slide }: { slide: DeckSlide }) {
+  const feature = slide.inlineVideo?.mode === 'feature' ? slide.inlineVideo : null;
+  if (!feature) return null;
+  return (
+    <div className="mt-5 overflow-hidden rounded-md border border-border bg-black">
+      {feature.label && (
+        <p className="flex items-center gap-2 bg-card px-4 py-3 text-sm font-semibold text-foreground">
+          <PlayCircle className="h-4 w-4 text-primary" />
+          {feature.label}
+        </p>
+      )}
+      {/* eslint-disable-next-line jsx-a11y/media-has-caption -- field recording; spoken content is summarised in the surrounding slide copy */}
+      <video className="w-full" src={feature.src} poster={feature.poster} controls preload="none" />
+    </div>
+  );
+}
+
+function GoDeeper({ slide }: { slide: DeckSlide }) {
+  if (!slide.goDeeper?.length) return null;
+  return (
+    <div className="mt-5 flex flex-wrap gap-2 border-t border-dashed border-border pt-4">
+      {slide.goDeeper.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-3 py-1.5 text-xs font-semibold text-foreground transition-colors hover:border-primary/50 hover:text-primary"
+        >
+          {link.label}
+          <ArrowUpRight className="h-3 w-3" />
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+function SlideSection({
+  slide,
+  index,
+  total,
+  onOpenImage,
+}: {
+  slide: DeckSlide;
+  index: number;
+  total: number;
+  onOpenImage: (img: GalleryImage) => void;
+}) {
+  return (
+    <section id={slide.id} className="scroll-mt-24 rounded-lg border border-border bg-card">
+      <SlideMedia slide={slide} />
+      <div className="p-5 md:p-8">
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs uppercase tracking-widest text-accent">{slide.eyebrow}</p>
+          <p className="text-[11px] font-semibold text-muted-foreground">
+            {index + 1} / {total}
+          </p>
+        </div>
+
+        <h2
+          className="mt-2 text-2xl font-light leading-tight text-foreground md:text-4xl"
+          style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
+        >
+          {slide.headline}
+        </h2>
+
+        <p className="mt-3 max-w-2xl text-sm leading-relaxed text-muted-foreground md:text-base">
+          {slide.body}
+        </p>
+
+        {slide.steps && (
+          <ol className="mt-6 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+            {slide.steps.map((step, i) => (
+              <li key={step} className="flex gap-2 rounded-md border border-border bg-background p-3">
+                <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-primary text-[11px] font-bold text-primary-foreground">
+                  {i + 1}
+                </span>
+                <span className="text-xs leading-relaxed text-foreground">{step}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+
+        {slide.literalQuotes && slide.literalQuotes.length > 0 && (
+          <div className="mt-6 grid gap-3 sm:grid-cols-2">
+            {slide.literalQuotes.map((q) => (
+              <blockquote
+                key={q.text}
+                className="rounded-md border-l-2 border-primary/50 bg-muted/40 py-2 pl-3 pr-2"
+              >
+                <p className="text-sm leading-relaxed text-foreground">&ldquo;{q.text}&rdquo;</p>
+                <footer className="mt-1 text-[11px] text-muted-foreground">{q.attribution}</footer>
+              </blockquote>
+            ))}
+          </div>
+        )}
+
+        {slide.voiceNames && slide.voiceNames.length > 0 && (
+          <div className="mt-6 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {slide.voiceNames.map((name) => (
+              <VoiceCard key={name} name={name} />
+            ))}
+          </div>
+        )}
+
+        {slide.chips && slide.chips.length > 0 && (
+          <div className="mt-6 flex flex-wrap gap-2">
+            {slide.chips.map((chip) => (
+              <div key={chip.label} className="rounded-md border border-border bg-background px-3 py-2">
+                <p className="text-[10px] uppercase tracking-wide text-muted-foreground">{chip.label}</p>
+                <p className="text-sm font-semibold text-foreground">{chip.value}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <FeatureVideo slide={slide} />
+
+        {slide.gallery && slide.gallery.length > 0 && (
+          <GalleryStrip images={slide.gallery} onOpen={onOpenImage} />
+        )}
+
+        <GoDeeper slide={slide} />
+      </div>
+    </section>
+  );
+}
+
+/* ── Present (fullscreen) ───────────────────────────────────────────────── */
+
+function PresentSlide({ slide }: { slide: DeckSlide }) {
+  const leadName = slide.voiceNames?.[0] ?? null;
+  const registryQuote = leadName ? leadQuote(leadName) : null;
+  const literal = slide.literalQuotes?.[0] ?? null;
+  const loop = slide.inlineVideo?.mode === 'loop' ? slide.inlineVideo : null;
+
+  return (
+    <div className="absolute inset-0">
+      {loop ? (
+        <video
+          className="absolute inset-0 h-full w-full object-cover"
+          src={loop.src}
+          poster={loop.poster}
+          autoPlay
+          muted
+          loop
+          playsInline
+          aria-label={slide.photoAlt}
+        />
+      ) : (
+        <Image src={slide.photo} alt={slide.photoAlt} fill sizes="100vw" className="object-cover" priority />
+      )}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/50 to-black/25" />
+
+      <div className="absolute inset-x-0 bottom-0 p-6 md:p-16">
+        <div className="mx-auto max-w-4xl">
+          <p className="text-xs uppercase tracking-[0.3em] text-white/70 md:text-sm">{slide.eyebrow}</p>
+          <h2
+            className="mt-3 text-3xl font-light leading-tight text-white md:text-5xl"
+            style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
+          >
+            {slide.headline}
+          </h2>
+          <p className="mt-4 max-w-2xl text-sm leading-relaxed text-white/80 md:text-lg">{slide.body}</p>
+
+          {slide.steps && (
+            <div className="mt-5 flex flex-wrap gap-2">
+              {slide.steps.map((step, i) => (
+                <span
+                  key={step}
+                  className="rounded-full border border-white/25 bg-white/10 px-3 py-1 text-xs text-white/90 backdrop-blur-sm"
+                >
+                  {i + 1}. {step.split(': ')[0]}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {(registryQuote || literal) && (
+            <div className="mt-5 flex items-start gap-3">
+              {leadName && registryQuote && <VoiceAvatar name={leadName} size={48} />}
+              <div>
+                <p className="flex items-start gap-2 text-base italic leading-relaxed text-white md:text-xl">
+                  <Quote className="mt-1 h-4 w-4 flex-shrink-0 text-white/50" />
+                  <span>&ldquo;{(registryQuote?.text ?? literal?.text) as string}&rdquo;</span>
+                </p>
+                <p className="mt-1 pl-6 text-xs text-white/60 md:text-sm">
+                  {registryQuote ? leadName : literal?.attribution}
+                </p>
+              </div>
+            </div>
+          )}
+
+          {slide.chips && (
+            <div className="mt-6 flex flex-wrap gap-x-6 gap-y-3">
+              {slide.chips.map((chip) => (
+                <div key={chip.label}>
+                  <p className="text-lg font-semibold text-white md:text-2xl">{chip.value}</p>
+                  <p className="text-[11px] uppercase tracking-wide text-white/60">{chip.label}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PresentOverlay({
+  index,
+  setIndex,
+  onClose,
+}: {
+  index: number;
+  setIndex: (i: number) => void;
+  onClose: () => void;
+}) {
+  const total = deckSlides.length;
+  const go = useCallback(
+    (delta: number) => setIndex(Math.min(total - 1, Math.max(0, index + delta))),
+    [index, setIndex, total],
+  );
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight' || e.key === ' ' || e.key === 'PageDown') {
+        e.preventDefault();
+        go(1);
+      } else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
+        e.preventDefault();
+        go(-1);
+      } else if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [go, onClose]);
+
+  const slide = deckSlides[index];
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black">
+      <PresentSlide slide={slide} />
+
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute right-4 top-4 z-10 inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1.5 text-xs font-semibold text-white backdrop-blur-sm transition-colors hover:bg-white/25"
+      >
+        <X className="h-4 w-4" />
+        Exit
+      </button>
+
+      <div className="absolute left-4 top-4 z-10 rounded-full bg-white/15 px-3 py-1.5 text-xs font-semibold text-white backdrop-blur-sm">
+        {index + 1} / {total}
+      </div>
+
+      {index > 0 && (
+        <button
+          type="button"
+          onClick={() => go(-1)}
+          aria-label="Previous slide"
+          className="absolute left-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white/15 p-2 text-white backdrop-blur-sm transition-colors hover:bg-white/30"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+      )}
+      {index < total - 1 && (
+        <button
+          type="button"
+          onClick={() => go(1)}
+          aria-label="Next slide"
+          className="absolute right-3 top-1/2 z-10 -translate-y-1/2 rounded-full bg-white/15 p-2 text-white backdrop-blur-sm transition-colors hover:bg-white/30"
+        >
+          <ArrowRight className="h-5 w-5" />
+        </button>
+      )}
+
+      <div className="absolute inset-x-0 bottom-2 z-10 flex justify-center gap-1.5">
+        {deckSlides.map((s, i) => (
+          <button
+            key={s.id}
+            type="button"
+            aria-label={`Go to slide ${i + 1}`}
+            onClick={() => setIndex(i)}
+            className={[
+              'h-1.5 rounded-full transition-all',
+              i === index ? 'w-6 bg-white' : 'w-1.5 bg-white/40 hover:bg-white/70',
+            ].join(' ')}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ── Lightbox ───────────────────────────────────────────────────────────── */
+
+function Lightbox({ image, onClose }: { image: GalleryImage; onClose: () => void }) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/90 p-4 md:p-10"
+      onClick={onClose}
+      role="dialog"
+      aria-label={image.alt}
+    >
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute right-4 top-4 z-10 rounded-full bg-white/15 p-2 text-white backdrop-blur-sm hover:bg-white/25"
+        aria-label="Close image"
+      >
+        <X className="h-5 w-5" />
+      </button>
+      <div className="relative h-full w-full max-w-5xl">
+        <Image src={image.src} alt={image.alt} fill sizes="100vw" className="object-contain" />
+      </div>
+      <p className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-black/60 px-4 py-1.5 text-xs text-white/80">
+        {image.alt}
+      </p>
+    </div>
+  );
+}
+
+/* ── Root ───────────────────────────────────────────────────────────────── */
+
+export function DeckPublic() {
+  const [presentIndex, setPresentIndex] = useState<number | null>(null);
+  const [lightbox, setLightbox] = useState<GalleryImage | null>(null);
+
+  return (
+    <main className="bg-background text-foreground">
+      {/* Intro */}
+      <div className="border-b border-border bg-foreground text-background">
+        <div className="container mx-auto px-4 py-10 md:py-14">
+          <p className="mb-2 text-sm uppercase tracking-widest text-primary">The pitch</p>
+          <h1
+            className="max-w-3xl text-3xl font-light leading-tight md:text-5xl"
+            style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
+          >
+            The whole story, one page.
+          </h1>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-background/70 md:text-base">
+            Ten turns through what communities have built with Goods: the need, named by the people
+            living it; the products they designed; the making moving into community hands; and what
+            has to move next. Real voices, real photographs, and numbers that audit back to the
+            public register. Updated {deckUpdated}.
+          </p>
+
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setPresentIndex(0)}
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              <Presentation className="h-4 w-4" />
+              Present fullscreen
+            </button>
+            <Link
+              href="/register"
+              className="inline-flex items-center gap-2 rounded-md border border-background/25 px-4 py-2.5 text-sm font-semibold text-background transition-colors hover:bg-background/10"
+            >
+              Every number, audited
+              <ArrowUpRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Slides */}
+      <div className="container mx-auto max-w-4xl space-y-8 px-4 py-10">
+        {deckSlides.map((slide, index) => (
+          <SlideSection
+            key={slide.id}
+            slide={slide}
+            index={index}
+            total={deckSlides.length}
+            onOpenImage={setLightbox}
+          />
+        ))}
+
+        {/* Closing band */}
+        <div className="rounded-lg border border-border bg-card p-6 text-center md:p-10">
+          <h2
+            className="text-2xl font-light leading-tight text-foreground md:text-3xl"
+            style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
+          >
+            Sit down with us.
+          </h2>
+          <p className="mx-auto mt-3 max-w-xl text-sm leading-relaxed text-muted-foreground">
+            If this story holds something for you, the next step is a conversation, not a form.
+          </p>
+          <div className="mt-6 flex flex-wrap justify-center gap-3">
+            <Link
+              href="/get-involved"
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              Back the work
+            </Link>
+            <Link
+              href="/contact"
+              className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2.5 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
+            >
+              Talk to us
+            </Link>
+            <button
+              type="button"
+              onClick={() => setPresentIndex(0)}
+              className="inline-flex items-center gap-2 rounded-md border border-border px-4 py-2.5 text-sm font-semibold text-foreground transition-colors hover:bg-muted"
+            >
+              <Presentation className="h-4 w-4" />
+              Present from the top
+            </button>
+          </div>
+          <p className="mt-6 text-xs text-muted-foreground">
+            Figures verified {deckUpdated}. Every number on this page audits back to{' '}
+            <Link href="/register" className="underline hover:text-foreground">
+              the register
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+
+      {presentIndex !== null && (
+        <PresentOverlay index={presentIndex} setIndex={setPresentIndex} onClose={() => setPresentIndex(null)} />
+      )}
+
+      {lightbox && <Lightbox image={lightbox} onClose={() => setLightbox(null)} />}
+    </main>
+  );
+}

--- a/v2/src/app/pitch/deck/page.tsx
+++ b/v2/src/app/pitch/deck/page.tsx
@@ -1,11 +1,11 @@
-import { DeckClient } from './deck-client';
+import { DeckPublic } from './deck-public';
 
 export const metadata = {
-  title: 'The deck | Goods on Country pitch',
+  title: 'The Goods story deck | Goods on Country',
   description:
-    'The whole aligned investor deck on one screen: edit any slide in place, then hit Present to open the main deck.',
+    'Ten turns through what communities have built with Goods: the need, the products they designed, the making moving into community hands, and what moves next. Real voices, real photographs, audited numbers.',
 };
 
 export default function PitchDeckPage() {
-  return <DeckClient />;
+  return <DeckPublic />;
 }

--- a/v2/src/lib/data/deck.ts
+++ b/v2/src/lib/data/deck.ts
@@ -2,17 +2,26 @@
  * The Goods investor deck — one canonical, aligned sequence.
  *
  * Spine: the SIGNED 6-turn narrative foundation (wiki/outputs/2026-07-11-
- * narrative-foundation.md §1-2, §7): model + the loop up front, then the six
- * belief turns each carried by a named voice, the ask once and last.
+ * narrative-foundation.md §1-2, §7), integrated with Ben's 14 July story-first
+ * draft per wiki/outputs/2026-07-15-strategy-deck-core-messaging.md: model +
+ * the loop up front, the six belief turns each carried by a named voice, the
+ * truck-test hinge between Turn 4 and Turn 5, the ask once and last.
  *
  * This file is the single source of truth for the deck's words and picture
  * choices. The /pitch/deck page lets Ben edit copy live in the browser
  * (saved to localStorage, exported back here to commit) and open a Present
- * (fullscreen) view — the "main deck".
+ * (fullscreen) view — the "main deck". Every slide carries a presenter
+ * script in Ben's spoken voice; Present mode shows it as notes (N key).
  *
  * Voices resolve through storyteller-registry.ts, so every quote is
  * consent-tiered; the page never surfaces a `hold` quote (e.g. Dianne's
  * totem line). Photos are real, web-served paths under /public/images.
+ *
+ * Claims-status labels (observed / requested / agreed / delivered / measured
+ * / proposed) ride on chip labels and notes. NO Kununurra content may enter
+ * this file until the Elder clears her words and has a registry record
+ * (core-messaging doc §5) — this page is public and click-to-editable, so
+ * "gated in the code" is not a real gate.
  */
 
 export interface DeckChip {
@@ -32,7 +41,7 @@ export interface DeckVideo {
   note: string;
 }
 
-export type SlideKind = 'cover' | 'model' | 'turn' | 'ask' | 'closing';
+export type SlideKind = 'cover' | 'model' | 'turn' | 'hinge' | 'ask' | 'closing';
 
 export interface DeckSlide {
   id: string;
@@ -52,14 +61,16 @@ export interface DeckSlide {
   voiceAlternates?: string[];
   /** Verbatim field/anonymous lines shown as pull-quotes. */
   literalQuotes?: LiteralQuote[];
-  /** Data chips (canon figures / quiet specs). */
+  /** Data chips (canon figures / quiet specs), claims-status in the label. */
   chips?: DeckChip[];
   video?: DeckVideo;
+  /** Presenter script — Ben's spoken voice, shown as notes in Present (N). */
+  script?: string;
   /** Editorial / provenance note shown in the edit margin, never in Present. */
   note: string;
 }
 
-export const deckUpdated = '14 July 2026';
+export const deckUpdated = '15 July 2026';
 
 export const deckSlides: DeckSlide[] = [
   {
@@ -71,6 +82,8 @@ export const deckSlides: DeckSlide[] = [
     body: 'Quality furniture and appliances for remote Indigenous communities. Designed in community, made on Country, moving toward community ownership.',
     photo: '/images/product/stretch-bed-community.jpg',
     photoAlt: 'A Stretch Bed set up in a remote community home',
+    script:
+      'Goods turns community knowledge into health hardware, local work, and production that communities can own. Goods started with a bed, but the first thing we had to learn was how to sit down. From a distance it can look like Goods is a couple of people driving around Australia taking products into communities. The photographs tend to show the truck, the bed and the handover. They do not show the part that makes any of it possible. Before we arrive, someone has taken the call, spoken with families, worked out where we should go and decided to let us in. They carry the relationships. We carry the components.',
     note: 'Cover line = Ben\'s, 9 July workshop (narrative-foundation §1). Language rule: "designed in community", never "co-design".',
   },
   {
@@ -80,7 +93,7 @@ export const deckSlides: DeckSlide[] = [
     headline: 'One loop, run twice. Two products, community-designed.',
     body: 'The Stretch Bed and Pakkimjalki Kari, the washing machine Dianne Stokes named in Warumungu, both came through the same loop, in different community hands each time. Every product into a home feeds back into the next design, and the plant itself is built to be handed over, place by place.',
     photo: '/images/process/factory-panorama.jpg',
-    photoAlt: 'The containerised on-Country plant',
+    photoAlt: 'The containerised plant on Country',
     steps: [
       'Listen: the community names the need',
       'Design in community: specs from lived conditions',
@@ -88,6 +101,8 @@ export const deckSlides: DeckSlide[] = [
       'Deliver and feed back: beds into homes, feedback into design',
       'Transfer and support: the plant moves toward community hands',
     ],
+    script:
+      'Goods is one loop, run twice. Listen. Design in community. Make on Country. Deliver and feed back. Transfer and support. The Stretch Bed came through that loop, and so did Pakkimjalki Kari, the washing machine Dianne Stokes designed and named in Warumungu. Two products, different community hands each time: Elders designing around the fire, a family building the current machines with Nic, young people building beds through Oonchiumpa. Every product into a home feeds back into the next design. And the plant itself is built to be handed over, place by place, with Goods staying on as support rather than owner.',
     note: 'Five-stage loop, narrative-foundation §1. Two-product loop: Pakkimjalki Kari is the second proof, not a side product.',
   },
   {
@@ -95,7 +110,7 @@ export const deckSlides: DeckSlide[] = [
     kind: 'turn',
     eyebrow: 'Turn 1',
     headline: 'The need is real, and people name it themselves.',
-    body: 'Before any bed lands, the community names the need, in its own words, not ours.',
+    body: 'Sit on the dirt. Leave the pen alone. Listen long enough for the idea to change. Before any bed lands, the community names the need, in its own words, not ours.',
     photo: '/images/media-pack/nic-with-elder-on-verandah.jpg',
     photoAlt: 'Nic listening with an Elder on a verandah',
     voiceNames: ['Ivy', 'Katrina Bloomfield'],
@@ -104,7 +119,9 @@ export const deckSlides: DeckSlide[] = [
       { text: 'We\'ve been sleeping on a door.', attribution: 'Arlparra household' },
       { text: 'Off the ground. That\'s the main thing.', attribution: 'Arlparra Elder' },
     ],
-    note: 'Turn 1, narrative-foundation §2. Anonymous Arlparra lines are usable unnamed (community-narrative.ts).',
+    script:
+      'We came with prototypes and more certainty than we should have had. Gary in Mount Isa described consultation as sitting on the grass or dirt, around the fire, without the pen and paper, and listening. His words exposed something uncomfortable. Asking is easy. The hard part is staying quiet when the answer begins to undo your idea. People spoke about family coming to stay and too few beds in the house. Freight. Mattresses on floors. Snakes. Sore knees. In Arlparra, a household told us they had been sleeping on a door. People already understood all of this. They did not need us to diagnose their lives. We were the ones catching up.',
+    note: 'Turn 1, narrative-foundation §2. Anonymous Arlparra lines are usable unnamed (community-narrative.ts). Gary\'s fire-and-dirt description stays narrated, never in quotation marks, until transcript-verified.',
   },
   {
     id: 'turn-2',
@@ -116,33 +133,37 @@ export const deckSlides: DeckSlide[] = [
     photoAlt: 'Remote community, the problem of reach and cost',
     voiceNames: ['Alfred Johnson', 'Daniel Patrick Noble'],
     voiceAlternates: ['Ivy', 'Jason'],
-    note: 'Turn 2, narrative-foundation §2. "The two price tags" diagram belongs here.',
+    script:
+      'A product made for a quiet suburban bedroom does not always survive a large family, constant movement, heat and dust. And most products never get there at all. Alfred Johnson on Palm Island put it plainly: you have to bring them on the barge, you have to pay for freight, and it all adds up. Daniel Patrick Noble told us what that arithmetic means: sometimes people would rather go without. Freight, cost and distance break the ordinary supply chain long before it reaches the community. Remote families pay too much for goods that fail too quickly. They can be made better.',
+    note: 'Turn 2, narrative-foundation §2. "The two price tags" diagram belongs here (photo gap: nothing yet shows the supply failure itself).',
   },
   {
     id: 'turn-3',
     kind: 'turn',
     eyebrow: 'Turn 3',
     headline: 'The products work because community designed them. Both of them.',
-    body: 'Specs come from lived conditions: washable, low for Elders, no tools, built to survive remote. The Stretch Bed and the washing machine Dianne named both prove it.',
+    body: 'Maroon. Washable canvas. Replaceable parts. A height older people could get out of. The specs come from lived conditions, and the Stretch Bed and the washing machine Dianne named both carry them.',
     photo: '/images/product/stretch-bed-hero.jpg',
     photoAlt: 'The Stretch Bed, community-designed',
     voiceNames: ['Dianne Stokes', 'Dorrie Jones', 'Melissa Jackson', 'Patricia Frank'],
     voiceAlternates: ['Heather Mundo'],
     chips: [
-      { label: 'Weight', value: '26 kg' },
-      { label: 'Capacity', value: '200 kg' },
-      { label: 'Assembly', value: 'No tools, ~5 min' },
+      { label: 'Weight', value: '26kg' },
+      { label: 'Capacity', value: '200kg' },
+      { label: 'Assembly', value: 'No tools, ~5min' },
       { label: 'Material', value: 'Recycled HDPE + canvas' },
       { label: 'Washer base', value: 'Speed Queen, one-button' },
     ],
-    note: 'Turn 3, narrative-foundation §2-3. Dianne\'s PRIMARY quote is Pakkimjalki Kari; her totem line is HOLD — never surface it. Specs from products.ts.',
+    script:
+      'Norman asked for maroon. The request sounds small until you notice what usually happens: a product arrives in whatever colour somebody else selected, and the person using it is expected to be grateful. Maroon went into the work. The bed changed. Washable canvas. Replaceable parts. A flat pack for the road. No toolbox needed. A height that gave older knees a fair chance. The Stretch Bed is made from those corrections. The washing machine followed the bed; one without the other left the job half done. Dianne Stokes designed it and named it Pakkimjalki Kari. She says that every time she goes away, it is like it is calling her: come back home.',
+    note: 'Turn 3, narrative-foundation §2-3. Dianne\'s PRIMARY quote is Pakkimjalki Kari; her totem line is HOLD — never surface it. Specs from products.ts. Health carried by Patricia Frank + Dr Boe Remenyi (labelled practitioner); the why only, never an outcome.',
   },
   {
     id: 'turn-4',
     kind: 'turn',
     eyebrow: 'Turn 4',
     headline: 'The making belongs in community hands. Young people are one proof; families are another.',
-    body: 'The Bloomfield family built the five current machines with Nic. Young makers built the Utopia beds through Oonchiumpa. Different hands, the same loop.',
+    body: 'The Bloomfield family built the current washing machines with Nic. Young makers built the Utopia beds through Oonchiumpa. Different hands, the same loop. The direction of the request is changing: from receiving products to making them.',
     photo: '/images/build/build-001.jpg',
     photoAlt: 'Young people building a bed on Country',
     voiceNames: ['Mykel', 'Fred Campbell', 'Karen Liddle', 'Kristy Bloomfield'],
@@ -152,45 +173,73 @@ export const deckSlides: DeckSlide[] = [
       href: '/field-notes/utopia-may-2026',
       note: 'At his house, putting the bed together. Already live and public.',
     },
-    note: 'Turn 4, narrative-foundation §2. Fred narrates Xavier — never a direct Xavier quote.',
+    script:
+      'The work with Oonchiumpa in Alice Springs pushed the question to the front. Young people built beds outside the office before the Utopia trip. Mykel said, "Yeah, I\'ll be rocking up every day to make them." He was not talking about attending a program. He was talking about making something his community needed. Fred, his case worker, tells the story of Xavier going back to family, so proud showing them that he can build it. And the Bloomfield family built the current washing machines with Nic. Different hands, the same loop. Mykel made us look at the supply chain from the other end: why did the making, the wage and the machinery keep beginning somewhere else?',
+    note: 'Turn 4, narrative-foundation §2. Fred narrates Xavier — never a direct Xavier quote. Mykel on screen is always the registry verbatim, never a paraphrase.',
+  },
+  {
+    id: 'hinge-truck-test',
+    kind: 'hinge',
+    eyebrow: 'The hinge',
+    headline: 'The product is proven. The transfer is not.',
+    body: 'What came in on the truck? What leaves on it? What stays? If the beds stay while the wages, tools, knowledge and decisions leave with us, the old arrangement has survived the delivery.',
+    photo: '/images/utopia/utopia-09.jpg',
+    photoAlt: 'A delivery day on Country, Utopia',
+    chips: [
+      { label: 'Delivered · beds', value: '496 across 9 communities' },
+      { label: 'Delivered · washing machines', value: '16 in community' },
+      { label: 'Delivered · plastic diverted', value: '2,660kg' },
+    ],
+    script:
+      'The beds are real. The deliveries are real. 496 beds across nine communities. Sixteen washing machines in community. 2,660kg of plastic diverted. People have assembled them, used them and asked for more. But a delivery count does not tell us where the work, tools, contracts, margin or decisions sit. The truck is a useful test for this whole project. What came in on it? What leaves on it? What stays? If the beds stay but the jobs, tools, knowledge and decisions leave with us, then we have delivered a product and preserved the old arrangement.',
+    note: 'The truck test, adopted from Ben\'s 14 July draft (core-messaging doc §2-3). The one framing device, used once — Ben\'s rule. 2,660kg is Stretch-only provenance (133 × 20kg). Photo is place-attributable (Utopia).',
   },
   {
     id: 'turn-5',
     kind: 'turn',
     eyebrow: 'Turn 5',
-    headline: 'The plant makes the pattern transferable. Ownership is the promise.',
-    body: 'The containerised plant is visible, teachable and movable — Alice to Tennant Creek to Katherine to Darwin. It is built to be handed over, place by place, with Goods staying on as support, not owner. PICC has asked to buy a production facility of its own; Dianne received one bed and came back to self-fund twenty.',
+    headline: 'The plant makes the pattern transferable. Ownership is the promise, and it is not true yet.',
+    body: 'The containerised plant is visible, teachable and movable: Alice to Tennant Creek to Katherine to Darwin. But a plant is an operating system: orders, wages, safety, maintenance, working capital, quality, governance. Handed over without that system, it becomes another dead machine at the edge of town. Ownership is a pathway. What has to move: title, contracts, margin, knowledge, decisions.',
     photo: '/images/process/heat-press-full.jpg',
     photoAlt: 'The heat press — the one move at the heart of the plant',
     voiceNames: ['Norman Frank', 'Shayne Bloomfield'],
     voiceAlternates: ['Karen Liddle', 'Dianne Stokes'],
-    note: 'Turn 5, narrative-foundation §2. Ownership is a PATHWAY, never claimed complete (locked by Ben 2026-07-10).',
+    chips: [
+      { label: 'Requested · Oonchiumpa', value: 'Interest in owning a plant' },
+      { label: 'Requested · PICC', value: 'Asked to buy a facility' },
+      { label: 'Requested · Dianne', value: 'Came back to self-fund 20 beds' },
+    ],
+    script:
+      'Dropping machinery in a community would be the easy part. Keeping it operating is another matter. People need wages and enough orders to support them. There is safety training, maintenance, quality control and the gap between buying materials and being paid. A facility handed over without that support can become another dead machine sitting at the edge of town. Goods is not yet a community-owned production system, and we will not use the word ownership as decoration. Oonchiumpa has asked about owning a plant. PICC has asked to buy a production facility. These are requests, not settled deals. We are moving closer to community ownership, and we have to be explicit about what Goods holds today, what can move, on what timetable, and what support remains after it does.',
+    note: 'Turn 5, narrative-foundation §2 merged with the 14 July operating-system framing. Ownership is a PATHWAY, never claimed complete (locked by Ben 2026-07-10). Demand signals are labelled requested — an invitation is not a mandate.',
   },
   {
     id: 'ask',
     kind: 'ask',
     eyebrow: 'Turn 6 · The ask',
-    headline: 'What the capital does — once, near the end.',
-    body: 'The funding buys the bridge: the 50-bed in-source run (modelled, then measured), the first place-based ownership pathway with Oonchiumpa, the enterprise-support layer, and plant capex. AU$400K recoverable, at least 1:1 match-eligible, through QBE Catalysing Impact, on top of SEFA $300K, Snow $100K and Centrecorp $75K.',
+    headline: 'What the capital does, once, near the end.',
+    body: 'The funding buys the bridge: the 50-bed in-source run (modelled, then measured), the first place-based ownership pathway with Oonchiumpa, the enterprise-support layer, and plant capex. AU$400K through QBE Catalysing Impact, matched at least 1:1 by signed external commitments. The target match stack (SEFA $300K, Snow $100K, Centrecorp $75K) is proposed today, not signed. Ordinary capital will not fund this stage, because the return being built is the transfer itself.',
     photo: '/images/qbe/communities-screen.png',
     photoAlt: 'The nine communities served, on the map',
     chips: [
-      { label: 'Beds delivered', value: '496 across 9 communities' },
-      { label: 'Washing machines in community', value: '16' },
-      { label: 'Plastic diverted', value: '2,660 kg' },
-      { label: 'Revenue (accountant-signed carve-out)', value: 'AU$713,827' },
-      { label: 'Current ask', value: 'AU$400K (QBE, by 31 Aug 2026)' },
+      { label: 'Measured · revenue (accountant-signed carve-out)', value: 'AU$713,827' },
+      { label: 'Proposed · the ask', value: 'AU$400K QBE Catalysing Impact' },
+      { label: 'Gate', value: 'Signed LOIs by 31 Aug 2026' },
     ],
-    note: 'Turn 6, narrative-foundation §2/§5. Every number audits back to /register. Revenue LOCKED to the $713,827 carve-out on all external surfaces.',
+    script:
+      'We are not asking you to rescue a community or sponsor a delivery photograph. The funding buys the bridge: the first 50-bed production run in our own plant, taking the cost model from modelled to measured; the first place-based ownership pathway with Oonchiumpa; the enterprise-support layer; and plant capital. AU$400K through QBE Catalysing Impact, matched at least one to one by signed external commitments. We need those signed letters by 31 August. Ordinary capital will not fund this stage, because the return we are building is the transfer itself: assets, jobs and authority moving to community hands. We ask partners to accept that trust moves more slowly than a grant deadline.',
+    note: 'Turn 6, narrative-foundation §2/§5. Every number audits back to /register. Revenue LOCKED to the $713,827 carve-out on all external surfaces. Match stack is PROPOSED (0 signed LOIs today) — never shown as committed. QBE prefers repayable structures; structure not settled, so "recoverable" is not promised. 31 Aug = LOI gate; application Sept, outcomes Nov.',
   },
   {
     id: 'closing',
     kind: 'closing',
     eyebrow: 'The promise',
-    headline: 'The funding buys the middle of the sentence, so communities can own the end of it.',
-    body: 'Community is the subject of the first beat and the last. Goods only appears in the middle, as the verb.',
+    headline: 'We know what we need. Sit down and ask us, make it with us, and leave the making with us.',
+    body: 'A Goods synthesis, assembled from what people have told us; no one person said this sentence. The funding buys the middle of the sentence, so communities can own the end of it.',
     photo: '/images/media-pack/lying-on-stretch-bed.jpg',
     photoAlt: 'Resting on a Stretch Bed, off the ground',
-    note: 'Closing. Credit rule (spine): they said, it changed, it returned.',
+    script:
+      'We have been using one sentence to hold all of this. We know what we need. Sit down and ask us, make it with us, and leave the making with us. No one person said that whole sentence. We assembled it from what people have told us and from the direction they have pushed the work. Each part makes a demand on us: whether we believe the knowledge already in community, whether we can listen long enough to have our plans changed, who is being paid, and what stays after we leave. Community is the subject of the first beat and the last. Goods only appears in the middle, as the verb.',
+    note: 'Closing. The synthesis is NEVER rendered in quotation marks and never attributed to a community member (essay rule). Credit rule (spine): they said, it changed, it returned.',
   },
 ];

--- a/v2/src/lib/data/deck.ts
+++ b/v2/src/lib/data/deck.ts
@@ -41,6 +41,26 @@ export interface DeckVideo {
   note: string;
 }
 
+export interface GalleryImage {
+  /** Served path under /public. */
+  src: string;
+  alt: string;
+}
+
+export interface InlineVideo {
+  /** Served path under /public/video. */
+  src: string;
+  poster: string;
+  /** loop = silent ambient header; feature = click-to-play with controls. */
+  mode: 'loop' | 'feature';
+  label?: string;
+}
+
+export interface GoDeeperLink {
+  label: string;
+  href: string;
+}
+
 export type SlideKind = 'cover' | 'model' | 'turn' | 'hinge' | 'ask' | 'closing';
 
 export interface DeckSlide {
@@ -64,6 +84,12 @@ export interface DeckSlide {
   /** Data chips (canon figures / quiet specs), claims-status in the label. */
   chips?: DeckChip[];
   video?: DeckVideo;
+  /** Ambient loop replacing the header photo, or a featured click-to-play clip. */
+  inlineVideo?: InlineVideo;
+  /** Real photos shown as a strip under the slide (public page). */
+  gallery?: GalleryImage[];
+  /** Links to the specific live pages that carry the detail. */
+  goDeeper?: GoDeeperLink[];
   /** Presenter script — Ben's spoken voice, shown as notes in Present (N). */
   script?: string;
   /** Editorial / provenance note shown in the edit margin, never in Present. */
@@ -82,6 +108,10 @@ export const deckSlides: DeckSlide[] = [
     body: 'Quality furniture and appliances for remote Indigenous communities. Designed in community, made on Country, moving toward community ownership.',
     photo: '/images/product/stretch-bed-community.jpg',
     photoAlt: 'A Stretch Bed set up in a remote community home',
+    goDeeper: [
+      { label: 'The work', href: '/the-work' },
+      { label: 'The communities', href: '/communities' },
+    ],
     script:
       'Goods turns community knowledge into health hardware, local work, and production that communities can own. Goods started with a bed, but the first thing we had to learn was how to sit down. From a distance it can look like Goods is a couple of people driving around Australia taking products into communities. The photographs tend to show the truck, the bed and the handover. They do not show the part that makes any of it possible. Before we arrive, someone has taken the call, spoken with families, worked out where we should go and decided to let us in. They carry the relationships. We carry the components.',
     note: 'Cover line = Ben\'s, 9 July workshop (narrative-foundation §1). Language rule: "designed in community", never "co-design".',
@@ -101,6 +131,16 @@ export const deckSlides: DeckSlide[] = [
       'Deliver and feed back: beds into homes, feedback into design',
       'Transfer and support: the plant moves toward community hands',
     ],
+    gallery: [
+      { src: '/images/process/01-source.jpg', alt: 'Plastic collected around community' },
+      { src: '/images/process/shredded-chips-weighed.jpg', alt: 'Shredded HDPE, weighed' },
+      { src: '/images/process/pressed-sheets.jpg', alt: 'Pressed recycled-plastic sheets' },
+      { src: '/images/process/container-factory.jpg', alt: 'The containerised plant' },
+    ],
+    goDeeper: [
+      { label: 'How it is made', href: '/process' },
+      { label: 'Inside the facility', href: '/wiki/manufacturing/facility-manual' },
+    ],
     script:
       'Goods is one loop, run twice. Listen. Design in community. Make on Country. Deliver and feed back. Transfer and support. The Stretch Bed came through that loop, and so did Pakkimjalki Kari, the washing machine Dianne Stokes designed and named in Warumungu. Two products, different community hands each time: Elders designing around the fire, a family building the current machines with Nic, young people building beds through Oonchiumpa. Every product into a home feeds back into the next design. And the plant itself is built to be handed over, place by place, with Goods staying on as support rather than owner.',
     note: 'Five-stage loop, narrative-foundation §1. Two-product loop: Pakkimjalki Kari is the second proof, not a side product.',
@@ -119,6 +159,15 @@ export const deckSlides: DeckSlide[] = [
       { text: 'We\'ve been sleeping on a door.', attribution: 'Arlparra household' },
       { text: 'Off the ground. That\'s the main thing.', attribution: 'Arlparra Elder' },
     ],
+    gallery: [
+      { src: '/images/media-pack/community-testing-bed-golden-hour.jpg', alt: 'Trying the bed in community, golden hour' },
+      { src: '/images/media-pack/goods-early-2023-community.jpg', alt: 'Early days: listening in community, 2023' },
+      { src: '/images/media-pack/community-bed-assembly.jpg', alt: 'Community members assembling a bed' },
+    ],
+    goDeeper: [
+      { label: 'The communities', href: '/communities' },
+      { label: 'Community stories', href: '/stories' },
+    ],
     script:
       'We came with prototypes and more certainty than we should have had. Gary in Mount Isa described consultation as sitting on the grass or dirt, around the fire, without the pen and paper, and listening. His words exposed something uncomfortable. Asking is easy. The hard part is staying quiet when the answer begins to undo your idea. People spoke about family coming to stay and too few beds in the house. Freight. Mattresses on floors. Snakes. Sore knees. In Arlparra, a household told us they had been sleeping on a door. People already understood all of this. They did not need us to diagnose their lives. We were the ones catching up.',
     note: 'Turn 1, narrative-foundation §2. Anonymous Arlparra lines are usable unnamed (community-narrative.ts). Gary\'s fire-and-dirt description stays narrated, never in quotation marks, until transcript-verified.',
@@ -133,6 +182,7 @@ export const deckSlides: DeckSlide[] = [
     photoAlt: 'Remote community, the problem of reach and cost',
     voiceNames: ['Alfred Johnson', 'Daniel Patrick Noble'],
     voiceAlternates: ['Ivy', 'Jason'],
+    goDeeper: [{ label: 'What a bed really costs', href: '/cost-story' }],
     script:
       'A product made for a quiet suburban bedroom does not always survive a large family, constant movement, heat and dust. And most products never get there at all. Alfred Johnson on Palm Island put it plainly: you have to bring them on the barge, you have to pay for freight, and it all adds up. Daniel Patrick Noble told us what that arithmetic means: sometimes people would rather go without. Freight, cost and distance break the ordinary supply chain long before it reaches the community. Remote families pay too much for goods that fail too quickly. They can be made better.',
     note: 'Turn 2, narrative-foundation §2. "The two price tags" diagram belongs here (photo gap: nothing yet shows the supply failure itself).',
@@ -154,6 +204,22 @@ export const deckSlides: DeckSlide[] = [
       { label: 'Material', value: 'Recycled HDPE + canvas' },
       { label: 'Washer base', value: 'Speed Queen, one-button' },
     ],
+    inlineVideo: {
+      src: '/video/stretch-bed-desktop.mp4',
+      poster: '/video/stretch-bed-poster.jpg',
+      mode: 'loop',
+    },
+    gallery: [
+      { src: '/images/pitch/bed-seq-1-leg-pole.jpg', alt: 'Assembly, step one: a leg and a pole' },
+      { src: '/images/pitch/bed-seq-2-legs-pole.jpg', alt: 'Assembly, step two: both legs on the pole' },
+      { src: '/images/pitch/bed-seq-3-all-parts.jpg', alt: 'Every part of the Stretch Bed, laid out' },
+      { src: '/images/pitch/bed-canvas.jpg', alt: 'The washable canvas sleeping surface' },
+      { src: '/images/product/washing-machine-name.jpg', alt: 'Pakkimjalki Kari: the name plate on the washing machine' },
+    ],
+    goDeeper: [
+      { label: 'The Stretch Bed', href: '/stretch-bed' },
+      { label: 'Pakkimjalki Kari', href: '/wiki/products/washing-machine' },
+    ],
     script:
       'Norman asked for maroon. The request sounds small until you notice what usually happens: a product arrives in whatever colour somebody else selected, and the person using it is expected to be grateful. Maroon went into the work. The bed changed. Washable canvas. Replaceable parts. A flat pack for the road. No toolbox needed. A height that gave older knees a fair chance. The Stretch Bed is made from those corrections. The washing machine followed the bed; one without the other left the job half done. Dianne Stokes designed it and named it Pakkimjalki Kari. She says that every time she goes away, it is like it is calling her: come back home.',
     note: 'Turn 3, narrative-foundation §2-3. Dianne\'s PRIMARY quote is Pakkimjalki Kari; her totem line is HOLD — never surface it. Specs from products.ts. Health carried by Patricia Frank + Dr Boe Remenyi (labelled practitioner); the why only, never an outcome.',
@@ -173,6 +239,19 @@ export const deckSlides: DeckSlide[] = [
       href: '/field-notes/utopia-may-2026',
       note: 'At his house, putting the bed together. Already live and public.',
     },
+    inlineVideo: {
+      src: '/video/partners/oonchiumpa/mykel-building-the-bed.mp4',
+      poster: '/video/partners/oonchiumpa/mykel-building-the-bed-poster.jpg',
+      mode: 'feature',
+      label: 'Mykel, building his bed at home, in his own voice',
+    },
+    gallery: [
+      { src: '/images/build/build-009.jpg', alt: 'Build day with Oonchiumpa, Alice Springs' },
+      { src: '/images/build/build-025.jpg', alt: 'Young makers assembling beds' },
+      { src: '/images/build/build-057.jpg', alt: 'Hands on the work, build day' },
+      { src: '/images/build/build-105.jpg', alt: 'Finished beds from the build session' },
+    ],
+    goDeeper: [{ label: 'The Utopia field note', href: '/field-notes/utopia-may-2026' }],
     script:
       'The work with Oonchiumpa in Alice Springs pushed the question to the front. Young people built beds outside the office before the Utopia trip. Mykel said, "Yeah, I\'ll be rocking up every day to make them." He was not talking about attending a program. He was talking about making something his community needed. Fred, his case worker, tells the story of Xavier going back to family, so proud showing them that he can build it. And the Bloomfield family built the current washing machines with Nic. Different hands, the same loop. Mykel made us look at the supply chain from the other end: why did the making, the wage and the machinery keep beginning somewhere else?',
     note: 'Turn 4, narrative-foundation §2. Fred narrates Xavier — never a direct Xavier quote. Mykel on screen is always the registry verbatim, never a paraphrase.',
@@ -189,6 +268,20 @@ export const deckSlides: DeckSlide[] = [
       { label: 'Delivered · beds', value: '496 across 9 communities' },
       { label: 'Delivered · washing machines', value: '16 in community' },
       { label: 'Delivered · plastic diverted', value: '2,660kg' },
+    ],
+    inlineVideo: {
+      src: '/video/partners/centrecorp/utopia-delivery-road.mp4',
+      poster: '/video/partners/centrecorp/utopia-delivery-road-poster.jpg',
+      mode: 'loop',
+    },
+    gallery: [
+      { src: '/images/utopia/utopia-02.jpg', alt: 'Delivery day, Utopia homelands' },
+      { src: '/images/utopia/utopia-05.jpg', alt: 'Beds arriving on Country' },
+      { src: '/images/utopia/utopia-12.jpg', alt: 'Unloading in community' },
+    ],
+    goDeeper: [
+      { label: 'Every number, audited', href: '/register' },
+      { label: 'One bed\'s life', href: '/bed/GB0-156-40' },
     ],
     script:
       'The beds are real. The deliveries are real. 496 beds across nine communities. Sixteen washing machines in community. 2,660kg of plastic diverted. People have assembled them, used them and asked for more. But a delivery count does not tell us where the work, tools, contracts, margin or decisions sit. The truck is a useful test for this whole project. What came in on it? What leaves on it? What stays? If the beds stay but the jobs, tools, knowledge and decisions leave with us, then we have delivered a product and preserved the old arrangement.',
@@ -209,6 +302,21 @@ export const deckSlides: DeckSlide[] = [
       { label: 'Requested · PICC', value: 'Asked to buy a facility' },
       { label: 'Requested · Dianne', value: 'Came back to self-fund 20 beds' },
     ],
+    inlineVideo: {
+      src: '/video/recycling-plant-desktop.mp4',
+      poster: '/video/recycling-plant-poster.jpg',
+      mode: 'loop',
+    },
+    gallery: [
+      { src: '/images/process/heat-press-detail.jpg', alt: 'The heat press, up close' },
+      { src: '/images/process/cnc-router-full.jpg', alt: 'CNC cutting the leg components' },
+      { src: '/images/process/parts-rack-sorted.jpg', alt: 'Cut parts, racked and sorted' },
+      { src: '/images/process/color-samples.jpg', alt: 'Recycled-plastic colour samples' },
+    ],
+    goDeeper: [
+      { label: 'How it is made', href: '/process' },
+      { label: 'The impact model', href: '/impact' },
+    ],
     script:
       'Dropping machinery in a community would be the easy part. Keeping it operating is another matter. People need wages and enough orders to support them. There is safety training, maintenance, quality control and the gap between buying materials and being paid. A facility handed over without that support can become another dead machine sitting at the edge of town. Goods is not yet a community-owned production system, and we will not use the word ownership as decoration. Oonchiumpa has asked about owning a plant. PICC has asked to buy a production facility. These are requests, not settled deals. We are moving closer to community ownership, and we have to be explicit about what Goods holds today, what can move, on what timetable, and what support remains after it does.',
     note: 'Turn 5, narrative-foundation §2 merged with the 14 July operating-system framing. Ownership is a PATHWAY, never claimed complete (locked by Ben 2026-07-10). Demand signals are labelled requested — an invitation is not a mandate.',
@@ -226,6 +334,11 @@ export const deckSlides: DeckSlide[] = [
       { label: 'Proposed · the ask', value: 'AU$400K QBE Catalysing Impact' },
       { label: 'Gate', value: 'Signed LOIs by 31 Aug 2026' },
     ],
+    goDeeper: [
+      { label: 'Every number, audited', href: '/register' },
+      { label: 'Where $750 goes', href: '/cost-story' },
+      { label: 'The impact model', href: '/impact' },
+    ],
     script:
       'We are not asking you to rescue a community or sponsor a delivery photograph. The funding buys the bridge: the first 50-bed production run in our own plant, taking the cost model from modelled to measured; the first place-based ownership pathway with Oonchiumpa; the enterprise-support layer; and plant capital. AU$400K through QBE Catalysing Impact, matched at least one to one by signed external commitments. We need those signed letters by 31 August. Ordinary capital will not fund this stage, because the return we are building is the transfer itself: assets, jobs and authority moving to community hands. We ask partners to accept that trust moves more slowly than a grant deadline.',
     note: 'Turn 6, narrative-foundation §2/§5. Every number audits back to /register. Revenue LOCKED to the $713,827 carve-out on all external surfaces. Match stack is PROPOSED (0 signed LOIs today) — never shown as committed. QBE prefers repayable structures; structure not settled, so "recoverable" is not promised. 31 Aug = LOI gate; application Sept, outcomes Nov.',
@@ -238,6 +351,16 @@ export const deckSlides: DeckSlide[] = [
     body: 'A Goods synthesis, assembled from what people have told us; no one person said this sentence. The funding buys the middle of the sentence, so communities can own the end of it.',
     photo: '/images/media-pack/lying-on-stretch-bed.jpg',
     photoAlt: 'Resting on a Stretch Bed, off the ground',
+    gallery: [
+      { src: '/images/media-pack/woman-on-red-stretch-bed.jpg', alt: 'Resting on a red Stretch Bed' },
+      { src: '/images/media-pack/thumbs-up-stretch-bed.jpg', alt: 'Thumbs up from a new bed' },
+      { src: '/images/product/stretch-bed-in-use.jpg', alt: 'A Stretch Bed in daily use' },
+      { src: '/images/media-pack/goods-branding-golden-hour.jpg', alt: 'Goods, golden hour' },
+    ],
+    goDeeper: [
+      { label: 'Back the work', href: '/get-involved' },
+      { label: 'Talk to us', href: '/contact' },
+    ],
     script:
       'We have been using one sentence to hold all of this. We know what we need. Sit down and ask us, make it with us, and leave the making with us. No one person said that whole sentence. We assembled it from what people have told us and from the direction they have pushed the work. Each part makes a demand on us: whether we believe the knowledge already in community, whether we can listen long enough to have our plans changed, who is being paid, and what stays after we leave. Community is the subject of the first beat and the last. Goods only appears in the middle, as the verb.',
     note: 'Closing. The synthesis is NEVER rendered in quotation marks and never attributed to a community member (essay rule). Credit rule (spine): they said, it changed, it returned.',

--- a/v2/tsconfig.json
+++ b/v2/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "sites"]
 }

--- a/wiki/outputs/2026-07-15-strategy-deck-core-messaging.md
+++ b/wiki/outputs/2026-07-15-strategy-deck-core-messaging.md
@@ -1,0 +1,259 @@
+# Strategy deck core messaging, aligned
+
+*2026-07-15. This is the single aligned message architecture for the Goods strategy deck, produced
+from four sources: the signed narrative foundation (`wiki/outputs/2026-07-11-narrative-foundation.md`),
+the live deck (`v2/src/lib/data/deck.ts`, goodsoncountry.com/pitch/deck), Ben's 14 July
+"story-first relationship deck v2" draft, and Ben's "Sit down and ask us" essay. An adversarial
+consent-and-claims verification pass ran over the first draft of this alignment; its eight
+confirmed defects are corrected here.*
+
+**Governing rule:** the signed foundation governs facts, figures, turn structure and the voice
+roster. The 14 July draft and the essay govern spoken voice, honesty discipline and claim hygiene.
+Where the new material is genuinely better, the foundation absorbs it, named explicitly below.
+
+---
+
+## 1. The verdict
+
+The two documents are the same argument at different altitudes. The six signed belief turns
+survive intact inside the 14 July draft. The draft adds three things the spine lacked (a live
+opening, the truck-test hinge, an operating-system reframe of Turn 5) and subtracts three things
+it must not (the second product, the consent-tiered voice roster, the specific QBE ask). The
+integrated deck keeps the signed turn order and reinstates the subtractions.
+
+**The deck is 10 slides.** Cover, model, Turns 1 to 4, the truck-test hinge, Turn 5, the ask,
+closing. A consent-gated 2-slide Kununurra opening (Variant A) exists on paper only, in this
+document and its Notion mirror. It does not enter `deck.ts`, the live site, the PDF or any
+external surface until the gate in §5 clears.
+
+## 2. What the 14 July draft and the essay add
+
+| # | Element | Decision | Why |
+|---|---|---|---|
+| 1 | Kununurra opening (NAIDOC scene, two trial beds, her yes) | **HOLD, paper variant only** | Strongest possible opening, zero consent coverage. Her words, the scene description, audience and use all need her explicit clearance, and she needs a storyteller-registry record first. Never enters production code before then; the live /pitch/deck is public and click-to-editable, so "gated in the code" is not a real gate. |
+| 2 | Invitation-is-not-a-mandate | **ADOPT as a standing principle** | Protects every demand claim in the corpus: PICC's facility ask, Groote's 300 washers, NPY's standing demand, Dianne's 20, and Kununurra alike. A request is evidence of direction, not a settled deal. |
+| 3 | The truck test (what came in on it, what leaves on it, what stays) | **ADOPT as the hinge slide** | Goods-authored, physical, no consent exposure. Does in three questions what the transfer stage does in a paragraph. Used once, per Ben's own rule. |
+| 4 | Claims-status labels (observed / requested / agreed / delivered / measured / proposed) | **ADOPT deck-wide** | Direct extension of the register honesty layer. Every figure chip and demand claim carries its status. |
+| 5 | The "what not to do" list | **ADOPT as deck governance** | Lives in deck.ts note fields and presenter notes, never on screen. |
+| 6 | Plant-as-operating-system (orders, wages, safety, maintenance, working capital, quality, governance; the dead-machine risk) | **ADOPT, merged into Turn 5** | Converts Turn 5 from aspiration into an investable operating problem, which is exactly what the Turn 6 capital buys. |
+| 7 | Three-way partner ask (procurement / philanthropic / finance) | **ADAPT as pre-meeting routing, never a slide** | An ask menu is not an ask. Know the room, name one ask with amount, timing, decision and community partner, delete the other two. For the QBE deck the one ask is chosen. |
+| 8 | Banned-words list (empower, beneficiaries, ecosystem, scalable solution, catalytic, transformational, journey, unlock, game-changing) | **ADOPT into brand voice standing rules** | "Catalytic" survives only inside the program name "QBE Catalysing Impact". |
+| 9 | Write-for-the-ear rules (one job per slide, plain first person, keep the irregularity of speech, end with a decision) | **ADOPT** | The presenter script in §4 is built on them. |
+| 10 | Essay claim: Warumungu names for BOTH products, with Norman and Patricia helping | **PARTIAL HOLD** | The registry supports Dianne having designed and named both products' story. What is NOT verified is Norman's and Patricia's role in the naming; that specific claim stays out until checked against transcripts. The essay's language-care line ("language offered through a relationship cannot quietly become company property") is safe and kept as a spoken line. |
+
+## 3. The integrated deck
+
+Quote rule: anything on screen in quotation marks renders registry-verbatim through
+`storyteller-registry.ts`. Fragments and reported speech live in prose, without quotation marks.
+
+| # | Slide | On screen | Voices (tier) | Claims-status | Photo | Video |
+|---|---|---|---|---|---|---|
+| 1 | **Cover** | Goods turns community knowledge into health hardware, local work, and production that communities can own. | Goods (Ben) | proposed (the model) | product/stretch-bed-community.jpg | hero loop optional |
+| 2 | **The model** | One loop, run twice. Two products, designed in community. Steps: Listen · Design in community · Make on Country · Deliver and feed back · Transfer and support | Dianne Stokes named as designer and namer (external) | delivered (both products shipped through the loop) | process/factory-panorama.jpg | recycling-plant loop |
+| 3 | **Turn 1: the need is real, and people name it themselves** | Sit on the dirt. Leave the pen alone. Listen long enough for the idea to change. | Anonymous Arlparra lines (usable unnamed) · Ivy (external) · Katrina Bloomfield (external, voice-only) · alternates Linda Turner, Gary (narrated only, E4 flag) | observed | media-pack/nic-with-elder-on-verandah.jpg | community b-roll |
+| 4 | **Turn 2: the existing supply fails these places** | "You have to bring them on the barge. You can't just take them on the boat. You have to pay for freight. It all adds up." Alfred Johnson, Palm Island | Alfred Johnson (external) · Daniel Patrick Noble (external) | observed | media-pack/deadly-heart-trek-aug-2025.jpg (weakest fit, see gaps) | stretch-bed montage |
+| 5 | **Turn 3: the products work because community designed them. Both of them.** | Maroon. Washable canvas. Replaceable parts. A height older people could get out of. | Dianne Stokes (external, Pakkimjalki Kari line) · Dorrie Jones (external) · Melissa Jackson (external) · Patricia Frank (external, washing and health) · Dr Boe Remenyi (external, labelled practitioner) | delivered; health stated as the why only | product/stretch-bed-hero.jpg + pitch/bed-seq strip + product/washing-machine-name.jpg | jaquilane overlay where testimony referenced |
+| 6 | **Turn 4: the making belongs in community hands** | "Yeah, I'll be rocking up every day to make them." Mykel, Utopia | Mykel (external, youth-care framing) · Fred Campbell narrating Xavier (external, never Xavier direct) · Karen Liddle (external) · Kristy Bloomfield (external) · Bloomfield family build narrated as fact | delivered (paid builds happened) | build/build-001.jpg | mykel-building-the-bed.mp4, already wired |
+| 7 | **Hinge: the truck test** | The product is proven. The transfer is not. What came in on the truck? What leaves on it? What stays? Chips: 496 beds across 9 communities (delivered) · 16 washing machines in community (delivered) · 2,660kg plastic diverted (delivered, Stretch-only) | Goods (Ben), no community voice | delivered (chips), proposed (the transfer) | utopia/utopia-09.jpg (place-attributable delivery) | utopia-delivery-road.mp4 |
+| 8 | **Turn 5: the plant makes the pattern transferable; ownership is the promise, and it is not true yet** | Ownership is a pathway. What has to move: title, contracts, margin, knowledge, decisions. | Norman Frank (external) · Shayne Bloomfield (external) · alternates Karen Liddle, Dianne Stokes | proposed (transfer plan), requested (Oonchiumpa plant interest, PICC facility ask, Dianne's 20, Anyinginyi reorder) | process/heat-press-full.jpg + community-ownership diagram inset | recycling-plant loop |
+| 9 | **Turn 6: the ask, once, near the end** | AU$400K through QBE Catalysing Impact, matched at least 1:1 by signed external commitments. Signed letters by 31 August 2026. | Shayne Bloomfield carries the ask · Dianne carries scale (both external) | proposed (ask and match stack, 0 LOIs signed today), measured (revenue AU$713,827 carve-out, the only external revenue figure) | qbe/communities-screen.png + where-750 chart | none (text slide is fine) |
+| 10 | **Closing: the synthesis** | We know what we need. Sit down and ask us, make it with us, and leave the making with us. Rendered WITHOUT quotation marks, margin label: a Goods synthesis; no one person said this sentence. | Goods synthesis | proposed (the standard Goods is held to) | media-pack/lying-on-stretch-bed.jpg | none |
+
+**Variant A (paper only until §5 clears): Kununurra opening, 2 slides in front.**
+Slide A1 "Kununurra, now": an Elder has agreed to try two beds and is asking how local production
+could work. Her words are not reproduced anywhere in this document or its mirrors; they stay with
+Ben until she clears exact words, context, audience and use. Slide A2 "An invitation is not a
+mandate": two trial beds, a question about local making, the wider decision belongs to a local
+process that has not happened yet. A2's principle is already adopted ungated as deck governance.
+
+## 4. Presenter script
+
+Ben's first person, built from his 14 July spoken text and the essay. Registry quotes stay
+verbatim. The default run has no Kununurra content.
+
+**1. Cover.** Goods turns community knowledge into health hardware, local work, and production
+that communities can own. Goods started with a bed, but the first thing we had to learn was how
+to sit down. From a distance it can look like Goods is a couple of people driving around
+Australia taking products into communities. The photographs tend to show the truck, the bed and
+the handover. They do not show the part that makes any of it possible. Before we arrive, someone
+has taken the call, spoken with families, worked out where we should go and decided to let us in.
+They carry the relationships. We carry the components.
+
+**2. The model.** Goods is one loop, run twice. Listen. Design in community. Make on Country.
+Deliver and feed back. Transfer and support. The Stretch Bed came through that loop, and so did
+Pakkimjalki Kari, the washing machine Dianne Stokes designed and named in Warumungu. Two
+products, different community hands each time: Elders designing around the fire, a family
+building the current machines with Nic, young people building beds through Oonchiumpa. Every
+product into a home feeds back into the next design. And the plant itself is built to be handed
+over, place by place, with Goods staying on as support rather than owner.
+
+**3. Turn 1.** We came with prototypes and more certainty than we should have had. Gary in Mount
+Isa described consultation as sitting on the grass or dirt, around the fire, without the pen and
+paper, and listening. His words exposed something uncomfortable. Asking is easy. The hard part is
+staying quiet when the answer begins to undo your idea. People spoke about family coming to stay
+and too few beds in the house. Freight. Mattresses on floors. Snakes. Sore knees. In Arlparra, a
+household told us they had been sleeping on a door. People already understood all of this. They
+did not need us to diagnose their lives. We were the ones catching up.
+
+**4. Turn 2.** A product made for a quiet suburban bedroom does not always survive a large
+family, constant movement, heat and dust. And most products never get there at all. Alfred
+Johnson on Palm Island put it plainly: you have to bring them on the barge, you have to pay for
+freight, and it all adds up. Daniel Patrick Noble told us what that arithmetic means: sometimes
+people would rather go without. Freight, cost and distance break the ordinary supply chain long
+before it reaches the community. Remote families pay too much for goods that fail too quickly.
+They can be made better.
+
+**5. Turn 3.** Norman asked for maroon. The request sounds small until you notice what usually
+happens: a product arrives in whatever colour somebody else selected, and the person using it is
+expected to be grateful. Maroon went into the work. The bed changed. Washable canvas. Replaceable
+parts. A flat pack for the road. No toolbox needed. A height that gave older knees a fair chance.
+The Stretch Bed is made from those corrections. The washing machine followed the bed; one without
+the other left the job half done. Dianne Stokes designed it and named it Pakkimjalki Kari. She
+says that every time she goes away, it is like it is calling her: come back home.
+
+**6. Turn 4.** The work with Oonchiumpa in Alice Springs pushed the question to the front. Young
+people built beds outside the office before the Utopia trip. Mykel said, "Yeah, I'll be rocking
+up every day to make them." He was not talking about attending a program. He was talking about
+making something his community needed. Fred, his case worker, tells the story of Xavier going
+back to family, so proud showing them that he can build it. And the Bloomfield family built the
+current washing machines with Nic. Different hands, the same loop. Mykel made us look at the
+supply chain from the other end: why did the making, the wage and the machinery keep beginning
+somewhere else?
+
+**7. The truck test.** The beds are real. The deliveries are real. 496 beds across nine
+communities. Sixteen washing machines in community. 2,660kg of plastic diverted. People have
+assembled them, used them and asked for more. But a delivery count does not tell us where the
+work, tools, contracts, margin or decisions sit. The truck is a useful test for this whole
+project. What came in on it? What leaves on it? What stays? If the beds stay but the jobs, tools,
+knowledge and decisions leave with us, then we have delivered a product and preserved the old
+arrangement.
+
+**8. Turn 5.** Dropping machinery in a community would be the easy part. Keeping it operating is
+another matter. People need wages and enough orders to support them. There is safety training,
+maintenance, quality control and the gap between buying materials and being paid. A facility
+handed over without that support can become another dead machine sitting at the edge of town.
+Goods is not yet a community-owned production system, and we will not use the word ownership as
+decoration. Oonchiumpa has asked about owning a plant. PICC has asked to buy a production
+facility. These are requests, not settled deals. We are moving closer to community ownership, and
+we have to be explicit about what Goods holds today, what can move, on what timetable, and what
+support remains after it does.
+
+**9. The ask.** We are not asking you to rescue a community or sponsor a delivery photograph. The
+funding buys the bridge: the first 50-bed production run in our own plant, taking the cost model
+from modelled to measured; the first place-based ownership pathway with Oonchiumpa; the
+enterprise-support layer; and plant capital. AU$400K through QBE Catalysing Impact, matched at
+least one to one by signed external commitments. We need those signed letters by 31 August.
+Ordinary capital will not fund this stage, because the return we are building is the transfer
+itself: assets, jobs and authority moving to community hands. We ask partners to accept that
+trust moves more slowly than a grant deadline.
+
+**10. Closing.** We have been using one sentence to hold all of this. We know what we need. Sit
+down and ask us, make it with us, and leave the making with us. No one person said that whole
+sentence. We assembled it from what people have told us and from the direction they have pushed
+the work. Each part makes a demand on us: whether we believe the knowledge already in community,
+whether we can listen long enough to have our plans changed, who is being paid, and what stays
+after we leave. Community is the subject of the first beat and the last. Goods only appears in
+the middle, as the verb.
+
+*Variant A additions (paper only): an opening scene set in Kununurra and a closing pair of
+sentences returning to it. Both stay out of every surface until §5 clears. Her exact words are
+not reproduced here.*
+
+## 5. The Kununurra gate
+
+Before Variant A exists anywhere beyond this document and its Notion mirror:
+
+1. The Elder clears her exact words, the scene description, the intended audience and the
+   specific use, herself.
+2. She receives a storyteller-registry record with tier set by her decision, and the deck reads
+   her material through the registry like every other voice.
+3. The drinking-in-front-yards detail never appears in any deck, script or artifact, in any form.
+   The 14 July draft itself bans it.
+4. "Kununurra wants a facility" is never written or said. One Elder's yes opens a conversation;
+   the wider decision belongs to a local process that has not happened yet.
+5. Until all of the above: the deck's only reference to Kununurra is nothing at all.
+
+## 6. Media, reviewed with use cases
+
+Full inventories: `scratchpad/out-photos.md` and `out-videos.md` (session files, tables mirrored
+on the Notion page). Committed and web-served unless noted.
+
+**Photo picks by slide (from the 150+ file sweep):**
+cover product/stretch-bed-community.jpg · model process/factory-panorama.jpg · T1
+media-pack/nic-with-elder-on-verandah.jpg · T2 media-pack/deadly-heart-trek-aug-2025.jpg
+(placeholder, see gaps) · T3 product/stretch-bed-hero.jpg + pitch/bed-seq-1..3 strip +
+product/washing-machine-name.jpg (the loop-run-twice proof) · T4 build/build-001.jpg · hinge
+utopia/utopia-09.jpg (place-attributable) · T5 process/heat-press-full.jpg · ask
+qbe/communities-screen.png · closing media-pack/lying-on-stretch-bed.jpg. Spares:
+media-pack/community-testing-bed-golden-hour.jpg, media-pack/washing-machine-enclosure-sunset.jpg.
+
+**Video picks:** T4 partners/oonchiumpa/mykel-building-the-bed.mp4 (89s, cleared, already wired
+into the deck) · funder-meeting cutaway jaquilane-testimony.mp4 (72s, sound on, never a
+background) · T5 recycling-plant-desktop.mp4 (34s loop) · hinge/delivery
+partners/centrecorp/utopia-delivery-road.mp4 (12s loop) · partner authority
+partners/oonchiumpa/karen-liddle-on-beds.mp4 (40s).
+
+**Gaps that matter (build list, not blockers):**
+1. Turn 2 has no photo of the actual supply failure; the "two price tags" diagram is the fix.
+2. Turn 5 has no real transfer photo; a Bloomfield-family-at-the-plant image is the strongest
+   missing asset.
+3. 7 of 9 communities have no place-attributed public media; the "9 communities" claim leans on
+   the map. No Kalgoorlie, Palm Island or Darwin imagery despite transcript-backed trips.
+4. No Pakkimjalki Kari in-use footage; the two-product loop is video-blind on product two.
+5. Ask-slide charts (cost-curve, breakeven, where-750) exist only in gitignored staging; nothing
+   committed. May-trip Utopia files (alice-youth, ampilatwatja-elders, beds-being-made,
+   delivery-drone) still not in the repo.
+
+## 7. Formats
+
+| Format | What | Where | Use |
+|---|---|---|---|
+| Website deck | /pitch/deck edit view + fullscreen Present, now with presenter notes | live, goodsoncountry.com/pitch/deck | the room: present from the browser |
+| PDF | 10-slide print cut with the spoken script under each slide | design/deck-assets/goods-strategy-deck-2026-07-15.pdf (local-only, media stays out of git) | email-ahead, leave-behind |
+| Notion | "Goods strategy deck: core messaging + artifact library" under the Artifact Hub | Notion, internal | alignment surface; links, never duplicates |
+| Photos/videos | use-case tables above | repo + Notion mirror | per-slide backgrounds, cutaways, social |
+
+Per-audience routing (pre-meeting, never a slide): procurement rooms get orders language,
+philanthropic rooms get training-governance-repair language, finance rooms get
+machinery-and-working-capital language. One ask per room, the other two deleted.
+
+## 8. Flags register (corrected after verification)
+
+1. CONSENT, CRITICAL: the Kununurra Elder's words and scene are uncleared; §5 governs. No
+   registry record exists yet.
+2. CONSENT, CRITICAL: the drinking-in-front-yards detail never surfaces anywhere.
+3. FIGURE, HIGH: match stack (SEFA $300K, Snow $100K, Centrecorp $75K) is proposed, 0 signed
+   LOIs today; never shown as committed. Fixed in deck.ts this session.
+4. CONSENT-QUOTE, MEDIUM: Gary's fire-and-dirt consultation description is narrated, never in
+   quotation marks, until transcript-verified (his transcript is also tagged to a different ACT
+   project).
+5. FIGURE-CLAIM, MEDIUM: Norman's and Patricia's role in Warumungu naming is unverified; Dianne
+   as designer and namer of both products' story is registry-supported and usable.
+6. BRAND, MEDIUM: deck.ts carried em dashes, spaced units and lowercase on-Country; fixed this
+   session.
+7. FIGURE, MEDIUM: 31 Aug is the signed-LOI gate, not the application date (Sept) or outcome
+   (Nov); the ask chip now says "signed LOIs by 31 Aug 2026". QBE prefers repayable structures;
+   the structure is not settled, so "recoverable" is not promised in copy.
+8. CONSENT-QUOTE, LOW: Mykel on screen is always the registry verbatim "Yeah, I'll be rocking up
+   every day to make them.", never a paraphrase.
+9. BRAND, LOW: banned words apply to all deck copy; "catalytic" only inside the QBE program name.
+10. CLAIM-CEILING, LOW: health carried by Patricia Frank plus Dr Boe Remenyi labelled
+    practitioner; never Jessica Allardyce's held line; always the why, never an outcome.
+11. CLAIMS-STATUS, LOW: 2,660kg is Stretch-only provenance (internal note); Ray Nelson's
+    back-pains line, if ever used, is lived experience, never a measured result.
+12. CONSENT, LOW: pending-tier voices (Frankie Holmes OAM, Donald Thompson OAM, Charley) and
+    website-tier Zelda Hogan stay out of funder surfaces; "which Ivy" is still open before print.
+13. SYNTHESIS RULE, LOW: the synthesis sentence appears without quotation marks on every surface,
+    labelled as a Goods synthesis (this document renders it in italics when mentioning it).
+
+## 9. What changed on the live deck (this session)
+
+- New hinge slide (the truck test) between Turn 4 and Turn 5; delivery chips moved there from
+  the ask slide with claims-status labels.
+- Presenter script added to every slide; Present mode gained a notes toggle (N key).
+- Ask slide: match stack relabelled proposed; "recoverable" removed; LOI-gate chip corrected;
+  em dash removed from the headline.
+- Turn 5: operating-system framing merged in; requests labelled as requests; em dash removed.
+- Closing: the synthesis sentence is the headline, unquoted, with the Goods-synthesis label.
+- Chips: units closed up (26kg, 200kg, 2,660kg, 5min).
+- No Kununurra content anywhere in the code.


### PR DESCRIPTION
## What this ships

**1. Core messaging alignment (7264ea4)** - one aligned architecture per wiki/outputs/2026-07-15-strategy-deck-core-messaging.md: the signed 6-turn spine absorbs the 14 July story-first draft. New truck-test hinge slide, presenter script on every slide, match stack labelled proposed (0 signed LOIs), recoverable claim removed, LOI-gate chip corrected, em dashes and spaced units fixed. No Kununurra content (consent-gated on the Elder's clearance + a registry record).

**2. Public/builder split (8bd1019)** - /pitch/deck is now fully public-facing: aligned photos, ambient loop videos, Mykel's video embedded with controls, per-slide galleries with lightbox, go-deeper links to the specific live pages, closing people-on-beds gallery, no edit affordances or provenance notes. The click-to-edit builder moved to /admin/deck-builder behind admin auth (N-key presenter notes live there).

Also: v2/tsconfig.json excludes the nested sites/ workers project from the Next typecheck (it broke the build).

## Verify on the preview
- /pitch/deck shows the public story page (no Export edits button, no margin notes)
- /admin/deck-builder requires admin login and carries the editor
- Videos play muted/looping on the model/hinge/turn-5 slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)