### PR TITLE
Provenance: the storyteller transcript model, in code and on the atlas

### DIFF
--- a/v2/src/app/admin/story-atlas/atlas-client.tsx
+++ b/v2/src/app/admin/story-atlas/atlas-client.tsx
@@ -8,9 +8,45 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import type { StorytellerRecord, VoiceTier } from '@/lib/data/storyteller-registry';
+import {
+  getProvenance,
+  provenanceLabel,
+  releaseStateLabel,
+  type ProvenanceKind,
+} from '@/lib/data/transcript-provenance';
 
 /** Registry record annotated server-side with its atlas place bucket. */
 export type AtlasRecord = StorytellerRecord & { place: string };
+
+// Provenance kind buckets for the filter. The provenance module is metadata
+// only (counts, dates, release states); no transcript text exists in it and
+// none is ever rendered here.
+export type ProvenanceGroup = 'transcript-backed' | 'trip-notes' | 'curated' | 'other';
+
+export function provenanceGroup(kind: ProvenanceKind): ProvenanceGroup {
+  if (kind === 'el-transcript' || kind === 'ben-provided-transcript') return 'transcript-backed';
+  if (kind === 'trip-notes') return 'trip-notes';
+  if (kind === 'curated') return 'curated';
+  return 'other';
+}
+
+const PROVENANCE_BADGE: Record<ProvenanceKind, string> = {
+  'el-transcript': 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  'ben-provided-transcript': 'bg-green-50 text-green-700 border-green-200',
+  'trip-notes': 'bg-sky-50 text-sky-700 border-sky-200',
+  'funder-pack': 'bg-gray-100 text-gray-600 border-gray-200',
+  narrated: 'bg-gray-50 text-gray-500 border-gray-200 italic',
+  'content-hardcoded': 'bg-amber-50 text-amber-800 border-amber-200',
+  curated: 'bg-amber-50 text-amber-800 border-amber-200',
+};
+
+const PROVENANCE_FILTER_OPTIONS: Array<{ value: 'all' | ProvenanceGroup; label: string }> = [
+  { value: 'all', label: 'All provenance' },
+  { value: 'transcript-backed', label: 'Transcript-backed' },
+  { value: 'trip-notes', label: 'Trip notes' },
+  { value: 'curated', label: 'Curated, no primary source' },
+  { value: 'other', label: 'Other (funder pack, hardcoded, narrated)' },
+];
 
 const DISPLAY_FONT = { fontFamily: 'var(--font-display, Georgia, serif)' } as const;
 
