### PR TITLE
Admin: one content system - media workbench notes, swap widget, story atlas

### DIFF
--- a/v2/src/app/admin/deck-builder/deck-builder-client.tsx
+++ b/v2/src/app/admin/deck-builder/deck-builder-client.tsx
@@ -9,14 +9,33 @@ import {
   ArrowRight,
   Copy,
   Download,
+  Film,
+  Images,
   PlayCircle,
   Presentation,
   Quote,
   RotateCcw,
+  Star,
   X,
 } from 'lucide-react';
 import { deckSlides, deckUpdated, type DeckSlide } from '@/lib/data/deck';
-import { getStoryteller } from '@/lib/data/storyteller-registry';
+import { getStoryteller, STORYTELLER_REGISTRY } from '@/lib/data/storyteller-registry';
+
+/** Item shape served by /api/admin/media-pick (local, committed media only). */
+interface MediaPickItem {
+  id: string;
+  url: string;
+  poster_url: string | null;
+  media_type: 'image' | 'video';
+  area: string | null;
+  starred: boolean;
+  tags: string[];
+}
+
+interface VideoPick {
+  src: string;
+  poster: string;
+}
 
 const STORAGE_KEY = 'goods-deck-v1';
 
@@ -153,7 +172,7 @@ function VoiceCard({
 
       {open && pickable.length > 0 && (
         <div className="mt-4 border-t border-border pt-3">
-          <div className="grid gap-2 sm:grid-cols-2">
+          <div className="grid max-h-72 gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
             {pickable.map((name) => {
               const alt = getStoryteller(name);
               const altQuote = leadQuote(name);
@@ -188,9 +207,152 @@ function VoiceCard({
   );
 }
 
+/** Every externally-cleared voice is swappable onto any slide (one system). */
+const ALL_CLEARED_VOICES = STORYTELLER_REGISTRY.filter((s) => s.tier === 'external').map(
+  (s) => s.name,
+);
+
 function voicePool(slide: DeckSlide, currentAtIndex: string): string[] {
   return Array.from(
-    new Set([...(slide.voiceNames ?? []), ...(slide.voiceAlternates ?? []), currentAtIndex]),
+    new Set([
+      ...(slide.voiceNames ?? []),
+      ...(slide.voiceAlternates ?? []),
+      currentAtIndex,
+      ...ALL_CLEARED_VOICES,
+    ]),
+  );
+}
+
+/* ── Media picker (photo/video swap widget) ─────────────────────────────── */
+
+function MediaPicker({
+  kind,
+  items,
+  onPick,
+  onReset,
+  onClose,
+}: {
+  kind: 'image' | 'video';
+  items: MediaPickItem[] | null;
+  onPick: (item: MediaPickItem) => void;
+  onReset: () => void;
+  onClose: () => void;
+}) {
+  const [q, setQ] = useState('');
+  const [area, setArea] = useState<string | null>(null);
+
+  const pool = (items ?? []).filter((i) => i.media_type === kind);
+  const areas = Array.from(new Set(pool.map((i) => i.area).filter(Boolean))).sort() as string[];
+  const needle = q.trim().toLowerCase();
+  const shown = pool.filter(
+    (i) =>
+      (!area || i.area === area) &&
+      (!needle ||
+        i.url.toLowerCase().includes(needle) ||
+        i.tags.some((t) => t.toLowerCase().includes(needle))),
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={onClose}>
+      <div
+        className="flex max-h-[85vh] w-full max-w-4xl flex-col rounded-lg border border-border bg-card shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 border-b border-border p-4">
+          <p className="text-sm font-semibold text-foreground">
+            Swap {kind === 'image' ? 'photo' : 'video'} — every committed {kind} in the library
+          </p>
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search path or tag"
+            className="ml-auto w-48 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs text-foreground outline-none focus:ring-1 focus:ring-primary/40"
+          />
+          <button
+            type="button"
+            onClick={onReset}
+            className="inline-flex items-center gap-1 rounded-md border border-border px-2.5 py-1.5 text-xs font-semibold text-muted-foreground hover:text-foreground"
+          >
+            <RotateCcw className="h-3 w-3" />
+            Canonical
+          </button>
+          <button type="button" onClick={onClose} className="text-muted-foreground hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="flex flex-wrap gap-1.5 border-b border-border px-4 py-2">
+          <button
+            type="button"
+            onClick={() => setArea(null)}
+            className={[
+              'rounded-full px-2.5 py-1 text-[11px] font-semibold',
+              area === null ? 'bg-primary text-primary-foreground' : 'border border-border text-muted-foreground hover:text-foreground',
+            ].join(' ')}
+          >
+            All ({pool.length})
+          </button>
+          {areas.map((a) => (
+            <button
+              key={a}
+              type="button"
+              onClick={() => setArea(a === area ? null : a)}
+              className={[
+                'rounded-full px-2.5 py-1 text-[11px] font-semibold',
+                area === a ? 'bg-primary text-primary-foreground' : 'border border-border text-muted-foreground hover:text-foreground',
+              ].join(' ')}
+            >
+              {a}
+            </button>
+          ))}
+        </div>
+
+        <div className="grid flex-1 grid-cols-3 gap-2 overflow-y-auto p-4 sm:grid-cols-4 md:grid-cols-5">
+          {items === null && (
+            <p className="col-span-full py-8 text-center text-sm text-muted-foreground">Loading the library…</p>
+          )}
+          {items !== null && shown.length === 0 && (
+            <p className="col-span-full py-8 text-center text-sm text-muted-foreground">Nothing matches.</p>
+          )}
+          {shown.map((i) => {
+            const thumb = i.media_type === 'video' ? i.poster_url : i.url;
+            return (
+              <button
+                key={i.id}
+                type="button"
+                onClick={() => onPick(i)}
+                title={i.url}
+                className="group relative overflow-hidden rounded-md border border-border bg-muted transition-transform hover:scale-[1.02] focus:ring-2 focus:ring-primary/50"
+              >
+                {thumb ? (
+                  // eslint-disable-next-line @next/next/no-img-element -- admin picker thumbs, local files
+                  <img src={thumb} alt={i.url} loading="lazy" className="h-24 w-full object-cover" />
+                ) : (
+                  <span className="flex h-24 w-full items-center justify-center text-[10px] text-muted-foreground">
+                    <Film className="mr-1 h-3 w-3" />
+                    no poster
+                  </span>
+                )}
+                {i.starred && (
+                  <Star className="absolute right-1 top-1 h-3.5 w-3.5 fill-yellow-400 text-yellow-400 drop-shadow" />
+                )}
+                <span className="absolute inset-x-0 bottom-0 truncate bg-black/60 px-1.5 py-0.5 text-left text-[9px] text-white opacity-0 transition-opacity group-hover:opacity-100">
+                  {i.url.split('/').slice(-2).join('/')}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        <p className="border-t border-border px-4 py-2 text-[11px] text-muted-foreground">
+          Picks save in this browser; hit Export edits to hand them to Claude to commit. Local committed media only; tag and star in the{' '}
+          <Link href="/admin/media-library" className="underline hover:text-foreground">
+            media library
+          </Link>
+          .
+        </p>
+      </div>
+    </div>
   );
 }
 
@@ -206,6 +368,9 @@ function SlideCard({
   onVoice,
   onResetSlide,
   isDirty,
+  photoSrc,
+  onSwapPhoto,
+  onSwapVideo,
 }: {
   slide: DeckSlide;
   index: number;
@@ -216,12 +381,15 @@ function SlideCard({
   onVoice: (slideId: string, idx: number, name: string) => void;
   onResetSlide: (slideId: string) => void;
   isDirty: boolean;
+  photoSrc: string;
+  onSwapPhoto: () => void;
+  onSwapVideo: () => void;
 }) {
   return (
     <div id={slide.id} className="scroll-mt-24 rounded-lg border border-border bg-card">
       <div className="relative aspect-[16/7] w-full overflow-hidden rounded-t-lg border-b border-border bg-muted">
         <Image
-          src={slide.photo}
+          src={photoSrc}
           alt={slide.photoAlt}
           fill
           sizes="(max-width: 1024px) 100vw, 860px"
@@ -233,6 +401,24 @@ function SlideCard({
         <span className="absolute right-3 top-3 rounded-full bg-white/85 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-widest text-black/70">
           {slide.kind}
         </span>
+        <div className="absolute bottom-3 right-3 flex gap-2">
+          <button
+            type="button"
+            onClick={onSwapPhoto}
+            className="inline-flex items-center gap-1 rounded-full bg-black/60 px-2.5 py-1 text-[11px] font-semibold text-white backdrop-blur-sm transition-colors hover:bg-black/80"
+          >
+            <Images className="h-3 w-3" />
+            Swap photo
+          </button>
+          <button
+            type="button"
+            onClick={onSwapVideo}
+            className="inline-flex items-center gap-1 rounded-full bg-black/60 px-2.5 py-1 text-[11px] font-semibold text-white backdrop-blur-sm transition-colors hover:bg-black/80"
+          >
+            <Film className="h-3 w-3" />
+            {slide.inlineVideo ? 'Swap video' : 'Add video'}
+          </button>
+        </div>
       </div>
 
       <div className="p-5 md:p-6">
@@ -373,18 +559,36 @@ function PresentSlide({
   slide,
   getText,
   getVoice,
+  getPhoto,
+  getVideo,
 }: {
   slide: DeckSlide;
   getText: (slide: DeckSlide, field: TextField) => string;
   getVoice: (slide: DeckSlide, idx: number) => string;
+  getPhoto: (slide: DeckSlide) => string;
+  getVideo: (slide: DeckSlide) => VideoPick | null;
 }) {
   const leadName = slide.voiceNames?.[0] ? getVoice(slide, 0) : null;
   const registryQuote = leadName ? leadQuote(leadName) : null;
   const literal = slide.literalQuotes?.[0] ?? null;
+  const video = getVideo(slide);
 
   return (
     <div className="absolute inset-0">
-      <Image src={slide.photo} alt={slide.photoAlt} fill sizes="100vw" className="object-cover" priority />
+      {video ? (
+        <video
+          className="absolute inset-0 h-full w-full object-cover"
+          src={video.src}
+          poster={video.poster || undefined}
+          autoPlay
+          muted
+          loop
+          playsInline
+          aria-label={slide.photoAlt}
+        />
+      ) : (
+        <Image src={getPhoto(slide)} alt={slide.photoAlt} fill sizes="100vw" className="object-cover" priority />
+      )}
       <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/50 to-black/25" />
 
       <div className="absolute inset-x-0 bottom-0 p-6 md:p-16">
@@ -452,12 +656,16 @@ function PresentOverlay({
   onClose,
   getText,
   getVoice,
+  getPhoto,
+  getVideo,
 }: {
   index: number;
   setIndex: (i: number) => void;
   onClose: () => void;
   getText: (slide: DeckSlide, field: TextField) => string;
   getVoice: (slide: DeckSlide, idx: number) => string;
+  getPhoto: (slide: DeckSlide) => string;
+  getVideo: (slide: DeckSlide) => VideoPick | null;
 }) {
   const total = deckSlides.length;
   const [showNotes, setShowNotes] = useState(false);
@@ -490,7 +698,7 @@ function PresentOverlay({
 
   return (
     <div className="fixed inset-0 z-50 bg-black">
-      <PresentSlide slide={slide} getText={getText} getVoice={getVoice} />
+      <PresentSlide slide={slide} getText={getText} getVoice={getVoice} getPhoto={getPhoto} getVideo={getVideo} />
 
       <div className="absolute right-4 top-4 z-10 flex items-center gap-2">
         <button
@@ -614,9 +822,13 @@ function ExportModal({ text, onClose }: { text: string; onClose: () => void }) {
 export function DeckClient() {
   const [overrides, setOverrides] = useState<Record<string, string>>({});
   const [voicePicks, setVoicePicks] = useState<Record<string, string>>({});
+  const [photoPicks, setPhotoPicks] = useState<Record<string, string>>({});
+  const [videoPicks, setVideoPicks] = useState<Record<string, VideoPick>>({});
   const [hydrated, setHydrated] = useState(false);
   const [presentIndex, setPresentIndex] = useState<number | null>(null);
   const [exportText, setExportText] = useState<string | null>(null);
+  const [picker, setPicker] = useState<{ slideId: string; kind: 'image' | 'video' } | null>(null);
+  const [pickItems, setPickItems] = useState<MediaPickItem[] | null>(null);
 
   useEffect(() => {
     try {
@@ -625,9 +837,13 @@ export function DeckClient() {
         const parsed = JSON.parse(raw) as {
           text?: Record<string, string>;
           voices?: Record<string, string>;
+          photos?: Record<string, string>;
+          videos?: Record<string, VideoPick>;
         };
         setOverrides(parsed.text ?? {});
         setVoicePicks(parsed.voices ?? {});
+        setPhotoPicks(parsed.photos ?? {});
+        setVideoPicks(parsed.videos ?? {});
       }
     } catch {
       /* ignore corrupt storage */
@@ -637,8 +853,41 @@ export function DeckClient() {
 
   useEffect(() => {
     if (!hydrated) return;
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ text: overrides, voices: voicePicks }));
-  }, [overrides, voicePicks, hydrated]);
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ text: overrides, voices: voicePicks, photos: photoPicks, videos: videoPicks }),
+    );
+  }, [overrides, voicePicks, photoPicks, videoPicks, hydrated]);
+
+  const openPicker = useCallback(
+    (slideId: string, kind: 'image' | 'video') => {
+      setPicker({ slideId, kind });
+      if (pickItems === null) {
+        fetch('/api/admin/media-pick')
+          .then((r) => r.json())
+          .then((d) => setPickItems(Array.isArray(d.items) ? d.items : []))
+          .catch(() => setPickItems([]));
+      }
+    },
+    [pickItems],
+  );
+
+  const getPhoto = useCallback(
+    (slide: DeckSlide) => photoPicks[slide.id] ?? slide.photo,
+    [photoPicks],
+  );
+
+  const getVideo = useCallback(
+    (slide: DeckSlide): VideoPick | null => {
+      const picked = videoPicks[slide.id];
+      if (picked) return picked;
+      if (slide.inlineVideo?.mode === 'loop') {
+        return { src: slide.inlineVideo.src, poster: slide.inlineVideo.poster };
+      }
+      return null;
+    },
+    [videoPicks],
+  );
 
   const getText = useCallback(
     (slide: DeckSlide, field: TextField) => overrides[`${slide.id}.${field}`] ?? slide[field],
@@ -683,14 +932,26 @@ export function DeckClient() {
       for (const [k, v] of Object.entries(prev)) if (!k.startsWith(`${slideId}.voice.`)) next[k] = v;
       return next;
     });
+    setPhotoPicks((prev) => {
+      const next = { ...prev };
+      delete next[slideId];
+      return next;
+    });
+    setVideoPicks((prev) => {
+      const next = { ...prev };
+      delete next[slideId];
+      return next;
+    });
   }, []);
 
   const dirtySlides = useMemo(() => {
     const set = new Set<string>();
     for (const k of Object.keys(overrides)) set.add(k.split('.')[0]);
     for (const k of Object.keys(voicePicks)) set.add(k.split('.')[0]);
+    for (const k of Object.keys(photoPicks)) set.add(k);
+    for (const k of Object.keys(videoPicks)) set.add(k);
     return set;
-  }, [overrides, voicePicks]);
+  }, [overrides, voicePicks, photoPicks, videoPicks]);
 
   const editCount = dirtySlides.size;
 
@@ -709,6 +970,12 @@ export function DeckClient() {
         const picked = voicePicks[`${slide.id}.voice.${idx}`];
         if (picked && picked !== defName) changes.push(`- voice ${idx + 1}: ${defName} → ${picked}`);
       });
+      const photoPicked = photoPicks[slide.id];
+      if (photoPicked && photoPicked !== slide.photo) changes.push(`- photo → ${photoPicked}`);
+      const videoPicked = videoPicks[slide.id];
+      if (videoPicked && videoPicked.src !== slide.inlineVideo?.src) {
+        changes.push(`- video → ${videoPicked.src} (poster: ${videoPicked.poster || 'none'})`);
+      }
       if (changes.length) {
         any = true;
         lines.push(`## Slide ${i + 1} — ${slide.id} (${slide.eyebrow})`, ...changes, '');
@@ -716,11 +983,13 @@ export function DeckClient() {
     });
     if (!any) lines.push('_No edits yet — the deck matches deck.ts._');
     setExportText(lines.join('\n'));
-  }, [overrides, voicePicks]);
+  }, [overrides, voicePicks, photoPicks, videoPicks]);
 
   const resetAll = useCallback(() => {
     setOverrides({});
     setVoicePicks({});
+    setPhotoPicks({});
+    setVideoPicks({});
   }, []);
 
   return (
@@ -796,6 +1065,9 @@ export function DeckClient() {
             onVoice={onVoice}
             onResetSlide={onResetSlide}
             isDirty={dirtySlides.has(slide.id)}
+            photoSrc={getPhoto(slide)}
+            onSwapPhoto={() => openPicker(slide.id, 'image')}
+            onSwapVideo={() => openPicker(slide.id, 'video')}
           />
         ))}
 
@@ -818,6 +1090,43 @@ export function DeckClient() {
           onClose={() => setPresentIndex(null)}
           getText={getText}
           getVoice={getVoice}
+          getPhoto={getPhoto}
+          getVideo={getVideo}
+        />
+      )}
+
+      {picker !== null && (
+        <MediaPicker
+          kind={picker.kind}
+          items={pickItems}
+          onPick={(item) => {
+            if (picker.kind === 'image') {
+              setPhotoPicks((prev) => ({ ...prev, [picker.slideId]: item.url }));
+            } else {
+              setVideoPicks((prev) => ({
+                ...prev,
+                [picker.slideId]: { src: item.url, poster: item.poster_url ?? '' },
+              }));
+            }
+            setPicker(null);
+          }}
+          onReset={() => {
+            if (picker.kind === 'image') {
+              setPhotoPicks((prev) => {
+                const next = { ...prev };
+                delete next[picker.slideId];
+                return next;
+              });
+            } else {
+              setVideoPicks((prev) => {
+                const next = { ...prev };
+                delete next[picker.slideId];
+                return next;
+              });
+            }
+            setPicker(null);
+          }}
+          onClose={() => setPicker(null)}
         />
       )}
 

--- a/v2/src/app/admin/media-library/curation.ts
+++ b/v2/src/app/admin/media-library/curation.ts
@@ -126,7 +126,10 @@ interface CurationRow {
   storyteller_id: string | null;
   tags: string[] | null;
   media_subtype: string | null;
+  notes?: string | null;
 }
+
+const CI_COLS = 'id, ref, starred, rating, archived_at, canon_slot, consent_tier, community_id, storyteller_id, tags, media_subtype';
 
 interface Curation {
   byRef: Map<string, CurationRow>;
@@ -139,11 +142,16 @@ async function fetchCuration(): Promise<Curation> {
   const empty: Curation = { byRef: new Map(), ready: false, commName: new Map(), personName: new Map() };
   try {
     const supabase = createServiceClient();
-    const [ci, comms, sts] = await Promise.all([
-      supabase.from('content_items').select('id, ref, starred, rating, archived_at, canon_slot, consent_tier, community_id, storyteller_id, tags, media_subtype'),
+    const [ciWithNotes, comms, sts] = await Promise.all([
+      supabase.from('content_items').select(`${CI_COLS}, notes`),
       supabase.from('communities').select('id, name'),
       supabase.from('storytellers').select('id, display_name'),
     ]);
+    // The notes column may not exist yet (ALTER pending): retry without it so
+    // the rest of the curation state still loads.
+    const ci = ciWithNotes.error
+      ? await supabase.from('content_items').select(CI_COLS)
+      : ciWithNotes;
     if (ci.error) return empty;
     const byRef = new Map<string, CurationRow>();
     for (const r of (ci.data ?? []) as CurationRow[]) byRef.set(r.ref, r);
@@ -174,6 +182,7 @@ function makeAttach(curation: Curation): (base: UnifiedItem, ref: string) => Uni
       community: c?.community_id ? commName.get(c.community_id) : undefined,
       person: c?.storyteller_id ? personName.get(c.storyteller_id) : undefined,
       mediaSubtype: c?.media_subtype ?? base.mediaSubtype,
+      notes: c?.notes ?? null,
       tags,
       theme: themeForItem({ area: base.area, canonSlot: canonSlot ?? null, tags }) ?? undefined,
     };

--- a/v2/src/app/admin/media-library/library-client.tsx
+++ b/v2/src/app/admin/media-library/library-client.tsx
@@ -27,6 +27,8 @@ export interface UnifiedItem {
   mediaType?: 'image' | 'video';
   /** e.g. 'overlay' | 'portrait' | 'render' — from content_items.media_subtype. */
   mediaSubtype?: string;
+  /** Free-form curation notes (content_items.notes). */
+  notes?: string | null;
   /** Poster/thumbnail image url for a video tile. */
   poster?: string;
   /** Community this asset belongs to (content_items.community_id → communities.name). */
@@ -171,6 +173,11 @@ export function MediaLibraryClient({
   const updateItemTags = useCallback((id: string, tags: string[]) => {
     setItems((prev) => prev.map((it) => (it.id === id ? { ...it, tags } : it)));
     setActive((cur) => (cur && cur.id === id ? { ...cur, tags } : cur));
+  }, []);
+
+  const updateItemNotes = useCallback((id: string, notes: string | null) => {
+    setItems((prev) => prev.map((it) => (it.id === id ? { ...it, notes } : it)));
+    setActive((cur) => (cur && cur.id === id ? { ...cur, notes } : cur));
   }, []);
 
   // --- curation write: optimistic, reverts on API failure --------------------
@@ -868,6 +875,11 @@ export function MediaLibraryClient({
                     canon
                   </span>
                 )}
+                {it.notes && (
+                  <span className="pointer-events-none absolute bottom-8 right-1.5 rounded-full bg-amber-500 text-white px-1.5 py-0.5 text-[9px] font-semibold" title={it.notes}>
+                    ✎
+                  </span>
+                )}
                 {it.aliases && it.aliases.length > 0 && (
                   <span
                     className="pointer-events-none absolute top-1.5 right-9 rounded-full bg-blue-100 text-blue-700 px-1.5 py-0.5 text-[9px] font-semibold"
@@ -895,6 +907,7 @@ export function MediaLibraryClient({
           roster={roster}
           onClose={() => setActive(null)}
           onSaveTags={updateItemTags}
+          onSaveNotes={updateItemNotes}
           onToggleStar={toggleStar}
           onToggleArchive={toggleArchive}
           onSetRating={setRating}
@@ -924,6 +937,7 @@ function PreviewModal({
   roster,
   onClose,
   onSaveTags,
+  onSaveNotes,
   onToggleStar,
   onToggleArchive,
   onSetRating,
@@ -934,6 +948,7 @@ function PreviewModal({
   roster: RosterPerson[];
   onClose: () => void;
   onSaveTags: (id: string, tags: string[]) => void;
+  onSaveNotes: (id: string, notes: string | null) => void;
   onToggleStar: (it: UnifiedItem) => void;
   onToggleArchive: (it: UnifiedItem) => void;
   onSetRating: (it: UnifiedItem, r: number) => void;
@@ -952,6 +967,13 @@ function PreviewModal({
   const [saveState, setSaveState] = useState<SaveState>('idle');
   const [saveError, setSaveError] = useState('');
 
+  // Notes editor state. Seeded from the item; kept local so a failed save
+  // doesn't wipe what was typed.
+  const [draftNotes, setDraftNotes] = useState(item.notes ?? '');
+  const [notesState, setNotesState] = useState<SaveState>('idle');
+  const [notesError, setNotesError] = useState('');
+  const [notesColPending, setNotesColPending] = useState(false);
+
   // Re-seed if a different item opens in the same modal instance.
   useEffect(() => {
     setDraftTags(item.tags);
@@ -959,6 +981,17 @@ function PreviewModal({
     setSaveState('idle');
     setSaveError('');
   }, [item.id, item.tags]);
+
+  const itemNotes = item.notes ?? '';
+  useEffect(() => {
+    setDraftNotes(itemNotes);
+    setNotesState('idle');
+    setNotesError('');
+    setNotesColPending(false);
+    // Seed only when a different item opens; item.notes changes from our own
+    // optimistic save must not clobber the draft.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [item.id]);
 
   const addTag = useCallback((raw: string) => {
     const t = raw.trim();
@@ -1002,6 +1035,38 @@ function PreviewModal({
       setSaveError(e instanceof Error ? e.message : String(e));
     }
   }, [item.contentId, item.id, draftTags, onSaveTags]);
+
+  // Notes save: optimistic (grid badge + state update immediately), reverts on
+  // API failure. Same {ids:[...]} body shape as the other curation writes.
+  const saveNotes = useCallback(async () => {
+    if (!item.contentId) {
+      setNotesState('error');
+      setNotesError('Not indexed yet. Run npm run content:index first.');
+      return;
+    }
+    const prev = item.notes ?? null;
+    const next = draftNotes.trim() === '' ? null : draftNotes;
+    setNotesState('saving');
+    setNotesError('');
+    setNotesColPending(false);
+    onSaveNotes(item.id, next); // optimistic
+    try {
+      const res = await fetch('/api/admin/content-item', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: [item.contentId], notes: next ?? '' }),
+      });
+      const data = (await res.json()) as { ok: boolean; error?: string };
+      if (!res.ok || !data.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setNotesState('saved');
+    } catch (e) {
+      onSaveNotes(item.id, prev); // revert
+      const msg = e instanceof Error ? e.message : String(e);
+      setNotesState('error');
+      setNotesError(msg);
+      if (/column|schema cache|42703/i.test(msg)) setNotesColPending(true);
+    }
+  }, [item.contentId, item.id, item.notes, draftNotes, onSaveNotes]);
 
   const copy = useCallback(async (text: string) => {
     try {
@@ -1165,6 +1230,39 @@ function PreviewModal({
             isWebsite && !curationReady && (
               <p className="mb-5 text-[11px] text-amber-700">Run the content index to star / rate / archive this image.</p>
             )
+          )}
+
+          {/* Notes (content_items.notes) — any indexed item */}
+          {canCurate && (
+            <div className="mb-5">
+              <p className="text-[10px] uppercase tracking-widest text-muted-foreground mb-2">
+                Notes
+              </p>
+              <textarea
+                value={draftNotes}
+                onChange={(e) => { setDraftNotes(e.target.value); setNotesState('idle'); }}
+                rows={3}
+                placeholder="Why it's a keeper, what to fix, where it's used…"
+                className="w-full rounded-lg border border-input bg-background px-2.5 py-1.5 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+              <button
+                type="button"
+                onClick={saveNotes}
+                disabled={notesState === 'saving'}
+                className="mt-1.5 w-full rounded-lg bg-foreground text-background px-3 py-2 text-sm font-semibold hover:opacity-90 transition disabled:opacity-50"
+              >
+                {notesState === 'saving' ? 'Saving…' : 'Save notes'}
+              </button>
+              <p className="mt-1.5 text-[11px] min-h-[1rem]" aria-live="polite">
+                {notesState === 'saved' && <span className="text-green-600">✓ Saved</span>}
+                {notesState === 'error' && (
+                  <span className="text-red-600">Error: {notesError}</span>
+                )}
+                {notesColPending && (
+                  <span className="block text-muted-foreground">Notes column pending: run the ALTER in Supabase SQL editor</span>
+                )}
+              </p>
+            </div>
           )}
 
           {item.aliases && item.aliases.length > 0 && (

--- a/v2/src/app/admin/story-atlas/atlas-client.tsx
+++ b/v2/src/app/admin/story-atlas/atlas-client.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+// Storyteller Atlas roster grid: client-side filtering (tier, community, name
+// search) over the server-rendered registry data. Internal admin surface, so
+// hold-tier voices and hold-status quotes ARE shown, clearly badged.
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import type { StorytellerRecord, VoiceTier } from '@/lib/data/storyteller-registry';
+
+/** Registry record annotated server-side with its atlas place bucket. */
+export type AtlasRecord = StorytellerRecord & { place: string };
+
+const DISPLAY_FONT = { fontFamily: 'var(--font-display, Georgia, serif)' } as const;
+
+const TIER_BADGE: Record<VoiceTier, { label: string; cls: string }> = {
+  external: { label: 'external cleared', cls: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
+  website: { label: 'website only', cls: 'bg-amber-50 text-amber-800 border-amber-200' },
+  funder: { label: 'funder only', cls: 'bg-indigo-50 text-indigo-700 border-indigo-200' },
+  hold: { label: 'HOLD, never external', cls: 'bg-red-50 text-red-700 border-red-200' },
+  pending: { label: 'pending confirmation', cls: 'bg-orange-50 text-orange-700 border-orange-200' },
+  internal: { label: 'internal', cls: 'bg-gray-100 text-gray-600 border-gray-200' },
+};
+
+const QUOTE_STATUS_BADGE: Record<'primary' | 'approved' | 'hold', { label: string; cls: string }> = {
+  primary: { label: 'primary', cls: 'bg-emerald-50 text-emerald-700 border-emerald-200' },
+  approved: { label: 'approved', cls: 'bg-gray-100 text-gray-600 border-gray-200' },
+  hold: { label: 'HOLD', cls: 'bg-red-100 text-red-700 border-red-200' },
+};
+
+const TIER_OPTIONS: Array<'all' | VoiceTier> = [
+  'all',
+  'external',
+  'website',
+  'funder',
+  'hold',
+  'pending',
+  'internal',
+];
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+function StorytellerCard({ rec }: { rec: AtlasRecord }) {
+  const tier = TIER_BADGE[rec.tier];
+  return (
+    <article className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-start gap-3">
+        {rec.portrait ? (
+          <Image
+            src={rec.portrait}
+            alt={rec.name}
+            width={64}
+            height={64}
+            className="h-16 w-16 shrink-0 rounded-full object-cover"
+          />
+        ) : (
+          <div
+            className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full bg-muted text-lg font-semibold text-muted-foreground"
+            aria-hidden="true"
+          >
+            {initials(rec.name)}
+          </div>
+        )}
+        <div className="min-w-0">
+          <h3 className="text-lg leading-snug text-foreground" style={DISPLAY_FONT}>
+            {rec.name}
+          </h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">{rec.role}</p>
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            <span
+              className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${tier.cls}`}
+            >
+              {tier.label}
+            </span>
+            <span className="inline-flex items-center rounded-full border border-border bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+              {rec.community}
+            </span>
+            {rec.practitioner ? (
+              <span className="inline-flex items-center rounded-full border border-border bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+                practitioner
+              </span>
+            ) : null}
+            {rec.turns ? (
+              <span className="inline-flex items-center rounded-full border border-border bg-background px-2 py-0.5 text-[11px] text-muted-foreground">
+                turns: {rec.turns}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {rec.quotes.length > 0 ? (
+        <ul className="mt-3 space-y-2.5">
+          {rec.quotes.map((q, i) => {
+            const status = QUOTE_STATUS_BADGE[q.status];
+            return (
+              <li key={i}>
+                <blockquote className="border-l-2 border-border pl-3">
+                  <p className="text-sm leading-relaxed text-foreground">"{q.text}"</p>
+                  <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                    <span
+                      className={`inline-flex items-center rounded-full border px-1.5 py-px text-[10px] font-medium ${status.cls}`}
+                    >
+                      {status.label}
+                    </span>
+                    <span className="text-[11px] text-muted-foreground">{q.context}</span>
+                  </div>
+                </blockquote>
+              </li>
+            );
+          })}
+        </ul>
+      ) : rec.narratedBy ? (
+        <p className="mt-3 text-xs text-muted-foreground">
+          No direct quotes by design: story narrated by {rec.narratedBy}.
+        </p>
+      ) : (
+        <p className="mt-3 text-xs text-muted-foreground">No quotes on record.</p>
+      )}
+
+      {/* Provenance: the registry carries no transcript/source field yet, so we
+          render a neutral registry label. A transcriptSource field is pending
+          (wiki storyteller provenance model). Do not invent transcript links. */}
+      <p className="mt-3 text-[10px] uppercase tracking-wide text-muted-foreground/80">
+        provenance: registry
+      </p>
+    </article>
+  );
+}
+
+export default function AtlasClient({
+  records,
+  placeOrder,
+}: {
+  records: AtlasRecord[];
+  placeOrder: string[];
+}) {
+  const [tier, setTier] = useState<'all' | VoiceTier>('all');
+  const [place, setPlace] = useState<string>('all');
+  const [search, setSearch] = useState('');
+
+  const placesWithVoices = useMemo(
+    () => placeOrder.filter((p) => records.some((r) => r.place === p)),
+    [records, placeOrder],
+  );
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return records.filter((r) => {
+      if (tier !== 'all' && r.tier !== tier) return false;
+      if (place !== 'all' && r.place !== place) return false;
+      if (q) {
+        const hay = [r.name, ...(r.aliases ?? []), r.role, r.community]
+          .join(' ')
+          .toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [records, tier, place, search]);
+
+  const groups = useMemo(
+    () =>
+      placesWithVoices
+        .map((p) => ({ place: p, voices: filtered.filter((r) => r.place === p) }))
+        .filter((g) => g.voices.length > 0),
+    [placesWithVoices, filtered],
+  );
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by name, role, community"
+          className="h-9 w-64 max-w-full rounded-md border border-border bg-background px-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+        />
+        <select
+          value={tier}
+          onChange={(e) => setTier(e.target.value as 'all' | VoiceTier)}
+          className="h-9 rounded-md border border-border bg-background px-2 text-sm text-foreground"
+          aria-label="Filter by consent tier"
+        >
+          {TIER_OPTIONS.map((t) => (
+            <option key={t} value={t}>
+              {t === 'all' ? 'All tiers' : t}
+            </option>
+          ))}
+        </select>
+        <select
+          value={place}
+          onChange={(e) => setPlace(e.target.value)}
+          className="h-9 rounded-md border border-border bg-background px-2 text-sm text-foreground"
+          aria-label="Filter by community"
+        >
+          <option value="all">All communities</option>
+          {placesWithVoices.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <span className="text-xs text-muted-foreground">
+          {filtered.length} of {records.length} voices
+        </span>
+      </div>
+
+      {groups.length === 0 ? (
+        <p className="rounded border border-dashed border-border bg-card p-6 text-center text-sm text-muted-foreground">
+          No voices match the current filters.
+        </p>
+      ) : (
+        groups.map((group) => (
+          <section key={group.place}>
+            <h2
+              className="mb-3 flex items-baseline gap-2 text-xl text-foreground"
+              style={DISPLAY_FONT}
+            >
+              {group.place}
+              <span className="text-sm text-muted-foreground">
+                {group.voices.length} {group.voices.length === 1 ? 'voice' : 'voices'}
+              </span>
+            </h2>
+            <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 2xl:grid-cols-3">
+              {group.voices.map((rec) => (
+                <StorytellerCard key={rec.slug} rec={rec} />
+              ))}
+            </div>
+          </section>
+        ))
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        Curate quote cards at{' '}
+        <Link href="/admin/quote-cards" className="text-primary hover:underline">
+          /admin/quote-cards
+        </Link>{' '}
+        and manage Empathy Ledger storytellers at{' '}
+        <Link href="/admin/el-storytellers" className="text-primary hover:underline">
+          /admin/el-storytellers
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}

--- a/v2/src/app/admin/story-atlas/page.tsx
+++ b/v2/src/app/admin/story-atlas/page.tsx
@@ -1,0 +1,237 @@
+// Storyteller Atlas: every voice in the canonical registry on one screen.
+// Thematic header maps the six belief turns of the signed narrative
+// (wiki/outputs/2026-07-11-narrative-foundation.md) to the voices that carry
+// them, the communities those voices come from, and a grounding metric on a
+// live page. Body is the full roster grouped by community, with consent tiers,
+// all blessed AND held quotes (badged), and provenance labels.
+//
+// Data source: v2/src/lib/data/storyteller-registry.ts only. Canonical metrics
+// imported from asset-canonical.ts, never hardcoded.
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
+import {
+  STORYTELLER_REGISTRY,
+  type StorytellerRecord,
+} from '@/lib/data/storyteller-registry';
+import AtlasClient, { type AtlasRecord } from './atlas-client';
+
+export const metadata: Metadata = {
+  title: 'Storyteller Atlas · Goods admin',
+  robots: { index: false, follow: false },
+};
+
+const DISPLAY_FONT = { fontFamily: 'var(--font-display, Georgia, serif)' } as const;
+
+// ── Community grouping ───────────────────────────────────────────────────────
+// Registry `community` strings are free text ("Alice Springs / Utopia",
+// "Arlparra (Utopia Homelands)"), so we bucket them into the atlas place
+// groups. Utopia checks run before Alice Springs so the Oonchiumpa
+// "Alice Springs / Utopia" records land with the Utopia group, matching the
+// registry's own section grouping. No Maningrida voices exist in the registry
+// today; the bucket renders only when it has voices.
+const PLACE_ORDER = [
+  'Tennant Creek',
+  'Utopia / Arlparra',
+  'Palm Island',
+  'Alice Springs',
+  'Kalgoorlie',
+  'Maningrida',
+  'Mount Isa',
+  'Darwin',
+  'Other',
+] as const;
+
+function placeFor(rec: StorytellerRecord): string {
+  const c = rec.community.toLowerCase();
+  if (c.includes('tennant')) return 'Tennant Creek';
+  if (c.includes('utopia') || c.includes('arlparra') || c.includes('ampilatwatja'))
+    return 'Utopia / Arlparra';
+  if (c.includes('palm')) return 'Palm Island';
+  if (c.includes('alice')) return 'Alice Springs';
+  if (c.includes('kalgoorlie')) return 'Kalgoorlie';
+  if (c.includes('maningrida')) return 'Maningrida';
+  if (c.includes('mount isa')) return 'Mount Isa';
+  if (c.includes('darwin')) return 'Darwin';
+  return 'Other';
+}
+
+// ── Turn analysis ────────────────────────────────────────────────────────────
+// The registry has no structured per-turn array; each record carries a
+// free-text `turns` field ("3, 5 → scale", "strengthens 1, 5"). We count a
+// voice as carrying turn N when the digit N appears anywhere in that string
+// (core and "strengthens" mentions both count).
+function turnNumbers(rec: StorytellerRecord): number[] {
+  if (!rec.turns) return [];
+  return Array.from(new Set((rec.turns.match(/[1-6]/g) ?? []).map(Number)));
+}
+
+interface TurnTheme {
+  n: number;
+  title: string;
+  metricLabel: string;
+  metricHref: string;
+}
+
+const nf = new Intl.NumberFormat('en-AU');
+
+const TURN_THEMES: TurnTheme[] = [
+  {
+    n: 1,
+    title: 'The need is real, people name it themselves',
+    metricLabel: 'Cost story: the need',
+    metricHref: '/cost-story',
+  },
+  {
+    n: 2,
+    title: 'The existing supply fails these places',
+    metricLabel: 'Cost story: supply failure',
+    metricHref: '/cost-story',
+  },
+  {
+    n: 3,
+    title: 'The products work because community designed them',
+    metricLabel: `${nf.format(CANONICAL_ASSETS.bedsDeployed)} beds · ${nf.format(CANONICAL_ASSETS.washersInCommunity)} washers`,
+    metricHref: '/register',
+  },
+  {
+    n: 4,
+    title: 'The making belongs in community hands',
+    metricLabel: 'Utopia build, May 2026',
+    metricHref: '/field-notes/utopia-may-2026',
+  },
+  {
+    n: 5,
+    title: 'The plant makes the pattern transferable; ownership is the promise',
+    metricLabel: `${nf.format(CANONICAL_ASSETS.communitiesServed)} communities served`,
+    metricHref: '/impact',
+  },
+  {
+    n: 6,
+    title: 'What the capital does',
+    metricLabel: 'AU$400K ask',
+    metricHref: '/pitch/deck',
+  },
+];
+
+export default function StoryAtlasPage() {
+  const records: AtlasRecord[] = STORYTELLER_REGISTRY.map((rec) => ({
+    ...rec,
+    place: placeFor(rec),
+  }));
+
+  const totalVoices = records.length;
+  const externalCleared = records.filter((r) => r.tier === 'external').length;
+  // Communities represented: distinct place buckets among community voices
+  // (funder and internal records are not community voices). "Other" bucket
+  // voices count by their raw community string (Katherine, NT-wide, East
+  // Arnhem) so distinct places are not collapsed into one.
+  const communityPlaces = new Set(
+    records
+      .filter((r) => r.tier !== 'funder' && r.tier !== 'internal')
+      .map((r) => (r.place === 'Other' ? r.community : r.place)),
+  );
+
+  const turnCards = TURN_THEMES.map((theme) => {
+    const voices = records.filter((r) => turnNumbers(r).includes(theme.n));
+    const places = Array.from(
+      new Set(voices.map((r) => (r.place === 'Other' ? r.community : r.place))),
+    );
+    return { ...theme, voiceCount: voices.length, places };
+  });
+
+  return (
+    <div className="space-y-8 p-6 pb-16">
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl text-foreground" style={DISPLAY_FONT}>
+            Storyteller Atlas
+          </h1>
+          <p className="mt-1 max-w-prose text-sm text-muted-foreground">
+            Every voice in the canonical registry on one screen: who they are, where they speak
+            from, which belief turns they carry, and every blessed or held quote. Internal admin
+            surface: holds are shown and clearly marked, never for external use.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center rounded-full border border-border bg-card px-3 py-1 text-xs text-foreground">
+            <span className="font-bold">{totalVoices}</span>&nbsp;voices
+          </span>
+          <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs text-emerald-700">
+            <span className="font-bold">{externalCleared}</span>&nbsp;external cleared
+          </span>
+          <span className="inline-flex items-center rounded-full border border-border bg-card px-3 py-1 text-xs text-foreground">
+            <span className="font-bold">{communityPlaces.size}</span>&nbsp;communities
+          </span>
+          <Link
+            href="/admin/quote-cards"
+            className="inline-flex items-center rounded-full border border-border bg-card px-3 py-1 text-xs text-primary hover:underline"
+          >
+            Quote cards
+          </Link>
+          <Link
+            href="/admin/el-storytellers"
+            className="inline-flex items-center rounded-full border border-border bg-card px-3 py-1 text-xs text-primary hover:underline"
+          >
+            EL storytellers
+          </Link>
+        </div>
+      </header>
+
+      <section aria-labelledby="themes-heading">
+        <h2 id="themes-heading" className="text-xl text-foreground" style={DISPLAY_FONT}>
+          The themes
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The six belief turns of the signed narrative, with the voices and places that carry each
+          one, grounded in a live number.
+        </p>
+        <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {turnCards.map((card) => (
+            <div key={card.n} className="rounded-lg border border-border bg-card p-4">
+              <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                Turn {card.n}
+              </p>
+              <h3 className="mt-1 text-base leading-snug text-foreground" style={DISPLAY_FONT}>
+                {card.title}
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                <span className="font-bold text-foreground">{card.voiceCount}</span>{' '}
+                {card.voiceCount === 1 ? 'voice carries' : 'voices carry'} this turn
+              </p>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {card.places.length > 0 ? (
+                  card.places.map((p) => (
+                    <span
+                      key={p}
+                      className="inline-flex items-center rounded-full border border-border bg-background px-2 py-0.5 text-[11px] text-muted-foreground"
+                    >
+                      {p}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-[11px] text-muted-foreground">
+                    No voice mapped to this turn yet
+                  </span>
+                )}
+              </div>
+              <div className="mt-3">
+                <Link
+                  href={card.metricHref}
+                  className="inline-flex items-center rounded-full border border-border bg-background px-2.5 py-1 text-xs font-medium text-primary hover:underline"
+                >
+                  {card.metricLabel}
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section aria-label="Storyteller roster">
+        <AtlasClient records={records} placeOrder={[...PLACE_ORDER]} />
+      </section>
+    </div>
+  );
+}

--- a/v2/src/app/api/admin/content-item/route.ts
+++ b/v2/src/app/api/admin/content-item/route.ts
@@ -21,6 +21,8 @@ interface Body {
   tags?: string[];
   consent_tier?: 'public' | 'gated' | 'red';
   community_id?: string | null;
+  /** Free-text curation note (nullable text column; cap 2000 chars). */
+  notes?: string | null;
 }
 
 export async function POST(request: NextRequest) {
@@ -60,6 +62,15 @@ export async function POST(request: NextRequest) {
   // Community tag: a uuid FK to communities.id, or null to clear.
   if ('community_id' in body) {
     patch.community_id = body.community_id ? String(body.community_id) : null;
+  }
+  // Curation note: free text or null to clear. Requires the nullable `notes`
+  // column (ALTER TABLE content_items ADD COLUMN IF NOT EXISTS notes text).
+  if ('notes' in body) {
+    if (body.notes !== null && typeof body.notes !== 'string') {
+      return NextResponse.json({ ok: false, error: 'notes must be a string or null' }, { status: 400 });
+    }
+    const trimmed = body.notes === null ? '' : body.notes.trim();
+    patch.notes = trimmed ? trimmed.slice(0, 2000) : null;
   }
 
   if (Object.keys(patch).length === 0) {

--- a/v2/src/app/api/admin/media-pick/route.ts
+++ b/v2/src/app/api/admin/media-pick/route.ts
@@ -1,0 +1,50 @@
+// Media picker feed — the swap widget's data source.
+// Returns LOCAL (repo-committed, web-served) images and videos from
+// content_items, starred first, for the deck builder's photo/video swap
+// picker. Local-only on purpose: anything picked here can be committed
+// straight into deck.ts and will render on the public site. EL media needs
+// its own consent path and is deliberately excluded from this feed.
+//
+// SECURITY: the middleware only guards /admin PAGES, not /api/admin/* routes,
+// so this route MUST self-authorise (same pattern as content-item).
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase/server';
+import { requireAdmin } from '@/lib/auth/admin';
+
+export const runtime = 'nodejs';
+
+export interface MediaPickItem {
+  id: string;
+  url: string;
+  poster_url: string | null;
+  media_type: 'image' | 'video';
+  area: string | null;
+  starred: boolean;
+  tags: string[];
+}
+
+export async function GET(request: NextRequest) {
+  const guard = await requireAdmin(request);
+  if (guard) return guard;
+
+  const kind = request.nextUrl.searchParams.get('kind'); // 'image' | 'video' | null (both)
+
+  const supabase = createServiceClient();
+  let query = supabase
+    .from('content_items')
+    .select('id,url,poster_url,media_type,area,starred,tags')
+    .eq('source', 'local')
+    .is('archived_at', null)
+    .like('url', '/%')
+    .order('starred', { ascending: false })
+    .order('updated_at', { ascending: false })
+    .limit(800);
+  if (kind === 'image' || kind === 'video') query = query.eq('media_type', kind);
+
+  const { data, error } = await query;
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true, items: (data ?? []) as MediaPickItem[] });
+}


### PR DESCRIPTION
Three admin surfaces, one system, per Ben's spec:

1. **Media workbench** (/admin/media-library): per-item notes/comments with save + amber badge on noted tiles, alongside the existing star/tag/community/consent filters. Pre-ALTER safe; needs one paste in Supabase SQL editor: `ALTER TABLE content_items ADD COLUMN IF NOT EXISTS notes text;`
2. **Swap widget** (/admin/deck-builder): Swap photo / Swap video on every slide from a searchable picker over all committed media (starred first, area filters), persisted like text edits and included in Export edits; Present renders picks live. Voice swap pool widened to every externally-cleared storyteller.
3. **Story atlas** (/admin/story-atlas): all storytellers with portraits, communities, tier badges, quotes + status underneath, provenance labels; thematic header = the six turns with voice counts, community chips and canonical metric links.

All admin-auth surfaces; no public pages touched. Build exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)