### PR TITLE
Media Room: tag video+website people, Descript videos in-app, fast tagging + read-back

### DIFF
--- a/v2/src/app/admin/atlas/atlas-client.tsx
+++ b/v2/src/app/admin/atlas/atlas-client.tsx
@@ -29,6 +29,7 @@ export interface AtlasCommunity {
   photoCount: number;
   videoCount: number;
   voices: Array<{ name: string; elder: boolean; portrait: string | null }>;
+  peopleInMedia: Array<{ personKey: string; name: string; photoSrc?: string; mediaCount: number }>;
 }
 
 interface Canon {
@@ -99,6 +100,7 @@ export default function AtlasClient({ communities, canon }: { communities: Atlas
           c.name.toLowerCase().includes(q) ||
           c.keyPeople.some((p) => p.name.toLowerCase().includes(q)) ||
           c.voices.some((v) => v.name.toLowerCase().includes(q)) ||
+          c.peopleInMedia.some((p) => p.name.toLowerCase().includes(q)) ||
           c.procurement.some((p) => p.name.toLowerCase().includes(q)),
       )
     : null;
@@ -457,6 +459,30 @@ export default function AtlasClient({ communities, canon }: { communities: Atlas
                       {v.elder && (
                         <span className="rounded-full bg-[#B44D2B]/10 px-1.5 py-0.5 text-[10px] font-semibold text-[#B44D2B]">Elder</span>
                       )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {/* People appearing in this community's media (media_links person tags) */}
+            {selected.peopleInMedia.length > 0 && (
+              <div className="px-5 pt-4">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-[#A79C8C]">
+                  In our media ({selected.peopleInMedia.length})
+                </h3>
+                <ul className="mt-2 space-y-1.5">
+                  {selected.peopleInMedia.map((p) => (
+                    <li key={p.personKey} className="flex items-center gap-2.5 text-sm">
+                      {p.photoSrc ? (
+                        <img src={p.photoSrc} alt="" className="h-7 w-7 rounded-full object-cover" loading="lazy" />
+                      ) : (
+                        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[#F5EEE4] text-[10px] font-semibold text-[#8A7F72]">
+                          {p.name.slice(0, 1)}
+                        </span>
+                      )}
+                      <span className="font-medium">{p.name}</span>
+                      {p.mediaCount > 1 && <span className="text-[11px] text-[#A79C8C]">×{p.mediaCount}</span>}
                     </li>
                   ))}
                 </ul>

--- a/v2/src/app/admin/atlas/page.tsx
+++ b/v2/src/app/admin/atlas/page.tsx
@@ -1,6 +1,7 @@
 import { createServiceClient } from '@/lib/supabase/server';
 import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
 import AtlasClient, { type AtlasCommunity } from './atlas-client';
+import { getPeopleInMediaByEntity } from '@/lib/data/media-links';
 
 export const dynamic = 'force-dynamic';
 
@@ -75,6 +76,10 @@ export default async function AtlasPage() {
     voices.set(v.community_id as string, list);
   }
 
+  // People tagged (media_links person picker) on media that also belongs to each
+  // community — the read-back for the Media Room's per-item person tagging.
+  const peopleInMediaMap = await getPeopleInMediaByEntity(supabase, 'community');
+
   const communities: AtlasCommunity[] = (commRes.data || [])
     .filter((c) => c.lat != null && c.lng != null)
     .map((c) => {
@@ -104,6 +109,7 @@ export default async function AtlasPage() {
         photoCount: md.photoCount,
         videoCount: md.videoCount,
         voices: voices.get(c.id as string) || [],
+        peopleInMedia: peopleInMediaMap.get(c.id as string) || [],
       };
     });
 

--- a/v2/src/app/admin/communities/[id]/page.tsx
+++ b/v2/src/app/admin/communities/[id]/page.tsx
@@ -8,7 +8,7 @@ import { AddDemandForm } from './add-demand-form';
 import { CommunityMetaForm } from './community-meta-form';
 import { getCommunityVoices, getCommunityStories } from '@/lib/data/community-stories';
 import CommunityPresent, { type PresentSlide } from './community-present';
-import { getMediaLinksFor } from '@/lib/data/media-links';
+import { getMediaLinksFor, getPeopleInMediaFor } from '@/lib/data/media-links';
 import { StorytellerAvatar } from '@/components/storyteller-avatar';
 
 export const dynamic = 'force-dynamic';
@@ -246,6 +246,9 @@ export default async function CommunityDetailPage({
   const allMediaItems = [...mediaItems, ...extraMedia];
   const photos = allMediaItems.filter((m) => m.media_type !== 'video');
   const videos = allMediaItems.filter((m) => m.media_type === 'video');
+  // People tagged (media_links person picker) on media that also belongs to this
+  // community — the read-back for the Media Room's per-item person tagging.
+  const peopleInMedia = await getPeopleInMediaFor(supabase, 'community', community.id);
   const storytellers = ((voicesRes.data || []) as Array<{ id: string; display_name: string; is_elder: boolean; portrait: { url?: string } | Array<{ url?: string }> | null }>).map((v) => ({
     name: v.display_name,
     elder: Boolean(v.is_elder),
@@ -676,6 +679,23 @@ export default async function CommunityDetailPage({
               </div>
             )}
           </>
+        )}
+        {peopleInMedia.length > 0 && (
+          <div className="pt-3">
+            <h3 className="mb-2 text-sm font-semibold font-display">People appearing in this media</h3>
+            <div className="flex flex-wrap gap-2.5">
+              {peopleInMedia.map((p) => (
+                <div key={p.personKey} className="flex items-center gap-2 rounded-full border border-border bg-card py-1 pl-1 pr-3">
+                  <StorytellerAvatar name={p.name} src={p.photoSrc ?? null} size={28} />
+                  <span className="text-xs font-medium">{p.name}</span>
+                  {p.mediaCount > 1 && <span className="text-[10px] text-muted-foreground">×{p.mediaCount}</span>}
+                </div>
+              ))}
+            </div>
+            <p className="mt-1.5 text-[11px] text-muted-foreground">
+              Tagged in the media library. Tag a person in a photo or video that belongs to {community.name} and they appear here.
+            </p>
+          </div>
         )}
       </section>
 

--- a/v2/src/app/admin/media-library/curation.ts
+++ b/v2/src/app/admin/media-library/curation.ts
@@ -8,6 +8,7 @@ import 'server-only';
 import { unstable_cache } from 'next/cache';
 import { safeImageUrl } from '@/lib/empathy-ledger/media-tier';
 import { getLocalImages, getLocalVideos } from '@/lib/data/local-images';
+import { DESCRIPT_VIDEOS, descriptViewUrl, descriptEmbedUrl } from '@/lib/data/descript-videos';
 import { createServiceClient } from '@/lib/supabase/server';
 import { themeForItem } from '@/lib/data/themes';
 import { getAlignData, type AlignPhoto, type AlignPerson } from '@/lib/empathy-ledger/align';
@@ -232,7 +233,31 @@ export async function buildLocalItems(): Promise<{ items: UnifiedItem[]; curatio
     ),
   );
 
-  return { items: [...localImageItems, ...localVideoItems], curationReady: curation.ready };
+  // Descript-hosted video cuts — external embeds, not curatable (no content_items
+  // row), each carrying its own consent + canon flag. Surfaced so "watch everything"
+  // lives in one place. See src/lib/data/descript-videos.ts + the Notion Video Map.
+  const descriptItems: UnifiedItem[] = DESCRIPT_VIDEOS.map((v) => ({
+    id: `descript:${v.viewId}`,
+    src: v.poster,
+    full: descriptViewUrl(v.viewId),
+    poster: v.poster,
+    embedUrl: descriptEmbedUrl(v.viewId),
+    mediaType: 'video' as const,
+    source: 'descript' as const,
+    area: v.beat,
+    title: v.title,
+    tags: [
+      ...(v.canonFresh ? [] : ['status:stale-canon']),
+      ...(v.cleared ? [] : ['consent:held']),
+    ],
+    consent: (v.cleared ? 'public' : 'flagged') as UnifiedItem['consent'],
+    notes: v.note ?? null,
+  }));
+
+  return {
+    items: [...localImageItems, ...localVideoItems, ...descriptItems],
+    curationReady: curation.ready,
+  };
 }
 
 /** Empathy Ledger images + video, curation-merged, with photo→people alignment.

--- a/v2/src/app/admin/media-library/library-client.tsx
+++ b/v2/src/app/admin/media-library/library-client.tsx
@@ -9,7 +9,7 @@ export interface UnifiedItem {
   src: string;
   /** Full-resolution url. */
   full: string;
-  source: 'el' | 'website';
+  source: 'el' | 'website' | 'descript';
   area: string;
   title: string;
   tags: string[];
@@ -31,6 +31,8 @@ export interface UnifiedItem {
   notes?: string | null;
   /** Poster/thumbnail image url for a video tile. */
   poster?: string;
+  /** For an embed-only video (e.g. Descript): the iframe src to play inline. */
+  embedUrl?: string;
   /** Community this asset belongs to (content_items.community_id → communities.name). */
   community?: string;
   /** Storyteller whose portrait this is (content_items.storyteller_id → display_name). */
@@ -42,7 +44,7 @@ export interface UnifiedItem {
   theme?: string;
 }
 
-type SourceFilter = 'all' | 'website' | 'el';
+type SourceFilter = 'all' | 'website' | 'el' | 'descript';
 /** Pickable storyteller for photo→people alignment (from the project_storytellers roster). */
 type RosterPerson = { id: string; name: string; isElder?: boolean };
 
@@ -62,6 +64,11 @@ function loadAspectCache(): Record<string, number> {
 }
 
 function consentBadge(item: UnifiedItem): { text: string; cls: string } {
+  if (item.source === 'descript') {
+    return item.consent === 'flagged'
+      ? { text: 'Descript · held', cls: 'bg-red-100 text-red-700' }
+      : { text: 'Descript', cls: 'bg-violet-100 text-violet-700' };
+  }
   switch (item.consent) {
     case 'local':
       return { text: 'Website', cls: 'bg-muted text-foreground' };
@@ -109,6 +116,7 @@ export function MediaLibraryClient({
   const [active, setActive] = useState<UnifiedItem | null>(null);
   // curation UI state
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkTagInput, setBulkTagInput] = useState('');
   const [showArchived, setShowArchived] = useState(false);
   const [starredOnly, setStarredOnly] = useState(false);
   const [selectMode, setSelectMode] = useState(false); // click tiles to select for batch ops
@@ -230,6 +238,47 @@ export function MediaLibraryClient({
     [selected, mutate],
   );
 
+  // Bulk-ADD a subject tag to the selection without clobbering each item's own
+  // tags (the content-item API replaces tags[], so we merge + write per item).
+  const bulkAddTag = useCallback(
+    async (raw: string) => {
+      const tag = raw.trim();
+      if (!tag) return;
+      const targets = items.filter(
+        (it) => selected.has(it.id) && it.contentId && !it.tags.includes(tag),
+      );
+      if (targets.length === 0) return;
+      setErr('');
+      const snapshot = items;
+      setItems((prev) =>
+        prev.map((it) =>
+          selected.has(it.id) && it.contentId && !it.tags.includes(tag)
+            ? { ...it, tags: [...it.tags, tag] }
+            : it,
+        ),
+      );
+      const results = await Promise.allSettled(
+        targets.map((it) =>
+          fetch('/api/admin/content-item', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: it.contentId, tags: [...it.tags, tag] }),
+          })
+            .then((r) => r.json())
+            .then((d: { ok: boolean; error?: string }) => {
+              if (!d.ok) throw new Error(d.error || 'save failed');
+            }),
+        ),
+      );
+      const failed = results.filter((r) => r.status === 'rejected').length;
+      if (failed) {
+        setItems(snapshot); // revert all on partial failure so state stays truthful
+        setErr(`Bulk tag failed on ${failed}/${targets.length} — nothing changed.`);
+      }
+    },
+    [items, selected],
+  );
+
   const toggleSelect = useCallback((id: string) => {
     setSelected((prev) => {
       const next = new Set(prev);
@@ -277,11 +326,13 @@ export function MediaLibraryClient({
   const sourceCounts = useMemo(() => {
     let website = 0;
     let el = 0;
+    let descript = 0;
     for (const it of items) {
       if (it.source === 'website') website += 1;
+      else if (it.source === 'descript') descript += 1;
       else el += 1;
     }
-    return { all: items.length, website, el };
+    return { all: items.length, website, el, descript };
   }, [items]);
 
   const areaOptions = useMemo(() => {
@@ -406,6 +457,12 @@ export function MediaLibraryClient({
 
   const archivedCount = useMemo(() => items.filter((it) => it.archived).length, [items]);
   const starredCount = useMemo(() => items.filter((it) => it.starred).length, [items]);
+  // Every distinct tag in the library — powers tag autocomplete + click-to-filter.
+  const allTags = useMemo(() => {
+    const set = new Set<string>();
+    for (const it of items) for (const t of it.tags) set.add(t);
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
+  }, [items]);
 
   // Batch selection helpers. selectAt supports shift-click range select over the
   // currently-filtered set (only curatable items can be selected).
@@ -555,11 +612,19 @@ export function MediaLibraryClient({
         </p>
       )}
 
+      {/* Shared tag autocomplete source (bulk bar + item tag editor). */}
+      <datalist id="ml-tag-suggestions">
+        {allTags.map((t) => (
+          <option key={t} value={t} />
+        ))}
+      </datalist>
+
       {/* Source filter chips */}
       <div className="flex flex-wrap items-center gap-2 mb-1.5">
         {chip('all', 'All', sourceCounts.all, 'Everything, both sources')}
         {chip('website', 'Website', sourceCounts.website, "The site's own image & video files (public/) — marketing, product, brand. Yours to use freely.")}
         {chip('el', 'Empathy Ledger', sourceCounts.el, 'Community photos & videos in Empathy Ledger — consent-governed, linked to the people & communities in them.')}
+        {sourceCounts.descript > 0 && chip('descript', 'Descript', sourceCounts.descript, 'Hosted video cuts on Descript — the walkthrough, timelapse, storyteller cuts. Each carries a consent + canon flag; play inline.')}
       </div>
       <p className="mb-3 text-[11px] text-muted-foreground">
         <span className="font-medium text-foreground">Website</span> = the site&rsquo;s own files ·{' '}
@@ -733,6 +798,18 @@ export function MediaLibraryClient({
               <option value="__clear">— Clear community —</option>
             </select>
           )}
+          <div className="flex items-center gap-1">
+            <input
+              type="text"
+              value={bulkTagInput}
+              onChange={(e) => setBulkTagInput(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); bulkAddTag(bulkTagInput); setBulkTagInput(''); } }}
+              list="ml-tag-suggestions"
+              placeholder="tag selected…"
+              className="w-32 rounded-lg border border-input bg-background px-2 py-1 text-xs font-mono"
+            />
+            <button type="button" onClick={() => { bulkAddTag(bulkTagInput); setBulkTagInput(''); }} className="rounded-lg border border-border px-2.5 py-1 text-xs hover:border-foreground">+ Tag</button>
+          </div>
           <button type="button" onClick={() => bulkSet({ archived: true })} className="rounded-lg border border-red-300 px-2.5 py-1 text-xs font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:hover:bg-red-950/30">🗑 Archive (cull)</button>
           {showArchived && (
             <button type="button" onClick={() => bulkSet({ archived: false })} className="rounded-lg border border-border px-2.5 py-1 text-xs hover:border-foreground">Restore</button>
@@ -913,6 +990,7 @@ export function MediaLibraryClient({
           onToggleArchive={toggleArchive}
           onSetRating={setRating}
           onMutatePeople={mutatePeople}
+          onFilterTag={(t) => { setArea(t); setActive(null); }}
         />
       )}
     </div>
@@ -959,9 +1037,11 @@ interface MediaLink {
 function MediaLinksPanel({
   item,
   communities,
+  people,
 }: {
   item: UnifiedItem;
   communities: { id: string; name: string }[];
+  people: RosterPerson[];
 }) {
   const mediaSource = item.source === 'el' ? 'el_media' : 'local';
   const mediaKey = item.source === 'el' ? item.id.replace(/^el:/, '') : item.full;
@@ -973,6 +1053,7 @@ function MediaLinksPanel({
   const [err, setErr] = useState('');
   const [productPick, setProductPick] = useState('');
   const [communityPick, setCommunityPick] = useState('');
+  const [personPick, setPersonPick] = useState('');
 
   useEffect(() => {
     let alive = true;
@@ -1043,9 +1124,11 @@ function MediaLinksPanel({
     }
   }, []);
 
+  const personName = (id: string) => people.find((p) => p.id === id)?.name ?? id;
   const labelFor = (l: MediaLink) => {
     if (l.target_type === 'product') return prodName(l.target_key);
     if (l.target_type === 'community') return commName(l.target_key);
+    if (l.target_type === 'person') return l.title || personName(l.target_key);
     return l.title || l.target_key;
   };
   const toneFor = (t: MediaLink['target_type']) =>
@@ -1053,13 +1136,21 @@ function MediaLinksPanel({
       ? 'bg-primary/10 text-primary'
       : t === 'community'
         ? 'bg-accent/10 text-accent'
-        : 'bg-muted text-foreground';
+        : t === 'person'
+          ? 'bg-emerald-100 text-emerald-800'
+          : 'bg-muted text-foreground';
 
   const availableProducts = LINKABLE_PRODUCTS.filter(
     (p) => !links.some((l) => l.target_type === 'product' && l.target_key === p.slug),
   );
   const availableCommunities = communities.filter(
     (c) => !links.some((l) => l.target_type === 'community' && l.target_key === c.id),
+  );
+  // Person links let you tag WHO is in a website photo or video. EL images use
+  // their own EL-junction People panel instead, so this picker is website-only.
+  const canLinkPerson = item.source === 'website';
+  const availablePeople = people.filter(
+    (p) => !links.some((l) => l.target_type === 'person' && l.target_key === p.id),
   );
 
   return (
@@ -1090,6 +1181,30 @@ function MediaLinksPanel({
           </div>
 
           <div className="space-y-1.5">
+            {/* Add a person link — who is in this photo / video (website items) */}
+            {canLinkPerson && (
+              <div className="flex gap-1.5">
+                <select
+                  value={personPick}
+                  onChange={(e) => setPersonPick(e.target.value)}
+                  className="flex-1 rounded border border-border bg-background px-2 py-1 text-xs"
+                >
+                  <option value="">Tag a person…{people.length === 0 ? ' (loading…)' : ''}</option>
+                  {availablePeople.map((p) => (
+                    <option key={p.id} value={p.id}>{p.name}{p.isElder ? ' (elder)' : ''}</option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  disabled={!personPick || busy}
+                  onClick={() => { addLink('person', personPick, personName(personPick)); setPersonPick(''); }}
+                  className="rounded bg-primary px-2 py-1 text-xs font-medium text-primary-foreground disabled:opacity-40"
+                >
+                  Add
+                </button>
+              </div>
+            )}
+
             {/* Add a product link */}
             <div className="flex gap-1.5">
               <select
@@ -1153,6 +1268,7 @@ function PreviewModal({
   onToggleArchive,
   onSetRating,
   onMutatePeople,
+  onFilterTag,
 }: {
   item: UnifiedItem;
   curationReady: boolean;
@@ -1165,13 +1281,15 @@ function PreviewModal({
   onToggleArchive: (it: UnifiedItem) => void;
   onSetRating: (it: UnifiedItem, r: number) => void;
   onMutatePeople: (it: UnifiedItem, storytellerId: string, action: 'add' | 'remove') => void;
+  onFilterTag: (tag: string) => void;
 }) {
   const [copied, setCopied] = useState(false);
   const badge = consentBadge(item);
   const isWebsite = item.source === 'website';
   const isVideo = item.mediaType === 'video';
   const canCurate = !!item.contentId;
-  const showTagEditor = isWebsite && !isVideo;
+  // Subject tags apply to any indexed website item — images and video alike.
+  const showTagEditor = isWebsite;
 
   // Tag editor state (website items only). Seeded from the item's current tags.
   const [draftTags, setDraftTags] = useState<string[]>(item.tags);
@@ -1304,12 +1422,22 @@ function PreviewModal({
         {/* Media side */}
         <div className="bg-black flex items-center justify-center min-h-[40vh] md:min-h-[60vh]">
           {isVideo ? (
-            <video
-              src={item.full}
-              poster={item.poster}
-              controls
-              className="max-h-[88vh] max-w-full object-contain"
-            />
+            item.embedUrl ? (
+              <iframe
+                src={item.embedUrl}
+                title={item.title}
+                className="w-full aspect-video max-h-[88vh] bg-black"
+                allow="fullscreen; autoplay"
+                allowFullScreen
+              />
+            ) : (
+              <video
+                src={item.full}
+                poster={item.poster}
+                controls
+                className="max-h-[88vh] max-w-full object-contain"
+              />
+            )
           ) : (
             /* eslint-disable-next-line @next/next/no-img-element */
             <img
@@ -1339,11 +1467,17 @@ function PreviewModal({
               {badge.text}
             </span>
             <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium">
-              {item.source === 'website' ? 'Website' : 'Empathy Ledger'}
+              {item.source === 'website' ? 'Website' : item.source === 'descript' ? 'Descript' : 'Empathy Ledger'}
             </span>
             <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium">
               {item.area}
             </span>
+            {item.tags.includes('status:stale-canon') && (
+              <span className="rounded-full bg-amber-100 text-amber-800 px-2 py-0.5 text-[10px] font-semibold" title="Figures in this cut are behind current canon (540/22/3540)">figures stale</span>
+            )}
+            {item.tags.includes('consent:held') && (
+              <span className="rounded-full bg-red-100 text-red-700 px-2 py-0.5 text-[10px] font-semibold" title="Consent not confirmed — do not place on an external slide">consent held</span>
+            )}
             {item.theme && (
               <span className="rounded-full bg-primary/10 text-primary px-2 py-0.5 text-[10px] font-medium">{themeName(item.theme)}</span>
             )}
@@ -1360,9 +1494,18 @@ function PreviewModal({
             )}
           </div>
 
+          {/* Descript cut note (canon / consent context). */}
+          {item.source === 'descript' && item.notes && (
+            <p className="mb-4 rounded-lg border border-border bg-muted/40 p-3 text-xs leading-relaxed text-muted-foreground">
+              {item.notes}
+            </p>
+          )}
+
           {/* Links — media_links typed junction (product / community / story). The
               Atlas + community + product pages read these back. */}
-          <MediaLinksPanel item={item} communities={communities} />
+          {item.source !== 'descript' && (
+            <MediaLinksPanel item={item} communities={communities} people={roster} />
+          )}
 
           {/* People in this photo — EL alignment (media_storytellers). EL images only. */}
           {item.source === 'el' && !isVideo && (
@@ -1538,6 +1681,7 @@ function PreviewModal({
                       addTag(tagInput);
                     }
                   }}
+                  list="ml-tag-suggestions"
                   placeholder="namespace:value"
                   className="flex-1 rounded-lg border border-input bg-background px-2.5 py-1.5 text-xs font-mono text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                 />
@@ -1587,12 +1731,15 @@ function PreviewModal({
                 </p>
                 <div className="flex flex-wrap gap-1.5">
                   {item.tags.map((t) => (
-                    <span
+                    <button
                       key={t}
-                      className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[10px] font-mono"
+                      type="button"
+                      onClick={() => onFilterTag(t)}
+                      title={`Filter the library to ${t}`}
+                      className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[10px] font-mono hover:bg-primary hover:text-primary-foreground transition"
                     >
                       {t}
-                    </span>
+                    </button>
                   ))}
                 </div>
               </div>

--- a/v2/src/lib/data/descript-videos.ts
+++ b/v2/src/lib/data/descript-videos.ts
@@ -1,0 +1,113 @@
+// Curated Descript video cuts, surfaced as first-class items in the Media Room.
+// These are hosted on Descript (share.descript.com), not local .mp4 files, so they
+// carry their own consent + canon flags here and embed via an iframe in the viewer.
+//
+// Source of truth for the mapping + flags is the Notion "Goods Video Map" page
+// (3a6ebcf981cf81b3a6cee03c36d24f92). Keep the two in sync when a cut is added,
+// re-recorded, or cleared. Posters reference real hosted /images or /video files.
+
+export interface DescriptVideo {
+  /** The share.descript.com/view/<viewId> id. */
+  viewId: string;
+  title: string;
+  /** Storyboard beat / area this cut belongs to (used as the grid `area`). */
+  beat: string;
+  /** Real hosted poster image (/images/... or /video/...). */
+  poster: string;
+  /** Consent cleared for external use. false = held (do not surface publicly). */
+  cleared: boolean;
+  /** true = figures are current canon. false = older cut with stale numbers. */
+  canonFresh: boolean;
+  /** Short human note (shown in the viewer). */
+  note?: string;
+}
+
+export const DESCRIPT_VIDEOS: DescriptVideo[] = [
+  {
+    viewId: 'haRZJbfJadJ',
+    title: 'The walkthrough (Nic, production facility)',
+    beat: 'walkthrough',
+    poster: '/images/process/20260329-factory-panorama.jpg',
+    cleared: true,
+    canonFresh: false,
+    note: 'Main walkthrough. Cut Feb 2026 — if bed counts are spoken they read 496/16/2660 (behind canon 540/22/3540). Fine as a facility tour; re-cut only if figures are on screen.',
+  },
+  {
+    viewId: 'Xtrc5ZYsym6',
+    title: 'Stretch Bed timelapse',
+    beat: '05 the loop',
+    poster: '/images/process/pressed-sheets-stacked.jpg',
+    cleared: true,
+    canonFresh: true,
+    note: 'Object only, no consent gate. Wired to slide 05.',
+  },
+  {
+    viewId: 'YQwAcYfxzkn',
+    title: 'Fred and Xavier',
+    beat: '07 built by them',
+    poster: '/images/build/build-001.jpg',
+    cleared: true,
+    canonFresh: true,
+    note: 'Cleared voices. Xavier under the narration rule (Fred narrates, no direct Xavier quotes). Wired to slide 07.',
+  },
+  {
+    viewId: 'LAT0KNJMxmH',
+    title: 'Jaquilane, Alice Springs',
+    beat: 'people',
+    poster: '/video/jaquilane-poster.jpg',
+    cleared: false,
+    canonFresh: true,
+    note: 'HELD. Live on the site but not in cleared-voices.ts; confirm consent before placing on a new external slide.',
+  },
+  // The six Feb-2026 audience walkthroughs — stale canon. Kept for reference /
+  // re-record, never sent as current.
+  {
+    viewId: 'bkukTRVlJI9',
+    title: 'Snow Foundation cut',
+    beat: 'audience',
+    poster: '/images/media-pack/lying-on-stretch-bed.jpg',
+    cleared: true,
+    canonFresh: false,
+    note: 'Audience cut, Feb 2026. Stale figures (496/16/2660). Re-record before use.',
+  },
+  {
+    viewId: 'pZ1S0ACn1Fd',
+    title: 'PICC cut',
+    beat: 'audience',
+    poster: '/images/media-pack/lying-on-stretch-bed.jpg',
+    cleared: true,
+    canonFresh: false,
+    note: 'Audience cut, Feb 2026. Stale figures. Re-record before use.',
+  },
+  {
+    viewId: 'jJlpylKEh51',
+    title: 'Community general cut',
+    beat: 'audience',
+    poster: '/images/media-pack/lying-on-stretch-bed.jpg',
+    cleared: true,
+    canonFresh: false,
+    note: 'Audience cut, Feb 2026. Stale figures. Re-record before use.',
+  },
+  {
+    viewId: 'wuBq1QFnI9p',
+    title: 'Oonchiumpa cut',
+    beat: 'audience',
+    poster: '/images/community/alice-springs/oonchiumpa-team-red-bed.jpg',
+    cleared: true,
+    canonFresh: false,
+    note: 'Audience cut, Feb 2026. Stale figures. Re-record before use.',
+  },
+  {
+    viewId: '7MgH5VVhZVc',
+    title: 'The Funding Network cut',
+    beat: 'audience',
+    poster: '/images/media-pack/lying-on-stretch-bed.jpg',
+    cleared: true,
+    canonFresh: false,
+    note: 'Audience cut, Feb 2026. Stale figures. Re-record before use.',
+  },
+];
+
+/** view/embed URL helpers. */
+export const descriptViewUrl = (viewId: string) => `https://share.descript.com/view/${viewId}`;
+export const descriptEmbedUrl = (viewId: string) => `https://share.descript.com/embed/${viewId}`;

--- a/v2/src/lib/data/media-links.ts
+++ b/v2/src/lib/data/media-links.ts
@@ -115,3 +115,124 @@ export async function getMediaLinksFor(
   }
   return out;
 }
+
+/** A person surfaced from person media_links, with a photo they appear in. */
+export interface TaggedPerson {
+  /** media_links target_key for the person (storyteller id). */
+  personKey: string;
+  name: string;
+  /** A representative image they appear in (first non-video hit). */
+  photoSrc?: string;
+  /** How many tagged media items they appear in (within this entity's media). */
+  mediaCount: number;
+}
+
+/**
+ * People tagged (person media_links) on media that is ALSO tagged to the given
+ * entity (e.g. a community). This is the read-back for people the Media Room's
+ * person picker records: tag someone in a photo/video that also belongs to a
+ * community, and they surface on that community's page.
+ */
+export async function getPeopleInMediaFor(
+  supabase: SupabaseClient,
+  entityType: MediaTargetType,
+  entityKey: string,
+): Promise<TaggedPerson[]> {
+  // 1. Which media items belong to this entity — keyed by source+key so a shared
+  //    basename across sources can't cross-match.
+  const { data: entityRows } = await supabase
+    .from('media_links')
+    .select('media_source, media_key')
+    .eq('target_type', entityType)
+    .eq('target_key', entityKey);
+  if (!entityRows || entityRows.length === 0) return [];
+  const entitySet = new Set(
+    (entityRows as { media_source: string; media_key: string }[]).map((r) => `${r.media_source}::${r.media_key}`),
+  );
+  const mediaKeys = Array.from(new Set((entityRows as { media_key: string }[]).map((r) => r.media_key)));
+
+  // 2. Person links landing on those media_keys.
+  const { data: personRows } = await supabase
+    .from('media_links')
+    .select('media_source, media_key, media_type, target_key, title')
+    .eq('target_type', 'person')
+    .in('media_key', mediaKeys);
+  if (!personRows) return [];
+
+  const byPerson = new Map<string, TaggedPerson>();
+  for (const r of personRows as MediaLinkRow[]) {
+    if (!entitySet.has(`${r.media_source}::${r.media_key}`)) continue; // same media item both-tagged
+    const cur =
+      byPerson.get(r.target_key) ??
+      { personKey: r.target_key, name: r.title || r.target_key, photoSrc: undefined, mediaCount: 0 };
+    cur.mediaCount += 1;
+    if (cur.name === cur.personKey && r.title) cur.name = r.title;
+    if (!cur.photoSrc && r.media_type !== 'video') {
+      const src = resolveMediaUrl(r.media_source, r.media_key);
+      if (src) cur.photoSrc = src;
+    }
+    byPerson.set(r.target_key, cur);
+  }
+  return Array.from(byPerson.values()).sort((a, b) => b.mediaCount - a.mediaCount);
+}
+
+/**
+ * Bulk version of getPeopleInMediaFor for a whole map surface (e.g. the Atlas):
+ * one query returns every entity→people mapping, computed in memory. Avoids N
+ * round-trips when rendering people-in-media for every community at once.
+ */
+export async function getPeopleInMediaByEntity(
+  supabase: SupabaseClient,
+  entityType: MediaTargetType,
+): Promise<Map<string, TaggedPerson[]>> {
+  const result = new Map<string, TaggedPerson[]>();
+  const { data: rows } = await supabase
+    .from('media_links')
+    .select('media_source, media_key, media_type, target_type, target_key, title')
+    .in('target_type', [entityType, 'person']);
+  if (!rows) return result;
+
+  // Group both tag kinds by the media item (source+key).
+  const entityByKey = new Map<string, string[]>();
+  const personByKey = new Map<string, MediaLinkRow[]>();
+  for (const r of rows as MediaLinkRow[]) {
+    const k = `${r.media_source}::${r.media_key}`;
+    if (r.target_type === entityType) {
+      const arr = entityByKey.get(k) ?? [];
+      arr.push(r.target_key);
+      entityByKey.set(k, arr);
+    } else if (r.target_type === 'person') {
+      const arr = personByKey.get(k) ?? [];
+      arr.push(r);
+      personByKey.set(k, arr);
+    }
+  }
+
+  // For each media item tagged to both an entity and people, attribute the
+  // people to that entity.
+  const acc = new Map<string, Map<string, TaggedPerson>>();
+  for (const [k, entityKeys] of entityByKey) {
+    const persons = personByKey.get(k);
+    if (!persons) continue;
+    for (const ek of entityKeys) {
+      const pmap = acc.get(ek) ?? new Map<string, TaggedPerson>();
+      for (const pr of persons) {
+        const cur =
+          pmap.get(pr.target_key) ??
+          { personKey: pr.target_key, name: pr.title || pr.target_key, photoSrc: undefined, mediaCount: 0 };
+        cur.mediaCount += 1;
+        if (cur.name === cur.personKey && pr.title) cur.name = pr.title;
+        if (!cur.photoSrc && pr.media_type !== 'video') {
+          const src = resolveMediaUrl(pr.media_source, pr.media_key);
+          if (src) cur.photoSrc = src;
+        }
+        pmap.set(pr.target_key, cur);
+      }
+      acc.set(ek, pmap);
+    }
+  }
+  for (const [ek, pmap] of acc) {
+    result.set(ek, Array.from(pmap.values()).sort((a, b) => b.mediaCount - a.mediaCount));
+  }
+  return result;
+}


### PR DESCRIPTION
Makes the Media Room (`/admin/media-library`) world-class for tagging photos **and video**, and surfaces the tags back on the community/Atlas pages.

## What's in it
- **Tag people on video + website photos** — a Person picker in MediaLinksPanel (writes `media_links` `target_type=person`, website-only; EL keeps its own `media_storytellers` panel). Subject tags un-gated for video.
- **Descript videos first-class** — new `src/lib/data/descript-videos.ts` lists the 9 cuts with `cleared` + `canonFresh` flags; surfaced as `source=descript` items, played inline via iframe, with Descript / figures-stale / consent-held badges + a source chip. Kept in sync with the Notion Video Map.
- **Fast tagging** — shared `<datalist>` tag autocomplete, click a tag chip to filter the grid, bulk-add a tag to a selection (per-item merge, reverts all on partial failure).
- **Person read-back** — `media-links.ts` gains `getPeopleInMediaFor` (single) + `getPeopleInMediaByEntity` (bulk). The community detail page and the Atlas drill panel both show people tagged on media that also belongs to that community; Atlas search matches those names.

## Notes
- Typecheck clean (0 errors); pages verified 200 against the live register.
- Touches `atlas-client.tsx` only in the interface/search/drill regions — **disjoint** from the `deck-map-views` PR's geometry changes, so the two can merge in either order (clean 3-way).

🤖 Generated with [Claude Code](https://claude.com/claude-code)