@@ -50,6 +86,7 @@ function initials(name: string): string {
 
 function StorytellerCard({ rec }: { rec: AtlasRecord }) {
   const tier = TIER_BADGE[rec.tier];
+  const prov = getProvenance(rec.name);
   return (
     <article className="rounded-lg border border-border bg-card p-4">
       <div className="flex items-start gap-3">
@@ -126,12 +163,32 @@ function StorytellerCard({ rec }: { rec: AtlasRecord }) {
         <p className="mt-3 text-xs text-muted-foreground">No quotes on record.</p>
       )}
 
-      {/* Provenance: the registry carries no transcript/source field yet, so we
-          render a neutral registry label. A transcriptSource field is pending
-          (wiki storyteller provenance model). Do not invent transcript links. */}
-      <p className="mt-3 text-[10px] uppercase tracking-wide text-muted-foreground/80">
-        provenance: registry
-      </p>
+      {/* Provenance from transcript-provenance.ts (keyed by registry name).
+          Metadata only: kind, counts, dates, EL release state. Transcript text
+          never enters this repo and is never rendered. */}
+      <div className="mt-3 space-y-1">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span
+            className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${PROVENANCE_BADGE[prov.kind]}`}
+          >
+            {provenanceLabel(prov)}
+          </span>
+          {prov.inQuoteAnalysis ? (
+            <span className="inline-flex items-center rounded-full border border-border bg-background px-1.5 py-px text-[10px] text-muted-foreground">
+              in the 6-turn quote analysis (local)
+            </span>
+          ) : null}
+        </div>
+        {prov.recordingDates?.length || prov.releaseState || prov.note ? (
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            {prov.recordingDates?.length ? (
+              <span>Recorded {prov.recordingDates.join(' · ')}. </span>
+            ) : null}
+            {prov.releaseState ? <span>EL: {releaseStateLabel(prov.releaseState)}. </span> : null}
+            {prov.note ? <span>{prov.note}</span> : null}
+          </p>
+        ) : null}
+      </div>
     </article>
   );
 }
@@ -145,6 +202,7 @@ export default function AtlasClient({
 }) {
   const [tier, setTier] = useState<'all' | VoiceTier>('all');
   const [place, setPlace] = useState<string>('all');
+  const [prov, setProv] = useState<'all' | ProvenanceGroup>('all');
   const [search, setSearch] = useState('');
 
   const placesWithVoices = useMemo(
@@ -157,6 +215,7 @@ export default function AtlasClient({
     return records.filter((r) => {
       if (tier !== 'all' && r.tier !== tier) return false;
       if (place !== 'all' && r.place !== place) return false;
+      if (prov !== 'all' && provenanceGroup(getProvenance(r.name).kind) !== prov) return false;
       if (q) {
         const hay = [r.name, ...(r.aliases ?? []), r.role, r.community]
           .join(' ')
@@ -165,7 +224,7 @@ export default function AtlasClient({
       }
       return true;
     });
-  }, [records, tier, place, search]);
+  }, [records, tier, place, prov, search]);
 
   const groups = useMemo(
     () =>
@@ -207,6 +266,18 @@ export default function AtlasClient({
           {placesWithVoices.map((p) => (
             <option key={p} value={p}>
               {p}
+            </option>
+          ))}
+        </select>
+        <select
+          value={prov}
+          onChange={(e) => setProv(e.target.value as 'all' | ProvenanceGroup)}
+          className="h-9 rounded-md border border-border bg-background px-2 text-sm text-foreground"
+          aria-label="Filter by transcript provenance"
+        >
+          {PROVENANCE_FILTER_OPTIONS.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
             </option>
           ))}
         </select>

--- a/v2/src/app/admin/story-atlas/page.tsx
+++ b/v2/src/app/admin/story-atlas/page.tsx
@@ -5,7 +5,9 @@
 // live page. Body is the full roster grouped by community, with consent tiers,
 // all blessed AND held quotes (badged), and provenance labels.
 //
-// Data source: v2/src/lib/data/storyteller-registry.ts only. Canonical metrics
+// Data sources: v2/src/lib/data/storyteller-registry.ts (voices, quotes, tiers)
+// and v2/src/lib/data/transcript-provenance.ts (transcript metadata only, keyed
+// by registry name; no transcript text exists there or here). Canonical metrics
 // imported from asset-canonical.ts, never hardcoded.
 
 import type { Metadata } from 'next';
@@ -15,6 +17,14 @@ import {
   STORYTELLER_REGISTRY,
   type StorytellerRecord,
 } from '@/lib/data/storyteller-registry';
+import {
+  getProvenance,
+  provenanceLabel,
+  releaseStateLabel,
+  PROVENANCE_ASOF,
+  PROVENANCE_SOURCE,
+  UNREGISTERED_TRANSCRIPTS,
+} from '@/lib/data/transcript-provenance';
 import AtlasClient, { type AtlasRecord } from './atlas-client';
 
 export const metadata: Metadata = {
@@ -141,6 +151,18 @@ export default function StoryAtlasPage() {
     return { ...theme, voiceCount: voices.length, places };
   });
 
+  // Provenance summary over the whole roster (metadata only; grouping mirrors
+  // provenanceGroup() in atlas-client.tsx, kept local because client-module
+  // functions cannot be called from a server component).
+  const provKinds = records.map((r) => getProvenance(r.name).kind);
+  const transcriptBacked = provKinds.filter(
+    (k) => k === 'el-transcript' || k === 'ben-provided-transcript',
+  ).length;
+  const tripNotes = provKinds.filter((k) => k === 'trip-notes').length;
+  const curatedNoSource = provKinds.filter((k) => k === 'curated').length;
+
+  const unregistered = Object.entries(UNREGISTERED_TRANSCRIPTS);
+
   return (
     <div className="space-y-8 p-6 pb-16">
       <header className="flex flex-wrap items-start justify-between gap-4">
@@ -178,6 +200,46 @@ export default function StoryAtlasPage() {
           </Link>
         </div>
       </header>
+
+      <section aria-label="Provenance summary" className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs text-emerald-700">
+            <span className="font-bold">{transcriptBacked}</span>&nbsp;transcript-backed
+          </span>
+          <span className="inline-flex items-center rounded-full border border-sky-200 bg-sky-50 px-3 py-1 text-xs text-sky-700">
+            <span className="font-bold">{tripNotes}</span>&nbsp;trip notes
+          </span>
+          <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs text-amber-800">
+            <span className="font-bold">{curatedNoSource}</span>&nbsp;curated, no primary source
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Provenance as of {PROVENANCE_ASOF}: {PROVENANCE_SOURCE}
+        </p>
+        {unregistered.length > 0 ? (
+          <div className="max-w-md rounded-lg border border-border bg-card p-3">
+            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+              Not yet in the registry
+            </p>
+            {unregistered.map(([name, p]) => (
+              <div key={name} className="mt-1.5">
+                <p className="text-sm text-foreground" style={DISPLAY_FONT}>
+                  {name}
+                  <span className="ml-2 align-middle text-xs font-normal text-muted-foreground">
+                    transcript on file, not yet in the registry
+                  </span>
+                </p>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">
+                  {provenanceLabel(p)}
+                  {p.recordingDates?.length ? `. Recorded ${p.recordingDates.join(' · ')}` : ''}
+                  {p.releaseState ? `. EL: ${releaseStateLabel(p.releaseState)}` : ''}
+                  {p.note ? `. ${p.note}` : ''}
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </section>
 
       <section aria-labelledby="themes-heading">
         <h2 id="themes-heading" className="text-xl text-foreground" style={DISPLAY_FONT}>

--- a/v2/src/lib/data/transcript-provenance.ts
+++ b/v2/src/lib/data/transcript-provenance.ts
@@ -1,0 +1,386 @@
+/**
+ * TRANSCRIPT PROVENANCE — where every storyteller's words actually come from.
+ *
+ * This is the code-side home of the storyteller provenance model
+ * (wiki/outputs/2026-07-14-storyteller-provenance-model.md), CORRECTED and
+ * completed on 2026-07-15 from the Empathy Ledger database export
+ * (empathy-ledger-v2/output/goods-evidence/, 2026-07-14): the EL Supabase
+ * holds real transcripts for far more voices than the Notion-only view
+ * found, including the whole Tennant Creek roster the earlier doc marked
+ * "curated, unknown origin".
+ *
+ * METADATA ONLY. Titles, dates, word counts and release states are catalog
+ * facts; transcript TEXT is RED/sacred, lives locally in the EL export and
+ * the gitignored quote-analysis dir, and never enters this repo.
+ *
+ * Release state matters: a transcript EXISTING is not the same as it being
+ * cleared for external use. `releaseState` carries EL's own gate verbatim.
+ */
+
+export type ProvenanceKind =
+  /** A real transcript in the Empathy Ledger database (direct project record). */
+  | 'el-transcript'
+  /** Transcript provided directly by Ben and cleared for analysis (outside EL). */
+  | 'ben-provided-transcript'
+  /** Dated, cleared field-trip notes: real firsthand documentation, not a formal transcript. */
+  | 'trip-notes'
+  /** Traceable to a funder pack document. */
+  | 'funder-pack'
+  /** Hardcoded in website content, bypassing the EL consent pipeline. */
+  | 'content-hardcoded'
+  /** Story carried by another voice by design (e.g. Xavier via Fred Campbell). */
+  | 'narrated'
+  /** Hand-typed curated card; no primary source traced yet. */
+  | 'curated';
+
+export type ElReleaseState =
+  /** Transcript on file; external release not yet reviewed or granted. */
+  | 'blocked_no_review_or_grant'
+  /** Transcript on file; needs cultural and use review before any release. */
+  | 'blocked_cultural_and_use_review'
+  /** Recording on file; analysis itself not yet authorised. */
+  | 'blocked_analysis_not_authorized'
+  /** At least one story published publicly on EL. */
+  | 'public_story';
+
+export interface TranscriptProvenance {
+  kind: ProvenanceKind;
+  /** Distinct EL transcripts on file (duplicates excluded). */
+  transcriptCount?: number;
+  /** Largest single transcript, approximate words. */
+  approxWords?: number;
+  /** Recording dates known from the EL export (YYYY-MM-DD). */
+  recordingDates?: string[];
+  releaseState?: ElReleaseState;
+  /** In the 2026-07-14 six-turn quote re-analysis (local-only TABLE.md; lines promote by hand). */
+  inQuoteAnalysis?: boolean;
+  note?: string;
+}
+
+export const PROVENANCE_ASOF = '2026-07-15';
+export const PROVENANCE_SOURCE =
+  'EL Supabase export 2026-07-14 (goods-evidence inventory; metadata only). Supersedes the Notion-only table in wiki/outputs/2026-07-14-storyteller-provenance-model.md.';
+
+/** Keyed by storyteller-registry `name`. */
+export const TRANSCRIPT_PROVENANCE: Record<string, TranscriptProvenance> = {
+  // Tennant Creek (the earlier doc said zero transcripts here; EL says otherwise)
+  'Dianne Stokes': {
+    kind: 'el-transcript',
+    transcriptCount: 5,
+    approxWords: 2631,
+    recordingDates: ['2025-04-06', '2026-02-16', '2026-04-01'],
+    releaseState: 'public_story',
+    inQuoteAnalysis: true,
+    note: 'Five transcripts incl. the washing machine trip interviews; one story published on EL ("Where the Country Calls Me Home").',
+  },
+  'Norman Frank': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 2262,
+    recordingDates: ['2025-04-06'],
+    releaseState: 'blocked_cultural_and_use_review',
+    inQuoteAnalysis: true,
+    note: 'Transcript is about Wilya Janta housing context; product quotes stay registry-gated.',
+  },
+  'Linda Turner': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 2444,
+    recordingDates: ['2025-04-06'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+  },
+  'Jimmy Frank': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 4269,
+    recordingDates: ['2025-07-07'],
+    releaseState: 'blocked_cultural_and_use_review',
+    inQuoteAnalysis: true,
+  },
+  'Melissa Jackson': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 577,
+    recordingDates: ['2025-06-27'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+  },
+  'Annie Morrison': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 832,
+    recordingDates: ['2025-04-06'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+  },
+  'Brian Russell': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 1380,
+    recordingDates: ['2025-06-27'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+    note: 'Medical disclosure inside the transcript: external use HELD pending Ben.',
+  },
+  'Risilda Hogan': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 713,
+    recordingDates: ['2025-04-06'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+  },
+  'Cliff Plummer': {
+    kind: 'el-transcript',
+    transcriptCount: 2,
+    approxWords: 793,
+    recordingDates: ['2025-04-06'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+    note: 'Practitioner. Medical disclosure inside the transcript: external use HELD pending Ben.',
+  },
+  'Patricia Frank': {
+    kind: 'curated',
+    note: 'No EL transcript in the 2026-07-14 export despite carrying the washing/health thread. Priority gap: record her properly.',
+  },
+
+  // Kalgoorlie / Palm Island / Darwin / Mount Isa (the original 2024-25 research trip)
+  'Gloria Turner': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 1034,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+  },
+  'Chloe': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 1175,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+    note: 'Practitioner.',
+  },
+  'Walter': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 615,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+    note: 'Registry tier is hold: transcript exists, external use is not cleared.',
+  },
+  'Mark': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 389,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+    note: 'Website tier despite a real transcript.',
+  },
+  'Gary': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 5264,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+    note: 'EL files this under the Goods project; the Notion card tagged it "Beyond Shadows". Longest transcript in the corpus. Read before leaning harder on the fire-and-dirt line.',
+  },
+  'Wayne Glenn': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 1023,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+    note: 'Practitioner.',
+  },
+  'Alfred Johnson': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 932,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+  },
+  'Ivy': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 299,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+    note: '"Which Ivy" identity flag still open before print use.',
+  },
+  'Jason': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 817,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+  },
+  'Daniel Patrick Noble': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 1083,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+  },
+  'Carmelita & Colette': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 615,
+    recordingDates: ['2025-01-18'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+  },
+  'Tracy McCartney': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 2916,
+    recordingDates: ['2025-02-02'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+    note: 'Place conflict unresolved; out of the deck table until fixed.',
+  },
+
+  // Alice Springs / Utopia / Oonchiumpa
+  'Shayne Bloomfield': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 3936,
+    releaseState: 'blocked_analysis_not_authorized',
+    note: 'Filed in EL as "Shane Bloomfield". Long recording on file; analysis not yet authorised.',
+  },
+  'Kylie Bloomfield': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 3646,
+    releaseState: 'blocked_analysis_not_authorized',
+    note: 'Recording on file; analysis not yet authorised. Registry lists no usable transcript: this is why.',
+  },
+  'Fred Campbell': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 24,
+    releaseState: 'blocked_analysis_not_authorized',
+    note: 'Only a 24-word community-voices clip in EL; his narrative weight still rests on the curated card. Record him properly.',
+  },
+  'Mykel': {
+    kind: 'ben-provided-transcript',
+    transcriptCount: 1,
+    inQuoteAnalysis: true,
+    note: 'Transcript provided and cleared by Ben (2026-07-14 analysis batch D).',
+  },
+  'Xavier': {
+    kind: 'narrated',
+    note: 'By design: Fred Campbell narrates; consent via Oonchiumpa. Never quoted directly.',
+  },
+  'Katrina Bloomfield': {
+    kind: 'trip-notes',
+    note: 'Raw field-trip note, cleared. Real firsthand documentation, not a formal transcript.',
+  },
+  'Dorrie Jones': {
+    kind: 'trip-notes',
+    note: 'Trip note, Ben-cleared 2026-06-17.',
+  },
+  'Karen Liddle': {
+    kind: 'trip-notes',
+    note: 'Trip note, cleared. EL also holds Oonchiumpa partner lead records (not transcripts).',
+  },
+  'Kristy Bloomfield': {
+    kind: 'curated',
+    note: 'Seven partner lead records in EL (investigation only), no transcript. Record her properly.',
+  },
+  'Ray Nelson': {
+    kind: 'funder-pack',
+    note: 'Traceable to bed GB0-156-96 in a funder pack.',
+  },
+
+  // Practitioners / other
+  'Dr Boe Remenyi': {
+    kind: 'curated',
+    note: 'Practitioner. No primary source traced.',
+  },
+  'Heather Mundo': { kind: 'curated' },
+  'Jessica Allardyce': {
+    kind: 'content-hardcoded',
+    note: 'Bypasses the EL consent pipeline; hold tier, correctly unused.',
+  },
+  'Zelda Hogan': {
+    kind: 'content-hardcoded',
+    note: 'Website tier; never into funder surfaces.',
+  },
+  'Frankie Holmes OAM': { kind: 'trip-notes', note: 'Ampilatwatja trip voice card; full name crediting to confirm.' },
+  'Donald Thompson OAM': { kind: 'trip-notes', note: 'Ampilatwatja trip voice card; full name crediting to confirm.' },
+  'Charley': { kind: 'trip-notes', note: 'Trip voice card.' },
+  'Nicholas Marchesi': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 567,
+    releaseState: 'blocked_analysis_not_authorized',
+  },
+};
+
+/** Voices with EL transcripts who are NOT yet in the storyteller registry. */
+export const UNREGISTERED_TRANSCRIPTS: Record<string, TranscriptProvenance> = {
+  'Ana - Bega': {
+    kind: 'el-transcript',
+    transcriptCount: 1,
+    approxWords: 3054,
+    recordingDates: ['2025-02-02'],
+    releaseState: 'blocked_no_review_or_grant',
+    inQuoteAnalysis: true,
+    note: 'Bega Health practitioner; storyteller profile inactive in EL; not in the registry yet (open item).',
+  },
+};
+
+const DEFAULT_PROVENANCE: TranscriptProvenance = {
+  kind: 'curated',
+  note: 'Not yet mapped in the provenance model.',
+};
+
+export function getProvenance(name: string): TranscriptProvenance {
+  return TRANSCRIPT_PROVENANCE[name] ?? DEFAULT_PROVENANCE;
+}
+
+export function provenanceLabel(p: TranscriptProvenance): string {
+  switch (p.kind) {
+    case 'el-transcript': {
+      const n = p.transcriptCount ?? 1;
+      const w = p.approxWords ? `, ~${p.approxWords.toLocaleString()} words` : '';
+      return `EL transcript${n > 1 ? ` x${n}` : ''}${w}`;
+    }
+    case 'ben-provided-transcript':
+      return 'Transcript, Ben-provided + cleared';
+    case 'trip-notes':
+      return 'Trip notes, cleared';
+    case 'funder-pack':
+      return 'Funder pack, traceable';
+    case 'content-hardcoded':
+      return 'Hardcoded in site content';
+    case 'narrated':
+      return 'Narrated by another voice (by design)';
+    case 'curated':
+      return 'Curated card, no primary source';
+  }
+}
+
+export function releaseStateLabel(s: ElReleaseState): string {
+  switch (s) {
+    case 'blocked_no_review_or_grant':
+      return 'on file, external release not yet granted';
+    case 'blocked_cultural_and_use_review':
+      return 'on file, needs cultural + use review';
+    case 'blocked_analysis_not_authorized':
+      return 'recording on file, analysis not yet authorised';
+    case 'public_story':
+      return 'a story is published on EL';
+  }
+}

--- a/wiki/outputs/2026-07-14-storyteller-provenance-model.md
+++ b/wiki/outputs/2026-07-14-storyteller-provenance-model.md
@@ -1,0 +1,82 @@
+# Storyteller provenance model — where every quote actually comes from
+
+> **SUPERSEDED IN PART, 2026-07-15.** This doc queried the two Notion sources and concluded only
+> 12 people have real transcripts and Tennant Creek has none. The Empathy Ledger DATABASE export
+> of the same day (empathy-ledger-v2/output/goods-evidence/) shows that conclusion was an
+> artifact of where we looked: EL's Supabase holds real transcripts for ~27 named storytellers,
+> INCLUDING the full Tennant Creek roster this table marks "curated, unknown origin" (Dianne
+> Stokes has five; Norman, Linda, Jimmy, Melissa, Annie, Brian, Risilda, Cliff all have one),
+> and Gary's transcript is filed under the GOODS project in EL, not Beyond Shadows. The Notion
+> Storytellers table was the incomplete mirror, not the system of record.
+> The "full model going forward" proposed in the final section NOW EXISTS in code:
+> `v2/src/lib/data/transcript-provenance.ts` (metadata only, keyed by registry name, with EL
+> release states), rendered live on /admin/story-atlas. Still true from this doc: Patricia Frank
+> has no transcript anywhere (priority gap), Fred Campbell has only a 24-word clip, Kristy has
+> lead records but no transcript, and transcripts EXISTING is not the same as external release
+> being granted (every EL transcript sits behind a release gate).
+
+*Built 2026-07-14 by querying the real systems directly (SQL against both Notion data sources), not sampling. This supersedes the 2026-07-13 verification audit's framing of "transcript vs curated card" — that audit checked quote *wording* against whatever source existed; this maps whether a *primary transcript exists at all*, for every person currently carrying the pitch narrative.*
+
+## The honest headline
+
+**Two real data sources exist, and they don't overlap the way the pitch assumes:**
+
+1. **The EL "Storytellers table"** (Empathy Ledger, `Project = "Goods."`) — actual recorded interviews with a transcript in the page body. **Only 12 people, all from the October 2024 – January 2025 research trip: Kalgoorlie, Palm Island, Darwin.** Nobody from Tennant Creek. Nobody from Utopia/Alice Springs/Oonchiumpa.
+2. **The "Goods Storyteller Library"** (34 curated cards) — the thing every quote in the pitch actually gets pulled from. Each card has a `Notes` field that says where it came from. Most say "curated," which turns out to mean very different things person to person.
+
+Cross-referencing the two: **only 10 of the 34 people in active use have a real transcript backing their card.** The rest trace to raw field-trip notes (3 people), a funder pack (1 person), the website's own code with no EL link at all (2 people), or nothing recorded in Notion at all (18 people) — including some of the most load-bearing names in the whole story.
+
+## Full table — every active voice, its real source
+
+| Voice | Community (as used) | Real EL transcript? | Actual source (per Notion's own Notes field) | Flag |
+|---|---|---|---|---|
+| Alfred Johnson | Palm Island | ✅ Yes (2024-12-08) | EL transcript | — |
+| Carmelita & Colette | Palm Island | ✅ Yes (2024-12-12) | EL transcript | — |
+| Chloe | Kalgoorlie | ✅ Yes (2024-10-13) | EL transcript | — |
+| Daniel Patrick Noble | Palm Island | ✅ Yes (2024-12-11) | EL transcript | — |
+| Gloria Turner | Kalgoorlie | ✅ Yes (2024-10-13, as "Gloria") | EL transcript | Card lists her at Kalgoorlie, matches EL — no conflict here |
+| Ivy | Palm Island | ✅ Yes (2024-12-17) | EL transcript | Card itself flags "confirm which Ivy" — unresolved |
+| Jason | Palm Island | ✅ Yes (2024-11-14) | EL transcript | — |
+| Mark | Mount Isa | ✅ Yes (2024-11-03) | EL transcript | Tier is website-only despite having a real transcript |
+| Walter | Kalgoorlie | ✅ Yes (2024-10-13) | EL transcript | `hold` tier — real transcript exists but not cleared, correctly excluded from the spine |
+| Wayne Glenn | Darwin | ✅ Yes (2025-01-20) | EL transcript | — |
+| **Gary** | Mount Isa | ⚠️ **Exists, but tagged `Project: "Beyond Shadows"`, not Goods** (2024-11-12, Men's Group) | An interview recorded for a *different ACT program* | **Real flag.** One of the most-used quotes in the spine (Movement 1's anchor) comes from an interview never tagged as being about Goods at all. Need to confirm the actual interview content is genuinely about Goods before trusting the quote further. |
+| Katrina Bloomfield | Alice Springs / Utopia | ❌ No | "trip (cleared)" — raw field-trip note, not a formal transcript | Genuine firsthand documentation, just not in the EL transcript system |
+| Dorrie Jones | Arlparra | ❌ No | "trip; Ben-cleared 2026-06-17" | Same — real trip note, no formal transcript |
+| Karen Liddle | Oonchiumpa (Utopia) | ❌ No | "trip (cleared)" | Same |
+| Ray Nelson | Plenty Highway | ❌ No | "pack; bed GB0-156-96" — from a funder pack document | Traceable to a specific bed's QR record at least |
+| Jessica Allardyce | Miwatj Health | ❌ No | "content.ts" — hardcoded directly in the website's code | **Bypasses the Empathy Ledger consent pipeline entirely.** `hold` tier, not currently used — correctly so. |
+| Zelda Hogan | Tennant Creek | ❌ No | "content.ts" | Same bypass. `website` tier, not currently used in this spine. |
+| Xavier | Alice Springs | ❌ No (by design) | No own quote — narrated by Fred Campbell, consent via Oonchiumpa | Deliberate, documented, not a gap |
+| Kristy Bloomfield | Alice Springs / Utopia | ❌ No | "curated" — no further source given | Unknown ultimate origin |
+| Dr Boe Remenyi | practitioner | ❌ No | "curated" | Unknown ultimate origin |
+| Shayne Bloomfield | Oonchiumpa family | ❌ No | "curated" | Unknown ultimate origin |
+| Fred Campbell | Oonchiumpa, Alice Springs | ❌ No | "curated; carries Xavier's story" | Unknown ultimate origin — carries a lot of narrative weight (Movement 3, 5) for an unsourced quote |
+| Annie Morrison | Tennant Creek | ❌ No | "curated" | Unknown ultimate origin |
+| Brian Russell | Tennant Creek | ❌ No | "curated" | Unknown ultimate origin |
+| **Dianne Stokes** | Tennant Creek | ❌ No | "curated; named Pakkimjalki Kari" | **Unknown ultimate origin, despite being the emotional anchor of Movement 4.** Her totem line is separately marked hold — that's a different, already-handled flag. This is about the *primary* quote having no traceable transcript at all. |
+| Jimmy Frank | Tennant Creek | ❌ No | "curated" | Unknown ultimate origin |
+| Linda Turner | Tennant Creek | ❌ No | "curated" | Unknown ultimate origin — carries Movement 2's opening line |
+| Melissa Jackson | Tennant Creek | ❌ No | "curated" | Unknown ultimate origin |
+| Norman Frank | Tennant Creek | ❌ No | "curated" | Unknown ultimate origin |
+| Patricia Frank | Tennant Creek | ❌ No | "curated" | Unknown ultimate origin |
+| Risilda Hogan | Tennant Creek | ❌ No | "curated" | Unknown ultimate origin |
+| Cliff Plummer | Tennant Creek | ❌ No | "curated; label practitioner" | Unknown ultimate origin |
+| **Mykel** | Utopia Homelands | ❌ No | "Ben-cleared 2026-06-18 (canon + Snow dashboard)" | Cleared by you directly, not via a transcript — that's a real clearance, just not a transcript-backed one. Notes field itself flags "voices.md pending flag is stale, needs updating." |
+| Heather Mundo | Katherine | ❌ No | "curated" | Unknown ultimate origin |
+
+## What this actually means
+
+**Not "these quotes are fake."** Most of the "curated" entries are very likely real things people said — someone was in the room, wrote it down or remembered it, and typed it in. The gap is **traceability**, not necessarily truth: if a funder or a community member asked "show me the source," 24 of these 34 people currently in the story have nothing in Notion to point to except a hand-typed card.
+
+**Tennant Creek is the starkest gap.** It carries Movements 3, 4, and 5 of the current spine — the naming, the reversal, most of the emotional weight — and literally zero of its 10 voices have a transcript anywhere in the system. The May 2025 visit-log page (a separate "Actions" database entry, checked 2026-07-13) doesn't contain the quotes either; it's logistics notes and an uncaptioned photo dump.
+
+**Utopia/Oonchiumpa is thin but has *some* real documentation** — Katrina, Dorrie, and Karen have genuine trip notes (not full transcripts, but real firsthand records, dated and cleared). Mykel's clearance is a direct, dated decision from you, which is a real form of provenance even without a transcript. Fred, Kristy, Shayne, and Xavier's narration are the softest points here.
+
+**Gary is the one that needs an actual look, not a shrug.** His transcript exists and is real — it's just tagged to a different program. Two honest possibilities: either the interview genuinely touched on Goods and someone forgot to tag it correctly (fixable, low-stakes), or the interview was actually about the other program and the "fire and dirt" line is being used out of its real context (a real problem, since it's currently the lead quote of Movement 1). Worth reading the actual transcript before deciding which.
+
+## What a "full model" going forward should look like
+
+Right now provenance lives in three disconnected places: the EL Storytellers table (transcripts, Goods-tagged only), the Storyteller Library (curated cards, the thing actually used), and `storyteller-registry.ts` in the repo (the code-side mirror, which doesn't currently carry a "has real transcript: yes/no" field at all). None of the three point at each other.
+
+The concrete fix, if you want it: add a `transcriptSource` field to every entry in `storyteller-registry.ts` — `el-transcript` / `trip-notes` / `funder-pack` / `content-hardcoded` / `curated-unknown` / `narrated` — populated from this table, so the distinction this document just took an hour to reconstruct is visible at a glance from now on, in code, next to every quote. Not built yet — flagging it as the actual "full model" you're asking for, rather than another one-off document like this one.


### PR DESCRIPTION
The full storyteller data model, wired: v2/src/lib/data/transcript-provenance.ts (per-voice transcript metadata from the EL database export: counts, words, dates, release states, quote-analysis inclusion) rendered live on /admin/story-atlas with colour-coded badges, provenance filters and roster summary (26 of 41 voices transcript-backed). Corrects the superseded Notion-only view (which missed the entire Tennant Creek roster's transcripts). Metadata only; transcript text never enters the repo. Real gaps stay named: Patricia Frank (none), Fred Campbell (24-word clip), Kristy Bloomfield (leads only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)