### PR TITLE
Provenance: Gary's consultation line verified against his transcript

### DIFF
--- a/v2/src/lib/data/deck.ts
+++ b/v2/src/lib/data/deck.ts
@@ -170,7 +170,7 @@ export const deckSlides: DeckSlide[] = [
     ],
     script:
       'We came with prototypes and more certainty than we should have had. Gary in Mount Isa described consultation as sitting on the grass or dirt, around the fire, without the pen and paper, and listening. His words exposed something uncomfortable. Asking is easy. The hard part is staying quiet when the answer begins to undo your idea. People spoke about family coming to stay and too few beds in the house. Freight. Mattresses on floors. Snakes. Sore knees. In Arlparra, a household told us they had been sleeping on a door. People already understood all of this. They did not need us to diagnose their lives. We were the ones catching up.',
-    note: 'Turn 1, narrative-foundation §2. Anonymous Arlparra lines are usable unnamed (community-narrative.ts). Gary\'s fire-and-dirt description stays narrated, never in quotation marks, until transcript-verified.',
+    note: 'Turn 1, narrative-foundation §2. Anonymous Arlparra lines are usable unnamed (community-narrative.ts). Gary\'s fire-and-dirt description VERIFIED against his transcript 2026-07-15 (near-verbatim; interview is substantially about Goods). Narration is faithful; promoting the exact line to an on-screen registry quote is Ben\'s call.',
   },
   {
     id: 'turn-2',

--- a/v2/src/lib/data/transcript-provenance.ts
+++ b/v2/src/lib/data/transcript-provenance.ts
@@ -188,7 +188,7 @@ export const TRANSCRIPT_PROVENANCE: Record<string, TranscriptProvenance> = {
     recordingDates: ['2025-01-18'],
     releaseState: 'blocked_no_review_or_grant',
     inQuoteAnalysis: true,
-    note: 'EL files this under the Goods project; the Notion card tagged it "Beyond Shadows". Longest transcript in the corpus. Read before leaning harder on the fire-and-dirt line.',
+    note: 'EL files this under the Goods project; the Notion "Beyond Shadows" tag was a mis-filing. Longest transcript in the corpus (15 bed mentions). Fire-and-dirt consultation line VERIFIED verbatim 2026-07-15: "sitting down on the grass, on the dirt, with the fire, that\'s our consultation, without the pen and paper, and just actually sit down and listen." Promoting it into the registry as an on-screen quote is Ben\'s call.',
   },
   'Wayne Glenn': {
     kind: 'el-transcript',

--- a/wiki/outputs/2026-07-15-strategy-deck-core-messaging.md
+++ b/wiki/outputs/2026-07-15-strategy-deck-core-messaging.md
@@ -226,9 +226,12 @@ machinery-and-working-capital language. One ask per room, the other two deleted.
 2. CONSENT, CRITICAL: the drinking-in-front-yards detail never surfaces anywhere.
 3. FIGURE, HIGH: match stack (SEFA $300K, Snow $100K, Centrecorp $75K) is proposed, 0 signed
    LOIs today; never shown as committed. Fixed in deck.ts this session.
-4. CONSENT-QUOTE, MEDIUM: Gary's fire-and-dirt consultation description is narrated, never in
-   quotation marks, until transcript-verified (his transcript is also tagged to a different ACT
-   project).
+4. RESOLVED 2026-07-15: Gary's fire-and-dirt line verified against his 5,264-word transcript,
+   near-verbatim ("sitting down on the grass, on the dirt, with the fire, that's our
+   consultation, without the pen and paper, and just actually sit down and listen"), in an
+   interview substantially about Goods (15 bed mentions); the "Beyond Shadows" tag was a Notion
+   mis-filing, EL files it under Goods. Narration in the script is faithful; on-screen verbatim
+   use awaits Ben promoting the line into the registry.
 5. FIGURE-CLAIM, MEDIUM: Norman's and Patricia's role in Warumungu naming is unverified; Dianne
    as designer and namer of both products' story is registry-supported and usable.
 6. BRAND, MEDIUM: deck.ts carried em dashes, spaced units and lowercase on-Country; fixed this


### PR DESCRIPTION
Flag E4 resolved: the fire-and-dirt consultation line is near-verbatim in Gary's 5,264-word transcript, in an interview substantially about Goods; the Beyond Shadows tag was a Notion mis-filing. Deck note, provenance module note and spec flag updated. Metadata and one verified line only; the transcript stays local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)