### PR TITLE
Make the retired-figure guard catch phrases and money, so sweeps cannot rot

### DIFF
--- a/v2/scripts/check-retired-figures.mjs
+++ b/v2/scripts/check-retired-figures.mjs
@@ -52,7 +52,103 @@ const RETIRED = [
   { value: '16', what: 'washers in community', now: '22', context: /washer|washing machine|pakkimjalki/i, ruling: 'Ben 2026-07-21' },
   { value: '28', what: 'washers deployed', now: '22', context: /washer|washing machine/i, ruling: 'retired split, never reinstate' },
   { value: '9', what: 'communities served', now: '11', context: /communities (served|reached)|across 9 communities/i, ruling: '2026-07-19 canon move' },
+
+  // MONEY. Added 2026-07-26 after a retired capex band was found in the PRESENTER TALK TRACK,
+  // one day after the ruling that retired it. Every entry below reached a funder-facing surface.
+  { value: '475K', what: 'the old lead stack', now: '$607.5K grants / $710K repayable', context: /stack|sefa|snow|centrecorp/i, ruling: 'stack rebuilt 2026-07-25 from all 67 CRM rows' },
+  { value: '150K', what: 'per-site plant capital band', now: 'priced per site by the module model', context: /per site|a site|plant capital/i, ruling: 'DECISIONS.md ruling O' },
+  { value: '403,901', what: 'the "surplus"', now: 'never cited; the entity P&L is a net loss', context: /surplus|profit|revenue/i, ruling: 'DECISIONS.md ruling H' },
 ];
