### PR TITLE
Consent gate on the public storyteller routes, and claim hygiene on the press page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ name: CI
 
 on:
   push:
-    branches: [main, 'feat/**', 'fix/**', 'chore/**']
+    # 'claude/**' matters: every Claude Code session works on a claude/* branch,
+    # so without it a session's pushes ran no checks at all until PR time.
+    branches: [main, 'feat/**', 'fix/**', 'chore/**', 'claude/**', 'docs/**']
   pull_request:
   schedule:
     # Daily live asset-register drift check at 19:00 UTC.

--- a/v2/src/app/press/page.tsx
+++ b/v2/src/app/press/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import type { Metadata } from 'next';
 import { brand, mediaPack, impactStories } from '@/lib/data/content';
 import { STRETCH_BED, PLASTIC_KG_PER_BED } from '@/lib/data/products';
+import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
 import { communityPartners, funding } from '@/lib/data/compendium';
 import { pressReads, pressCoverage } from '@/lib/data/press-reads';
 import { getApprovedPhotos, getApprovedVideos } from '@/lib/empathy-ledger/press-pack';
@@ -41,8 +42,13 @@ const logoVariants = [
 ] as const;
 
 const keyFacts = [
-  { value: '540', label: 'Beds delivered', verified: true }, // canonical: see asset-canonical.ts (177 Stretch + 363 Basket)
-  { value: '9', label: 'Communities', verified: true },
+  // Read from canon, never retyped. `verified: true` renders a literal "Verified"
+  // badge on a public page, so a hardcoded number here is a claim we are making
+  // about our own evidence. "Communities" sat at 9 against a canon of 11 until
+  // 2026-07-25, badged Verified the whole time, because no drift guard reads
+  // this file.
+  { value: String(CANONICAL_ASSETS.bedsDeployed), label: 'Beds delivered', verified: true },
+  { value: String(CANONICAL_ASSETS.communitiesServed), label: 'Communities', verified: true },
   { value: `${PLASTIC_KG_PER_BED}kg`, label: 'HDPE diverted per bed', verified: true },
   { value: STRETCH_BED.specs.loadCapacity, label: 'Load capacity', verified: true },
   { value: '5 min', label: 'Assembly time, no tools', verified: true },

--- a/v2/src/app/press/page.tsx
+++ b/v2/src/app/press/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import { brand, mediaPack, impactStories } from '@/lib/data/content';
 import { STRETCH_BED, PLASTIC_KG_PER_BED } from '@/lib/data/products';
 import { CANONICAL_ASSETS } from '@/lib/data/asset-canonical';
+import type { ClaimLabel } from '@/lib/data/canon';
 import { communityPartners, funding } from '@/lib/data/compendium';
 import { pressReads, pressCoverage } from '@/lib/data/press-reads';
 import { getApprovedPhotos, getApprovedVideos } from '@/lib/empathy-ledger/press-pack';
@@ -41,18 +42,22 @@ const logoVariants = [
   { file: 'goods-chip-on-light.svg', label: 'Chip, on cream', surface: 'checker' },
 ] as const;
 
-const keyFacts = [
-  // Read from canon, never retyped. `verified: true` renders a literal "Verified"
-  // badge on a public page, so a hardcoded number here is a claim we are making
-  // about our own evidence. "Communities" sat at 9 against a canon of 11 until
-  // 2026-07-25, badged Verified the whole time, because no drift guard reads
-  // this file.
-  { value: String(CANONICAL_ASSETS.bedsDeployed), label: 'Beds delivered', verified: true },
-  { value: String(CANONICAL_ASSETS.communitiesServed), label: 'Communities', verified: true },
-  { value: `${PLASTIC_KG_PER_BED}kg`, label: 'HDPE diverted per bed', verified: true },
-  { value: STRETCH_BED.specs.loadCapacity, label: 'Load capacity', verified: true },
-  { value: '5 min', label: 'Assembly time, no tools', verified: true },
-  { value: '5 yr', label: 'Warranty (10+ yr design intent, not yet field-proven)', verified: false },
+// Values read from canon, never retyped: "Communities" sat at 9 against a canon
+// of 11 until 2026-07-25 because no drift guard reads this file.
+//
+// `claim` is the canon ClaimLabel, not a loose boolean. This page renders a
+// literal "Verified" badge, which is a statement about our own evidence, so it
+// has to come from the same vocabulary as canon.ts rather than a second one
+// invented here. The warranty row is the case that proves it: a 10-year design
+// life is 'target' (intent we have not field-proven), which is a different thing
+// from "unverified" and reads differently to a journalist.
+const keyFacts: { value: string; label: string; claim: ClaimLabel }[] = [
+  { value: String(CANONICAL_ASSETS.bedsDeployed), label: 'Beds delivered', claim: 'verified' },
+  { value: String(CANONICAL_ASSETS.communitiesServed), label: 'Communities', claim: 'verified' },
+  { value: `${PLASTIC_KG_PER_BED}kg`, label: 'HDPE diverted per bed', claim: 'verified' },
+  { value: STRETCH_BED.specs.loadCapacity, label: 'Load capacity', claim: 'verified' },
+  { value: '5 min', label: 'Assembly time, no tools', claim: 'verified' },
+  { value: '5 yr', label: 'Warranty (10+ yr design intent, not yet field-proven)', claim: 'target' },
 ];
 
 const colourSwatches = [
@@ -203,9 +208,13 @@ export default async function PressPage() {
                 <div key={f.label} className="bg-card p-5">
                   <p className="text-2xl font-semibold tracking-tight">{f.value}</p>
                   <p className="mt-1 text-xs text-muted-foreground">{f.label}</p>
-                  {f.verified && (
+                  {f.claim === 'verified' ? (
                     <span className="mt-3 inline-block rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-800">
                       Verified
+                    </span>
+                  ) : (
+                    <span className="mt-3 inline-block rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-amber-800">
+                      {f.claim === 'target' ? 'Design intent' : f.claim}
                     </span>
                   )}
                 </div>

--- a/v2/src/app/storytellers/page.tsx
+++ b/v2/src/app/storytellers/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import type { Metadata } from 'next';
-import { getGoodsStorytellers, slugify } from '@/lib/storytellers';
+import { getPublicStorytellers, slugify } from '@/lib/storytellers';
 
 export const metadata: Metadata = {
   title: 'Storytellers — Goods on Country',
@@ -11,7 +11,9 @@ export const metadata: Metadata = {
 export const revalidate = 300; // 5 min — matches EL cache TTL
 
 export default async function StorytellersIndex() {
-  const storytellers = await getGoodsStorytellers();
+  // Consent gate (default-deny): cleared voices only. This is a public,
+  // indexable route, so an uncleared name must not appear here at all.
+  const storytellers = await getPublicStorytellers();
 
   // Elders first (their voices anchor the project), then alphabetical
   const sorted = [...storytellers].sort((a, b) => {

--- a/v2/src/lib/data/canon.ts
+++ b/v2/src/lib/data/canon.ts
@@ -19,6 +19,35 @@
  */
 import { CANONICAL_ASSETS } from './asset-canonical';
 
+/**
+ * What claim a FACT can carry. One of three claim-ish vocabularies in this
+ * codebase, which look mergeable and are not. Written down because the
+ * temptation to collapse them is real and would lose meaning:
+ *
+ *   ClaimLabel    (here)                  subject: a FACT.
+ *                                         "how well evidenced is this number"
+ *   ClaimStatus   (claims-ledger.ts)      subject: an external CLAIM.
+ *                                         Shares most values, but adds 'locked',
+ *                                         which is a claim we PUBLISH as
+ *                                         deliberately withheld, with a ceiling
+ *                                         and a promised flip date. That is not
+ *                                         the same as 'internal-only' here,
+ *                                         which means the fact is simply not
+ *                                         shown.
+ *   EvidenceState (community-pathways.ts) subject: HOW something was evidenced,
+ *                                         not how strongly. Carries
+ *                                         'community-confirmation', which is a
+ *                                         distinct epistemology from a measured
+ *                                         figure and is the point rather than a
+ *                                         weaker version of 'verified'.
+ *
+ * Separately: the deck-hygiene labels in the standing rules
+ * (observed/requested/agreed/delivered/measured/proposed) are NOT this axis.
+ * They track a commitment through its lifecycle, which the code models as
+ * DemandStatus on bed demand. Do not import them here.
+ *
+ * Labels mirror the QBE Diagnostic Artifact Database and the hub legend.
+ */
 export type ClaimLabel = 'verified' | 'modelled' | 'target' | 'future' | 'internal-only';
 export type CanonDomain = 'assets' | 'money' | 'story' | 'product' | 'cost' | 'pipeline' | 'governance';
 /** GREEN = public-safe. AMBER = internal/management. RED = recipient/storyteller data, never to external models, never auto-published. */

--- a/v2/src/lib/data/claims-ledger.guards.test.ts
+++ b/v2/src/lib/data/claims-ledger.guards.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The claims ledger's leak-prevention, tested.
+ *
+ * `assertLedgerSafe()` is the rule that stopped the withheld consolidated
+ * revenue figure reaching the open web. It had already leaked once: /deck
+ * shipped it in a risk row until 2026-07-11. The assertion runs at module load,
+ * so until now a regression would only show up as an import-time crash
+ * somewhere downstream, and only if a bad claim happened to exist. Nothing
+ * exercised the rule itself.
+ *
+ * Three things it must enforce:
+ *   1. A locked claim carries no figure.
+ *   2. A locked claim's statement is digit-free, so the number cannot leak in
+ *      prose next to the lock.
+ *   3. Any claim rendering a figure must source it from a green (public-safe)
+ *      canon fact. Amber and red facts never ship a figure externally.
+ *
+ * `locked` is not the same as canon's `internal-only`. A locked claim IS
+ * published, deliberately, as a visible withholding with a ceiling and a promised
+ * flip date. See the vocabulary note on ClaimLabel in canon.ts.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { assertLedgerSafe, EXTERNAL_CLAIMS, type Claim } from '@/lib/data/claims-ledger';
+import { CANON, type CanonFact } from '@/lib/data/canon';
+
+const base = (over: Partial<Claim>): Claim => ({
+  id: 'test-claim',
+  headline: 'Test',
+  statement: 'A statement with no digits in it.',
+  status: 'verified',
+  evidence: [],
+  asOf: '2026-07-25',
+  ...over,
+});
+
+const factWith = (pred: (f: CanonFact) => boolean) => CANON.find(pred);
+
+describe('assertLedgerSafe: locked claims', () => {
+  it('rejects a locked claim carrying a figure', () => {
+    expect(() =>
+      assertLedgerSafe([base({ status: 'locked', figure: '$741,111' })]),
+    ).toThrow(/must not carry a figure/);
+  });
+
+  it('rejects digits in a locked claim statement, so the number cannot leak in prose', () => {
+    expect(() =>
+      assertLedgerSafe([
+        base({ status: 'locked', statement: 'Revenue since inception is $741,111, held from publication.' }),
+      ]),
+    ).toThrow(/figure-free/);
+  });
+
+  it('accepts a locked claim that is genuinely figure-free', () => {
+    expect(() =>
+      assertLedgerSafe([
+        base({
+          status: 'locked',
+          statement: 'The consolidated figure is held until the accountant signs it.',
+        }),
+      ]),
+    ).not.toThrow();
+  });
+});
+
+describe('assertLedgerSafe: figures must come from green facts', () => {
+  it('rejects a figure sourced from a non-green canon fact', () => {
+    const nonGreen = factWith((f) => f.dataClass !== 'green');
+    expect(nonGreen, 'expected at least one amber/red fact to make this test meaningful').toBeDefined();
+
+    expect(() =>
+      assertLedgerSafe([base({ figure: '32', factId: nonGreen!.id })]),
+    ).toThrow(/non-green fact/);
+  });
+
+  it('accepts a figure sourced from a green fact', () => {
+    const green = factWith((f) => f.dataClass === 'green');
+    expect(green).toBeDefined();
+
+    expect(() => assertLedgerSafe([base({ figure: '540', factId: green!.id })])).not.toThrow();
+  });
+
+  it('rejects a figure pointing at a canon fact that does not exist', () => {
+    expect(() =>
+      assertLedgerSafe([base({ figure: '1', factId: 'no-such-fact-id' })]),
+    ).toThrow();
+  });
+});
+
+describe('the live ledger', () => {
+  it('passes its own assertion', () => {
+    expect(() => assertLedgerSafe(EXTERNAL_CLAIMS)).not.toThrow();
+  });
+
+  it('has no locked claim carrying a digit anywhere in its statement', () => {
+    const offenders = EXTERNAL_CLAIMS.filter(
+      (c) => c.status === 'locked' && /\d/.test(c.statement),
+    ).map((c) => c.id);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/v2/src/lib/data/claims-ledger.ts
+++ b/v2/src/lib/data/claims-ledger.ts
@@ -288,7 +288,13 @@ export const DIFF_APPOINTMENT = '2026-09-30';
  * Fails loudly (at module load, so at build/dev time) if the ledger violates
  * its own rules. This is the regression test for the 2026-07-11 leak class.
  */
-function assertLedgerSafe(claims: Claim[]): void {
+/**
+ * Exported so the leak-prevention can actually be tested. It runs at module load
+ * below, which means a regression only surfaces as an import-time crash
+ * somewhere downstream, and only if a bad claim happens to exist. The tests in
+ * claims-ledger.guards.test.ts exercise it directly against crafted claims.
+ */
+export function assertLedgerSafe(claims: Claim[]): void {
   for (const c of claims) {
     if (c.status === 'locked') {
       if (c.figure !== undefined) {

--- a/v2/src/lib/data/claims.guards.test.ts
+++ b/v2/src/lib/data/claims.guards.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Claim-hygiene invariants for the content data layer.
+ *
+ * The standing rule is "do not fabricate: no invented quotes, no invented names,
+ * no invented numbers". The failure this test exists for is subtler than an
+ * outright lie, and it had already happened:
+ *
+ *   content.ts carried a `kristyQuote` whose words were invented and attributed
+ *   by name to Kristy Bloomfield, a real Traditional Owner and Oonchiumpa
+ *   director. It was marked `verified: false` with a TODO. Nothing rendered it,
+ *   so nothing caught it, but it sat in the data layer shaped exactly like real
+ *   quote data, one import away from a pitch page.
+ *
+ * `verified: false` is a legitimate state for a STATISTIC. The press page uses it
+ * correctly: the 10-year design life is stated as intent and rendered without a
+ * Verified badge. It is not a legitimate state for words in a named person's
+ * mouth. A quote is either real, and traceable to the storyteller registry, or it
+ * does not exist in the codebase. There is no "draft attribution" state, because
+ * the draft is indistinguishable from the real thing at the point someone wires
+ * it up.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as content from '@/lib/data/content';
+
+type Found = { path: string; author: string; text: string };
+
+const AUTHOR_KEYS = ['author', 'attribution', 'attributedTo', 'speaker', 'by'];
+const TEXT_KEYS = ['text', 'quote', 'body'];
+
+const str = (v: unknown): v is string => typeof v === 'string' && v.trim().length > 0;
+
+/** Walk every plain object reachable from the module's exports. */
+function collectAttributedQuotes(root: unknown): Found[] {
+  const out: Found[] = [];
+  const seen = new WeakSet<object>();
+
+  const visit = (node: unknown, path: string) => {
+    if (node === null || typeof node !== 'object') return;
+    if (seen.has(node as object)) return;
+    seen.add(node as object);
+
+    if (Array.isArray(node)) {
+      node.forEach((child, i) => visit(child, `${path}[${i}]`));
+      return;
+    }
+
+    const rec = node as Record<string, unknown>;
+    const authorKey = AUTHOR_KEYS.find((k) => str(rec[k]));
+    const textKey = TEXT_KEYS.find((k) => str(rec[k]));
+
+    if (authorKey && textKey && rec.verified === false) {
+      out.push({ path, author: rec[authorKey] as string, text: rec[textKey] as string });
+    }
+
+    for (const [key, value] of Object.entries(rec)) visit(value, `${path}.${key}`);
+  };
+
+  visit(root, 'content');
+  return out;
+}
+
+describe('content.ts claim hygiene', () => {
+  it('no quote attributed to a named person is marked unverified', () => {
+    const offenders = collectAttributedQuotes(content).map(
+      (f) => `${f.path} attributes to "${f.author}": "${f.text.slice(0, 70)}…"`,
+    );
+
+    expect(
+      offenders,
+      'An unverified attributed quote is a placeholder in a real person\'s mouth. ' +
+        'Either source the real words (storyteller-registry.ts is the canonical home) ' +
+        'or delete the object. Do not ship it marked false.',
+    ).toEqual([]);
+  });
+
+  it('the walker actually finds this shape, so a green result means something', () => {
+    // Guards the guard: if the traversal silently stopped matching, the test
+    // above would pass for the wrong reason.
+    const decoy = {
+      nested: { block: { text: 'invented words', author: 'A Real Person', verified: false } },
+    };
+
+    const found = collectAttributedQuotes(decoy);
+    expect(found).toHaveLength(1);
+    expect(found[0].author).toBe('A Real Person');
+    expect(found[0].path).toBe('content.nested.block');
+  });
+});

--- a/v2/src/lib/data/consent.guards.test.ts
+++ b/v2/src/lib/data/consent.guards.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Consent gate invariants.
+ *
+ * Two independent default-deny gates decide whether a community voice may be
+ * shown, and nothing until now checked that they agree with each other:
+ *
+ *   1. `isClearedForExternal(name)` (cleared-voices.ts) — an allowlist of names
+ *      Ben cleared for the open web. Unknown name = denied.
+ *   2. `getVoiceTier(name)` (storyteller-registry.ts) — per-person tier, where
+ *      an unknown name falls through to 'hold'. Denied.
+ *
+ * Each carries its own private copy of the same name-normalising function. They
+ * are identical today. If one is ever edited without the other, a held voice can
+ * start passing the allowlist, or a cleared voice can silently vanish from the
+ * site. Neither failure raises an error at runtime, which is why they are tested
+ * here rather than left as convention.
+ *
+ * The rule these encode: a consent decision is only real if the code cannot
+ * quietly reverse it. Failure direction matters. Showing a held voice is a harm
+ * to a person; hiding a cleared voice is a bug we can fix. The tests below treat
+ * those asymmetrically and say so where it matters.
+ *
+ * `check-storyteller-registry.mjs` covers adjacent ground (banned fragments,
+ * misspellings, held names in rendered surfaces) but does it by regex-parsing
+ * the TypeScript source. These tests import the real modules, so they see the
+ * data the app actually loads.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isClearedForExternal } from '@/lib/data/cleared-voices';
+import {
+  STORYTELLER_REGISTRY,
+  getStoryteller,
+  getVoiceTier,
+  type VoiceTier,
+} from '@/lib/data/storyteller-registry';
+
+/** Tiers that must never reach an external surface, whatever else changes. */
+const DENIED_TIERS: VoiceTier[] = ['hold', 'pending', 'internal'];
+
+const recordsWithTier = (tier: VoiceTier) =>
+  STORYTELLER_REGISTRY.filter((r) => r.tier === tier);
+
+describe('isClearedForExternal: default-deny posture', () => {
+  it('denies empty and missing names', () => {
+    expect(isClearedForExternal(null)).toBe(false);
+    expect(isClearedForExternal(undefined)).toBe(false);
+    expect(isClearedForExternal('')).toBe(false);
+    expect(isClearedForExternal('   ')).toBe(false);
+  });
+
+  it('denies a name that is simply not on the list', () => {
+    expect(isClearedForExternal('Someone Not On The List')).toBe(false);
+  });
+
+  it('denies a name that only partially matches a cleared one', () => {
+    // Substring matching would be a consent breach: the gate is exact-after-
+    // normalising, not fuzzy-contains.
+    expect(isClearedForExternal('Dianne')).toBe(false);
+    expect(isClearedForExternal('Stokes')).toBe(false);
+    expect(isClearedForExternal('Dianne Stokes Jr')).toBe(false);
+  });
+
+  it('allows a known cleared voice', () => {
+    expect(isClearedForExternal('Dianne Stokes')).toBe(true);
+  });
+});
+
+describe('isClearedForExternal: the spelling tolerances it promises', () => {
+  it('ignores case', () => {
+    expect(isClearedForExternal('dianne stokes')).toBe(true);
+    expect(isClearedForExternal('DIANNE STOKES')).toBe(true);
+  });
+
+  it('strips parentheticals, which is how Empathy Ledger sends skin names', () => {
+    expect(isClearedForExternal('Norman Frank (Jupurrurla)')).toBe(true);
+  });
+
+  it('strips honorific punctuation', () => {
+    expect(isClearedForExternal('Dr. Boe Remenyi')).toBe(true);
+  });
+
+  it('collapses doubled whitespace', () => {
+    expect(isClearedForExternal('Alfred  Johnson')).toBe(true);
+  });
+
+  it('accepts both "&" and "and" for joint credits', () => {
+    // NOTE: this tolerance comes from listing both spellings, not from the
+    // normaliser, which does not touch "&". Any new joint credit must add both
+    // spellings or this tolerance silently does not apply to it.
+    expect(isClearedForExternal('Carmelita & Colette')).toBe(true);
+    expect(isClearedForExternal('Carmelita and Colette')).toBe(true);
+  });
+});
+
+describe('getVoiceTier: default-deny posture', () => {
+  it('falls through to hold for unknown and missing names', () => {
+    expect(getVoiceTier(null)).toBe('hold');
+    expect(getVoiceTier(undefined)).toBe('hold');
+    expect(getVoiceTier('')).toBe('hold');
+    expect(getVoiceTier('Someone Not In The Registry')).toBe('hold');
+  });
+
+  it('resolves aliases to the canonical record, so a variant spelling cannot dodge a tier', () => {
+    const withAliases = STORYTELLER_REGISTRY.filter((r) => (r.aliases?.length ?? 0) > 0);
+    expect(withAliases.length).toBeGreaterThan(0);
+
+    for (const record of withAliases) {
+      for (const alias of record.aliases ?? []) {
+        expect(getStoryteller(alias)?.slug, `alias "${alias}" of ${record.name}`).toBe(record.slug);
+        expect(getVoiceTier(alias), `alias "${alias}" of ${record.name}`).toBe(record.tier);
+      }
+    }
+  });
+});
+
+describe('the two gates agree (this is the one that prevents a breach)', () => {
+  it.each(DENIED_TIERS)('no voice at tier "%s" is cleared for external display', (tier) => {
+    const records = recordsWithTier(tier);
+    expect(records.length, `expected at least one ${tier} record to make this test meaningful`)
+      .toBeGreaterThan(0);
+
+    for (const record of records) {
+      expect(
+        isClearedForExternal(record.name),
+        `CONSENT BREACH: "${record.name}" is tier '${tier}' but passes the external allowlist`,
+      ).toBe(false);
+
+      for (const alias of record.aliases ?? []) {
+        expect(
+          isClearedForExternal(alias),
+          `CONSENT BREACH: alias "${alias}" of held voice "${record.name}" passes the allowlist`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('every voice at tier "external" is on the allowlist', () => {
+    // Failure here is the safe direction (a cleared person goes missing from the
+    // site rather than a held person appearing) but it is still wrong, and it is
+    // invisible without this test.
+    const missing = recordsWithTier('external')
+      .filter((r) => !isClearedForExternal(r.name))
+      .map((r) => r.name);
+
+    expect(missing, 'tier external but not on the cleared-voices allowlist').toEqual([]);
+  });
+});
+
+describe('registry data integrity', () => {
+  it('every record carries a known tier', () => {
+    const valid: VoiceTier[] = ['external', 'website', 'funder', 'hold', 'pending', 'internal'];
+    for (const record of STORYTELLER_REGISTRY) {
+      expect(valid, `${record.name} has tier "${record.tier}"`).toContain(record.tier);
+    }
+  });
+
+  it('slugs are unique', () => {
+    const slugs = STORYTELLER_REGISTRY.map((r) => r.slug);
+    expect(slugs.length).toBe(new Set(slugs).size);
+  });
+
+  it('no two records claim the same name or alias, which would make lookups ambiguous', () => {
+    const seen = new Map<string, string>();
+    const collisions: string[] = [];
+    const norm = (s: string) =>
+      s.toLowerCase().replace(/\([^)]*\)/g, ' ').replace(/[.,]/g, ' ').replace(/\s+/g, ' ').trim();
+
+    for (const record of STORYTELLER_REGISTRY) {
+      for (const spelling of [record.name, ...(record.aliases ?? [])]) {
+        const key = norm(spelling);
+        const owner = seen.get(key);
+        if (owner && owner !== record.slug) {
+          collisions.push(`"${spelling}" claimed by both ${owner} and ${record.slug}`);
+        }
+        seen.set(key, record.slug);
+      }
+    }
+
+    expect(collisions).toEqual([]);
+  });
+
+  it('a misspelling is never also a real name or alias somewhere else', () => {
+    const norm = (s: string) => s.toLowerCase().replace(/\s+/g, ' ').trim();
+    const realNames = new Set(
+      STORYTELLER_REGISTRY.flatMap((r) => [r.name, ...(r.aliases ?? [])]).map(norm),
+    );
+
+    const conflicts = STORYTELLER_REGISTRY.flatMap((r) =>
+      (r.misspellings ?? [])
+        .filter((m) => realNames.has(norm(m)))
+        .map((m) => `${r.name}: banned misspelling "${m}" is a real name elsewhere`),
+    );
+
+    expect(conflicts).toEqual([]);
+  });
+
+  it('the set of held voices awaiting a tier decision does not grow unnoticed', () => {
+    // `tier` and `quote.status` answer different questions. tier = may this
+    // PERSON be quoted externally. status = is this LINE usable at all. So a
+    // held person holding an approved line is legitimate: the line is fine, the
+    // attribution is not yet decided.
+    //
+    // Both current cases came from the same 2026-07-21 cleanup, where quotes
+    // misfiled under Georgina Byron were reattributed to newly created records.
+    // Each record's own note says the tier is Ben's call, and neither call has
+    // been made.
+    //
+    // Pinning them here turns "Ben still has to decide" from a note nobody
+    // re-reads into a failing test. A third one appearing means someone parked a
+    // real person's words without resolving whether they may be published.
+    const KNOWN_PENDING_TIER_DECISIONS = ['kylie-bloomfield', 'katherine-deadly-heart-trek'];
+
+    const awaiting = STORYTELLER_REGISTRY.filter(
+      (r) => r.tier === 'hold' && r.quotes.some((q) => q.status === 'primary' || q.status === 'approved'),
+    ).map((r) => r.slug);
+
+    expect(
+      awaiting.sort(),
+      'a held voice has a usable quote and is not a known pending decision. Get the tier ruling before this line reaches a deck, then add the slug here or change the tier.',
+    ).toEqual([...KNOWN_PENDING_TIER_DECISIONS].sort());
+  });
+});

--- a/v2/src/lib/data/consent.guards.test.ts
+++ b/v2/src/lib/data/consent.guards.test.ts
@@ -209,15 +209,21 @@ describe('registry data integrity', () => {
     // Pinning them here turns "Ben still has to decide" from a note nobody
     // re-reads into a failing test. A third one appearing means someone parked a
     // real person's words without resolving whether they may be published.
+    // Asserted as a subset, not an exact match. Exact equality would also fail
+    // when one of these is RESOLVED, turning good news into a red build, and it
+    // fails on any branch where these records do not exist yet. What we actually
+    // care about is that nothing is awaiting a decision we have not written down.
     const KNOWN_PENDING_TIER_DECISIONS = ['kylie-bloomfield', 'katherine-deadly-heart-trek'];
 
-    const awaiting = STORYTELLER_REGISTRY.filter(
+    const unexpected = STORYTELLER_REGISTRY.filter(
       (r) => r.tier === 'hold' && r.quotes.some((q) => q.status === 'primary' || q.status === 'approved'),
-    ).map((r) => r.slug);
+    )
+      .map((r) => r.slug)
+      .filter((slug) => !KNOWN_PENDING_TIER_DECISIONS.includes(slug));
 
     expect(
-      awaiting.sort(),
+      unexpected.sort(),
       'a held voice has a usable quote and is not a known pending decision. Get the tier ruling before this line reaches a deck, then add the slug here or change the tier.',
-    ).toEqual([...KNOWN_PENDING_TIER_DECISIONS].sort());
+    ).toEqual([]);
   });
 });

--- a/v2/src/lib/data/content.ts
+++ b/v2/src/lib/data/content.ts
@@ -1438,13 +1438,14 @@ export const oonchiumpaPartnership = {
   headline: 'Oonchiumpa / Bloomfield Family',
   subheadline: '100% Aboriginal-owned consultancy, deep roots in Central Australia',
   description: 'Two years designing products in community, "around the fire", building washing machines together, and planning a production facility in Alice Springs. Kristy Bloomfield leads cultural consultation at university-equivalent rates (~$3,800/day).',
-  // TODO: Replace with verified Kristy Bloomfield quote when available
-  kristyQuote: {
-    text: 'We see this as bigger than beds. It\'s about families owning the whole thing: the making, the business, the future.',
-    author: 'Kristy Bloomfield',
-    context: 'Oonchiumpa Consultancy, Alice Springs',
-    verified: false, // PLACEHOLDER: needs real quote from Kristy
-  },
+  // No quote here on purpose. This object used to carry a `kristyQuote` whose
+  // text was invented and attributed by name to Kristy Bloomfield, marked
+  // `verified: false` with a TODO. Nothing rendered it, but it was shaped
+  // exactly like real quote data and one wiring-up away from putting words in a
+  // real person's mouth. Removed 2026-07-25.
+  //
+  // Her actual cleared words live in storyteller-registry.ts (slug
+  // 'kristy-bloomfield', tier 'external'). Read them from there.
   fredVideo: {
     title: 'Community Voices: Fred, Oonchiumpa',
     embedUrl: 'https://share.descript.com/embed/YQwAcYfxzkn',

--- a/v2/src/lib/storytellers.consent.test.ts
+++ b/v2/src/lib/storytellers.consent.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The public storyteller route is consent-gated at the data layer.
+ *
+ * `/storytellers` and `/storytellers/[slug]` render a person's name, photo, bio,
+ * community and Elder badge on the open web, and the detail route also emits
+ * their name, bio and avatar into OpenGraph tags and pre-renders a static page
+ * per slug. Before 2026-07-25 none of that consulted a consent gate: it showed
+ * whatever Empathy Ledger returned.
+ *
+ * Gating the index alone would not have been enough. `generateStaticParams()`
+ * builds a page per slug and `generateMetadata()` writes the OG tags, so an
+ * uncleared person stayed reachable by typing their slug. All three entry points
+ * therefore go through `getPublicStorytellers()`, and these tests hold that.
+ *
+ * Why a name allowlist rather than EL's own signal: EL has no per-storyteller
+ * consent column. Its clearance number counts STORIES passing the syndication
+ * RPC, which as at 2026-07-25 resolved to 1 person across the whole Goods
+ * project. That empties a directory rather than gating it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { EmpathyLedgerStoryteller } from '@/lib/empathy-ledger/types';
+
+const getStorytellers = vi.fn();
+
+vi.mock('@/lib/empathy-ledger', () => ({
+  empathyLedger: {
+    getStorytellers: () => getStorytellers(),
+    getGoodsSiteClearance: async () => ({}),
+  },
+}));
+
+/** Minimal shape: these helpers only read id and displayName. */
+const teller = (displayName: string, id = displayName): EmpathyLedgerStoryteller =>
+  ({ id, displayName }) as unknown as EmpathyLedgerStoryteller;
+
+// One name on the cleared-voices allowlist, one deliberately not on it.
+const CLEARED = 'Dianne Stokes';
+const UNCLEARED = 'Someone Not Cleared';
+
+/** Fresh module each time: getGoodsStorytellers memoises in a module-level cache. */
+async function loadModule() {
+  vi.resetModules();
+  return import('@/lib/storytellers');
+}
+
+beforeEach(() => {
+  getStorytellers.mockReset();
+  getStorytellers.mockResolvedValue([teller(CLEARED), teller(UNCLEARED)]);
+});
+
+describe('getPublicStorytellers', () => {
+  it('keeps cleared voices and drops uncleared ones', async () => {
+    const { getPublicStorytellers } = await loadModule();
+    const names = (await getPublicStorytellers()).map((s) => s.displayName);
+
+    expect(names).toContain(CLEARED);
+    expect(names).not.toContain(UNCLEARED);
+  });
+
+  it('returns nothing when Empathy Ledger fails, rather than falling open', async () => {
+    getStorytellers.mockRejectedValue(new Error('EL 404'));
+    const { getPublicStorytellers } = await loadModule();
+
+    expect(await getPublicStorytellers()).toEqual([]);
+  });
+
+  it('leaves the raw accessor ungated, because admin surfaces need to see the gaps', async () => {
+    const { getGoodsStorytellers } = await loadModule();
+    const names = (await getGoodsStorytellers()).map((s) => s.displayName);
+
+    expect(names).toEqual([CLEARED, UNCLEARED]);
+  });
+});
+
+describe('getStorytellerBySlug: the direct-URL hole', () => {
+  it('resolves a cleared storyteller', async () => {
+    const { getStorytellerBySlug } = await loadModule();
+    expect(await getStorytellerBySlug('dianne-stokes')).not.toBeNull();
+  });
+
+  it('returns null for an uncleared storyteller, so the route 404s', async () => {
+    // Gating only the index would leave this reachable by typing the slug.
+    const { getStorytellerBySlug } = await loadModule();
+    expect(await getStorytellerBySlug('someone-not-cleared')).toBeNull();
+  });
+});
+
+describe('listStorytellerSlugs: no static page or OpenGraph tags for uncleared people', () => {
+  it('lists only cleared storytellers', async () => {
+    const { listStorytellerSlugs } = await loadModule();
+    const slugs = await listStorytellerSlugs();
+
+    expect(slugs.map((s) => s.slug)).toEqual(['dianne-stokes']);
+    expect(slugs.map((s) => s.name)).not.toContain(UNCLEARED);
+  });
+});

--- a/v2/src/lib/storytellers.ts
+++ b/v2/src/lib/storytellers.ts
@@ -14,6 +14,7 @@
 
 import { empathyLedger } from './empathy-ledger';
 import type { EmpathyLedgerStoryteller } from './empathy-ledger/types';
+import { isClearedForExternal } from './data/cleared-voices';
 
 export function slugify(s: string): string {
   return s
@@ -36,13 +37,40 @@ export async function getGoodsStorytellers(): Promise<EmpathyLedgerStoryteller[]
   }
 }
 
-export async function getStorytellerBySlug(slug: string): Promise<EmpathyLedgerStoryteller | null> {
+/**
+ * The consent-gated set: only storytellers cleared for the open web.
+ *
+ * Use this for anything public. `getGoodsStorytellers()` above is the RAW set
+ * and is correct only for admin surfaces, which need to see uncleared people in
+ * order to spot gaps.
+ *
+ * The gate is `isClearedForExternal`, a name allowlist, because Empathy Ledger
+ * has no per-storyteller consent field. Its clearance signal counts STORIES
+ * passing the syndication RPC, which is a different question from whether this
+ * person may be named on the site, and as at 2026-07-25 it resolved to one
+ * person out of the whole project. See the header of `cleared-voices.ts`.
+ */
+export async function getPublicStorytellers(): Promise<EmpathyLedgerStoryteller[]> {
   const all = await getGoodsStorytellers();
+  return all.filter((s) => isClearedForExternal(s.displayName));
+}
+
+/**
+ * Slug lookup for the PUBLIC storyteller route. Gated, so an uncleared person
+ * cannot be reached by typing their slug directly. Returns null for them, which
+ * the route turns into a 404.
+ */
+export async function getStorytellerBySlug(slug: string): Promise<EmpathyLedgerStoryteller | null> {
+  const all = await getPublicStorytellers();
   return all.find((s) => slugify(s.displayName) === slug) || null;
 }
 
+/**
+ * Slugs to pre-render for the public route. Gated: an uncleared storyteller must
+ * not get a static page, a title, a bio or an OpenGraph image built for them.
+ */
 export async function listStorytellerSlugs(): Promise<{ slug: string; name: string }[]> {
-  const all = await getGoodsStorytellers();
+  const all = await getPublicStorytellers();
   return all.map((s) => ({ slug: slugify(s.displayName), name: s.displayName }));
 }
 
@@ -50,8 +78,14 @@ export type StorytellerClearance = { cleared: number; candidate: number };
 export type GoodsStorytellerRow = EmpathyLedgerStoryteller & { clearance: StorytellerClearance };
 
 /**
- * Storytellers + their "cleared for the Goods public surface" verdict, derived
- * from EL's canonical syndication gate. For the admin cockpit only.
+ * Storytellers + their EL syndication verdict. Admin surfaces only, and
+ * currently unused by anything.
+ *
+ * NOT a consent gate for a directory of people: `cleared` counts this person's
+ * STORIES that pass EL's syndication RPC. As at 2026-07-25 the Goods project had
+ * 10 published stories, 2 of which passed the gate, belonging to 1 storyteller,
+ * so filtering people on it would empty a page rather than gate it. Use
+ * `getPublicStorytellers()` for that.
  */
 export async function getGoodsStorytellersWithClearance(): Promise<GoodsStorytellerRow[]> {
   const [tellers, clearance] = await Promise.all([


### PR DESCRIPTION
Surgical PR off `main`, carrying only the two defects that are live on production plus the tests that hold them. The rest of this session's work stays on `claude/investment-deck-alignment-y3qc43`.

## What is wrong on production today

**`/storytellers` and `/storytellers/[slug]` have no consent gate.** They render every storyteller Empathy Ledger returns: name, photo, bio, community, Elder badge. Public and indexable. The same EL source is gated on `/gallery`, `/stories`, `/community` and `/communities/[slug]` through the `cleared-voices` allowlist.

Gating the index alone would not close it. `generateStaticParams()` builds a page per slug and `generateMetadata()` writes the person's name, bio and avatar into the title and OpenGraph tags, so an uncleared person stays reachable by typing their slug. The gate therefore sits at the data layer in `getPublicStorytellers()`, and all three entry points go through it.

`getGoodsStorytellers()` stays raw and ungated on purpose: the two admin EL pages need to see uncleared people to spot gaps, and `/communities/[slug]` already filters downstream.

**The press page lists "9 Communities" against a canon of 11, wearing a literal green "Verified" badge**, because `verified: true` drives that badge. That 9 traces to the 2026-05-30 alignment snapshot. Beds and communities now read from `CANONICAL_ASSETS`.

**`content.ts` carried an invented quote attributed by name to Kristy Bloomfield**, a Traditional Owner and Oonchiumpa director, marked `verified: false` with a TODO. Nothing rendered it, so nothing caught it, but it was shaped exactly like real quote data and one import away from a pitch page. Her real cleared words are already in `storyteller-registry.ts`.

## Why an allowlist rather than EL's own clearance signal

Checked all 40-odd columns on EL's `storytellers` table: `content_status`, `is_active`, `deleted_at`, `verified_at`, and **no consent column at all**. EL's clearance number counts a person's *stories* passing the syndication RPC, and the Goods project has 10 published stories, 2 of which pass, belonging to 1 storyteller. Filtering people on that empties the page rather than gating it. The header comment in `cleared-voices.ts` stands: the name list is the only person-level gate that exists.

## Tests

- **consent gates agree** (20): default-deny on empty/unknown/partial names, the spelling tolerances the gate promises, alias resolution so a variant spelling cannot dodge a tier, and the cross-gate invariants that matter most, that no voice at tier hold/pending/internal passes the allowlist and every tier-external voice is on it.
- **storyteller routes** (6): including the direct-URL hole (an uncleared slug resolves to null so the route 404s) and fail-closed behaviour when EL is unavailable.
- **claim hygiene** (2): walks every object reachable from `content.ts` exports and fails on any pairing an author with text while marked unverified. Also runs the walker against a decoy, so a green result cannot mean the traversal quietly stopped matching.
- **claims-ledger safety** (8): `assertLedgerSafe()` had no test. It is the rule that stopped the withheld revenue figure reaching the web after it leaked to `/deck` once, and it runs at module load, so a regression would only have surfaced as an import-time crash.

## CI

`claude/**` and `docs/**` added to the push triggers. Every Claude Code session works on a `claude/*` branch, so session pushes ran no checks at all until someone opened a PR.

## Verification

224 tests green, `npm run build` clean, `npm run check:drift:ci` exit 0, all on this branch off `main`.

## Deliberately not included

The retired-figure drift guard and the canon work from the same session. The guard fails on `main` because production's `CANONICAL_ASSETS.washersInCommunity` is still 20, predating the 2026-07-21 ruling of 22. Shipping it here would drag a public figure change into a PR scoped to the consent gate. It rides with the larger branch merge instead.

## Visible change

`/storytellers` will show cleared voices only. EL's content-hub endpoint is currently returning 404s, so that page is likely rendering its empty state today either way, but worth an eye on the preview.