### PR TITLE
Stop the legacy redirect shadowing the /brand page

### DIFF
--- a/v2/next.config.ts
+++ b/v2/next.config.ts
@@ -77,7 +77,18 @@ const nextConfig: NextConfig = {
   async redirects() {
     return [
       { source: '/media', destination: '/press', permanent: true },
-      { source: '/brand', destination: '/press#brand-system', permanent: true },
+      // The '/brand' -> '/press#brand-system' redirect was REMOVED 2026-07-25. It predated the
+      // dedicated /brand page (src/app/brand/page.tsx, the brand kit and guide downloads) and
+      // silently shadowed it: the route shipped in PR #160 and was unreachable in production,
+      // 308-ing to the press page's brand section instead.
+      //
+      // CACHING GOTCHA, because the old rule was `permanent: true` and that is a 308: browsers
+      // and intermediaries cache it hard, so anyone who has already hit /brand keeps getting
+      // redirected until they hard-refresh or clear it. A clean client sees the new page
+      // immediately. If you test and still land on /press, that is the cache, not the config.
+      //
+      // /press#brand-system still exists and is still correct; it is the short version. Do not
+      // re-add a redirect here without checking whether src/app/brand/page.tsx is still live.
     ];
   },
 };


### PR DESCRIPTION
`/brand` shipped in #160 and is **unreachable in production**. A redirect that predates it catches the request first:

```
{ source: '/brand', destination: '/press#brand-system', permanent: true }
```

Verified against www after #160 merged: `/brand` returns 308, final URL `/press#brand-system`. The brand kit and guide page never renders.

One line removed. `/press#brand-system` still exists and is still correct; it is the short version of the same material.

## Two things worth knowing

**The old rule was `permanent: true`, so it is a 308 and gets cached hard.** Anyone who has already hit `/brand` will keep being redirected until they hard-refresh or clear it. A clean client gets the new page immediately. If it still lands on `/press` after this ships, that is the cache, not the config.

**Nothing in the app links to `/brand`.** It is direct-URL only, which is fine for a page you hand to press and partners, but it means the redirect could shadow it indefinitely without anyone noticing. Which is what happened. Left a note in `next.config.ts` not to re-add a redirect there without checking the route still exists.

## Verification

`tsc` 0 · 267 tests · build clean · `check:drift` 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)