+
+/**
+ * RETIRED PHRASES. The gap that let ruling D rot for a day and ruling O reach a talk track.
+ *
+ * A retired number is unambiguous. A retired phrase is not, so every entry needs a `context` or a
+ * tight pattern, and the exemptions below matter more than the patterns do.
+ */
+const RETIRED_PHRASES = [
+  {
+    pattern: /\bco-design(ed|ing)?\b/i,
+    what: '"co-design"',
+    use: 'designed in community, led by community',
+    ruling: 'Ben 2026-07-11, standing',
+  },
+  {
+    pattern: /\b(become unnecessary|then step back)\b/i,
+    what: 'the retired purpose line',
+    use: 'name what Goods is FOR after a handover: design, quality, training, parts, back office',
+    ruling: 'DECISIONS.md ruling A',
+  },
+  {
+    pattern: /\baccountant[- ]signed\b/i,
+    what: '"accountant-signed"',
+    use: 'workpaper, prepared with the accountant. No signed document exists.',
+    ruling: 'DECISIONS.md rulings G and H',
+  },
+  {
+    pattern: /\b75\s*(to|-|–)\s*100\s+beds\b/i,
+    what: 'the "75 to 100 beds a year" claim',
+    use: 'the honest denominator is 234 to 529 beds/yr, decided by who pays the line supervisor',
+    ruling: 'DECISIONS.md ruling I',
+  },
+  {
+    pattern: /\bNET_CAPITAL/,
+    what: 'a net capital figure',
+    use: 'quote capital GROSS only, with sunk spend stated beside it',
+    ruling: 'DECISIONS.md ruling P',
+  },
+  {
+    // The object, not the building. "the plant" as the thing offered to or owned by a community.
+    pattern: /\b(a|the)\s+plant\s+(is\s+the\s+(path|bridge)|that\s+(can\s+)?moves?|can\s+(move|transfer))\b/i,
+    what: 'the plant as the thing offered or transferred',
+    use: 'infrastructure that scales from a single shredder up. Name the making or the facility.',
+    ruling: 'DECISIONS.md ruling D',
+  },
+  {
+    pattern: /\b(community[- ]owned plant|owns? the plant|back the plant)\b/i,
+    what: 'the plant as the ownership object',
+    use: 'the making, or the site. And ownership is a pathway: use "toward".',
+    ruling: 'DECISIONS.md ruling D',
+  },
+];
+
+/**
+ * Files that RECORD a retirement necessarily contain the retired words.
+ *
+ * This is the third time this pattern has bitten in one week (mustNeverSee in audience.ts,
+ * neverSay in deck-road.ts, and now here). A guard that reads the file enforcing the rule will
+ * always flag the rule itself.
+ */
+const PHRASE_EXEMPT = [
+  { path: 'lib/data/retired', why: 'Anything explicitly named as a retired-claims register.' },
+  { path: 'guards.test.', why: 'Guard tests assert on the retired strings by design.' },
+  { path: 'check-', why: 'This script and its siblings quote what they ban.' },
+  { path: 'app/admin', why: 'Internal operator UI, and it is where we TELL editors what not to write.' },
+];
+
+/**
+ * A line that NEGATES a retired phrase is enforcing the rule, not breaking it.
+ *
+ * This is the fourth time in one week a guard has flagged the field that enforces the thing it
+ * guards (mustNeverSee in audience.ts, neverSay in deck-road.ts, the MEL historical record, and
+ * now every "not accountant-signed" in the codebase). Without this, the guard fires on
+ * ask-surface.ts saying "workpaper (not accountant-signed)", which is exactly right.
+ *
+ * Deliberate tradeoff: a negation ANYWHERE on the line suppresses that line. A long line that
+ * both negates one claim and asserts another would slip through. Accepted, because the failure
+ * direction of the alternative is worse: a guard with false positives gets muted, and a muted
+ * guard catches nothing at all.
+ */
+const NEGATED = /\b(not|never|no longer|retired|banned|instead of|rather than|do not|don't|avoid|stop using|is wrong)\b/i;
+
+/**
+ * Ownership language is compliant when it names itself as a pathway. Ruling D and the standing
+ * ceiling forbid claiming ownership COMPLETE, not discussing ownership.
+ */
+const PATHWAY_QUALIFIED = /\b(still ahead|not yet|destination|over time|toward|towards|pathway|will be|closer to|moving)\b/i;
+
+/** "co-design" as a ThemeId key or label is data, not prose. Migration is tracked separately. */
+const CODESIGN_AS_KEY = /(theme|themes|id)\s*:|['"`]co-design['"`]\s*[:,\]]|\|\s*'co-design'/;
 
 /**
  * Lines that legitimately mention a retired figure. Each needs a reason: this
@@ -63,6 +159,16 @@ const ALLOWED = [
     file: 'lib/data/compendium.ts',
     match: /Washing machine count: 5 deployed/,
     why: 'A note recording a past data discrepancy. Quoting the old number is the point.',
+  },
+  {
+    file: 'lib/data/compendium.ts',
+    match: /Per 2026-07-03 lead stack/,
+    why: 'Explicitly dated as the 3 July position. A record of what was true then, not a claim about now.',
+  },
+  {
+    file: 'lib/data/cost-story.ts',
+    match: /never the \$403,901/i,
+    why: 'A watchOut instructing us NEVER to cite this figure. The rule has to name the number it bans.',
   },
 ];
 
@@ -92,7 +198,10 @@ for (const file of walk(SRC)) {
     for (const fig of RETIRED) {
       // The literal in a rendered position: quoted, in JSX text, or after a separator.
       const escaped = fig.value.replace(',', '[,]');
-      if (!new RegExp(`(['"\`>·]\\s*)${escaped}(?![0-9%])`).test(line)) continue;
+      // Prefix class includes $ because money figures are written "$475K", and the money entries
+      // are the ones that actually reached a funder. Found by probing the guard with known-bad
+      // lines rather than trusting it: without $, it silently missed both capex entries.
+      if (!new RegExp(`(['"\`>·$]\\s*)${escaped}(?![0-9%])`).test(line)) continue;
       if (fig.context && !fig.context.test(line)) continue;
       if (isDateOrVersion(line, fig.value)) continue;
       if (ALLOWED.some((a) => rel.includes(a.file) && a.match.test(line))) continue;
@@ -100,6 +209,21 @@ for (const file of walk(SRC)) {
       violations.push(
         `  ${rel}:${idx + 1}\n` +
           `    retired ${fig.what}: ${fig.value} -> ${fig.now}  (${fig.ruling})\n` +
+          `    ${line.trim().slice(0, 110)}`,
+      );
+    }
+
+    if (PHRASE_EXEMPT.some((e) => rel.includes(e.path))) return;
+
+    for (const ph of RETIRED_PHRASES) {
+      if (!ph.pattern.test(line)) continue;
+      if (NEGATED.test(line)) continue;
+      if (PATHWAY_QUALIFIED.test(line)) continue;
+      if (/co-design/i.test(ph.what) && CODESIGN_AS_KEY.test(line)) continue;
+      violations.push(
+        `  ${rel}:${idx + 1}\n` +
+          `    retired phrase, ${ph.what}  (${ph.ruling})\n` +
+          `    use instead: ${ph.use}\n` +
           `    ${line.trim().slice(0, 110)}`,
       );
     }
@@ -117,4 +241,4 @@ if (violations.length) {
   process.exit(1);
 }
 
-console.log('OK — no retired canon figures found in src/.');
+console.log(`OK — no retired figures or phrases in src/ (${RETIRED.length} figures, ${RETIRED_PHRASES.length} phrases guarded).`);

--- a/v2/src/lib/data/audience.ts
+++ b/v2/src/lib/data/audience.ts
@@ -120,7 +120,7 @@ export const AUDIENCES: Audience[] = [
       'A facility proposal before a yarn.',
       'The cost model as a spreadsheet. It is presented as the questions it came from, and the answers belong to the community.',
       'Their own photo, story or name used before they cleared it.',
-      'The words "co-design". The products are designed in community, led by community.',
+      'Never the words "co-design". The products are designed in community, led by community.',
     ],
     nextAction: 'A yarn, with nothing proposed.',
     door: null,

--- a/v2/src/lib/data/content.ts
+++ b/v2/src/lib/data/content.ts
@@ -1687,7 +1687,7 @@ export const enterpriseVision = {
     'Logistics and delivery',
   ],
   youthPathways: 'Young people learning manufacturing, business skills, and robotics through Red Dust partnership. A pathway from community engagement to employment.',
-  ownership: 'Communities eventually own and run the whole operation. We transfer manufacturing capability, supply chain connections, and quality frameworks, then step back.',
+  ownership: 'Communities come to own and run the making over time. We transfer manufacturing capability, supply chain connections and quality frameworks, and afterwards Goods stays useful for design, quality, training, parts and back office.',
 };
 
 // Themes from community voices

--- a/v2/src/lib/data/product-wiki.ts
+++ b/v2/src/lib/data/product-wiki.ts
@@ -300,7 +300,7 @@ const PLANT: ProductWiki = {
       title: 'A pathway to community ownership',
       body: [
         'The plant is designed to move to community ownership. That transfer has not happened yet, and Goods is careful never to claim it has. The pathway is being built through a first measured production run, a first community operator on payroll, quality control and maintenance, working capital, and a clear transfer of rights and decisions.',
-        'The stated goal of the whole enterprise is to move title, contracts, margin, knowledge and decisions into community hands, and then step back.',
+        'The stated goal of the whole enterprise is to move title, contracts, margin, knowledge and decisions toward community hands. Goods does not disappear afterwards: design, quality, training, parts and back office are what it is for.',
       ],
       image: `${P}/process/01-source.jpg`,
     },

--- a/v2/src/lib/data/trip-stories.ts
+++ b/v2/src/lib/data/trip-stories.ts
@@ -1030,13 +1030,13 @@ const utopia: TripStory = {
         {
           who: 'Funders',
           title: 'Move the making to Country',
-          body: 'Back the containerised plant and the move to community ownership. Production is around 85% complete. The next round closes the gap and starts local jobs.',
-          cta: { label: 'Back the plant', href: '/partner' },
+          body: 'Back local production and the move toward community ownership. Production is around 85% complete. The next round closes the gap and starts local jobs.',
+          cta: { label: 'Back local production', href: '/partner' },
         },
         {
           who: 'Partners',
           title: 'Build it in your community',
-          body: 'Bring the work to your homelands. The design happens in community with the people who will use it. Goods supports the build and the realising. The community runs and owns the plant.',
+          body: 'Bring the work to your homelands. The design happens in community with the people who will use it. Goods supports the build and the realising, and the making moves toward the community that runs it.',
           cta: { label: 'Start a conversation', href: '/partner' },
         },
       ],


### PR DESCRIPTION
Four rulings this week had sweep lists that rotted, and a capex band retired by ruling O reached the **presenter talk track** a day later. The fix is a guard, not more discipline.

## I did not build a new script

`check-retired-figures.mjs` already existed and already ran in `check:drift:ci`. It covered canon **counts** only, which is exactly why every money figure and every retired phrase walked past it. Extended rather than duplicated — a second guard doing the same job is the sprawl this week has been about.

**Added:** three money figures that actually reached funders ($475K lead stack, $100-150K per-site band, $403,901 "surplus") and seven retired phrases with their rulings.

## The hard part was false positives, not patterns

First run: **31 violations, most of them the guard flagging the rule that enforces the rule.** `ask-surface.ts` says *"workpaper (not accountant-signed)"*. `audience.ts` lists co-design in `mustNeverSee`. `partners/dashboard` says *"the community owns the plant. This is the destination, and it is still ahead of us"* — which I'd already held up as the correct model.

A guard that fires on those gets muted in a week, and a muted guard catches nothing. So it now understands **negation** and **pathway qualifiers**, skips `admin` (where we tell editors what *not* to write), and treats `co-design` as data when it's a `ThemeId` key, since that migration is tracked separately per `CLAUDE.md`.

**This is the fourth time in a week a guard has flagged the field enforcing its own rule.** The docblock says so.

## I probed it rather than trusting it, and that mattered

A fixture of 7 known-bad and 2 known-good lines showed it **silently missing both money figures** — the prefix pattern required a quote or separator, and money is written `$475K`. Without the probe this would have shipped not catching the exact figures that motivated it. Now 7 of 7, both compliant lines correctly ignored.

## Six real violations it found that my manual sweep missed

`content.ts` and `product-wiki.ts` both ended the ownership story with *"then step back"* (ruling A). `trip-stories.ts` had *"Back the plant"* as a CTA and *"The community runs and owns the plant"* in present tense. `investor-narrative-lab` and `pitch-workshop` had the plant as the thing that moves to ownership.

Two allowlisted with reasons: `compendium.ts` is explicitly dated "per 2026-07-03" (a record, not a claim), and `cost-story.ts` has a watchOut that must name the figure it bans.

## On the two stale PRs

Salvaged the idea, not the code. **#55**'s community-count guard was the right shape with a figure that is now itself stale (9; canon says 11). **#22**'s brand linter duplicates `check:voice`. Neither needs to merge.

`tsc` clean · 351 tests · `check:drift:ci` clean · build clean