### PR TITLE
feat(register): per-community integrity judge — count rulings enforced in code

### DIFF
--- a/v2/package.json
+++ b/v2/package.json
@@ -19,7 +19,7 @@
     "check:artifacts": "node scripts/check-artifact-drift.mjs",
     "check:qbe-readiness": "node scripts/check-qbe-readiness.mjs",
     "check:story-coverage": "node scripts/check-story-coverage.mjs",
-    "check:drift": "npm run check:community-copy && npm run check:qbe-guardrails && npm run check:canon && npm run check:artifacts && npm run check:qbe-readiness && npm run check:story-coverage && npm run check:asset-drift && npm run check:retired-figures && npm run check:voice",
+    "check:drift": "npm run check:community-copy && npm run check:qbe-guardrails && npm run check:canon && npm run check:artifacts && npm run check:qbe-readiness && npm run check:story-coverage && npm run check:asset-drift && npm run check:register && npm run check:retired-figures && npm run check:voice",
     "check:drift:ci": "npm run check:community-copy && npm run check:qbe-guardrails && npm run check:canon && npm run check:artifacts && npm run check:qbe-readiness && npm run check:story-coverage && npm run check:retired-figures && npm run check:voice",
     "funding:sweep": "node scripts/funding-sweep.mjs",
     "audit:model": "node --env-file=.env.local scripts/audit-data-model.mjs",
@@ -30,7 +30,8 @@
     "wiki:sync": "if [ -d ../wiki/articles ]; then rm -rf .wiki-content && mkdir -p .wiki-content && cp -R ../wiki/articles/. .wiki-content/; else echo 'wiki:sync skipped (../wiki/articles absent; using tracked .wiki-content/)'; fi",
     "prebuild": "npm run wiki:sync",
     "check:retired-figures": "node scripts/check-retired-figures.mjs",
-    "check:voice": "node scripts/check-voice.mjs"
+    "check:voice": "node scripts/check-voice.mjs",
+    "check:register": "node --env-file=.env.local scripts/check-register-integrity.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.74.0",

--- a/v2/scripts/check-register-integrity.mjs
+++ b/v2/scripts/check-register-integrity.mjs
@@ -1,0 +1,178 @@
+/**
+ * READ-ONLY per-community integrity judge for the assets register.
+ *
+ * check-asset-drift.mjs guards the HEADLINE totals (540/177/363). This script
+ * guards the layer below, where every real counting error has actually
+ * happened: per-community splits (Utopia 147 vs Community OS's 169, the
+ * Maningrida 18/40 split), banned products (Weave Bed rows), unknown
+ * communities appearing in the register, and the washer stale-row gap moving.
+ *
+ * The per-community numbers are NOT mirrored here. They are parsed straight
+ * out of src/lib/data/community-canonical.ts, which is the single source of
+ * truth and is itself locked to CANONICAL_ASSETS by
+ * community-canonical.guards.test.ts. Each failure cites the ruling recorded
+ * on the canon entry — fix the canon (with a Ben ruling) or investigate the
+ * register write; never hand-patch a surface.
+ *
+ * Always prints a full per-community scoreboard, pass or fail, so a green run
+ * doubles as the live reconciliation view that used to be assembled by hand in
+ * wiki/investor/10-community-counts.md.
+ *
+ *   node --env-file=.env.local scripts/check-register-integrity.mjs   (from v2/)
+ *
+ * Dependency-free (global fetch + REST) so it runs in any fresh worktree.
+ * NEVER use the Supabase MCP for v2 data — wrong-project risk; see CLAUDE.md.
+ */
+import { readFileSync } from 'node:fs';
+
+// ── Load canon from the .ts source (no mirrored numbers in this file) ────────
+const canonSrc = readFileSync(new URL('../src/lib/data/community-canonical.ts', import.meta.url), 'utf8');
+const assetCanonSrc = readFileSync(new URL('../src/lib/data/asset-canonical.ts', import.meta.url), 'utf8');
+
+function parseEntries(src) {
+  const body = src.match(/COMMUNITY_BED_CANON[^=]*=\s*\[([\s\S]*?)\]\s*as const/)?.[1];
+  if (!body) throw new Error('cannot parse COMMUNITY_BED_CANON from community-canonical.ts');
+  const entries = [];
+  for (const m of body.matchAll(/\{([\s\S]*?)\},/g)) {
+    const block = m[1];
+    const get = (field) => block.match(new RegExp(`${field}:\\s*'([^']*)'`))?.[1];
+    const getNum = (field) => Number(block.match(new RegExp(`${field}:\\s*(\\d+)`))?.[1]);
+    entries.push({
+      id: get('id'),
+      registerName: get('registerName'),
+      basketBeds: getNum('basketBeds'),
+      stretchBeds: getNum('stretchBeds'),
+      ruling: get('ruling') ?? block.match(/ruling:\s*'([\s\S]*?)',/)?.[1] ?? '(ruling not parsed)',
+    });
+  }
+  return entries;
+}
+
+function parseRecord(src, name) {
+  const body = src.match(new RegExp(`${name}[^=]*=\\s*\\{([\\s\\S]*?)\\}`))?.[1];
+  if (!body) throw new Error(`cannot parse ${name}`);
+  const rec = {};
+  for (const m of body.matchAll(/'?([a-z0-9-]+)'?:\s*(\d+)/g)) rec[m[1]] = Number(m[2]);
+  return rec;
+}
+
+const CANON = parseEntries(canonSrc);
+const ALLOWED_PRODUCTS = [...canonSrc.matchAll(/ALLOWED_REGISTER_PRODUCTS\s*=\s*\[([^\]]*)\]/g)][0]?.[1]
+  .match(/'([^']+)'/g)?.map((s) => s.replace(/'/g, '')) ?? [];
+const WASHER_STALE = parseRecord(canonSrc, 'WASHER_STALE_DEPLOYED_ROWS');
+const WASHERS_BY_COMMUNITY = parseRecord(assetCanonSrc, 'WASHERS_IN_COMMUNITY_BY_COMMUNITY');
+if (!CANON.length || !ALLOWED_PRODUCTS.length) throw new Error('canon parse produced empty sets — refusing to run');
+
+// ── Connect (wrong-project guard) ────────────────────────────────────────────
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/['"]/g, '');
+const key = (process.env.SUPABASE_SERVICE_ROLE_KEY || '').replace(/['"]/g, '');
+if (!url || !key) {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY (run with --env-file=.env.local).');
+  process.exit(2);
+}
+const GOODS_PROJECT_REF = 'cwsyhpiuepvdjtxaozwf';
+if (!url.includes(GOODS_PROJECT_REF)) {
+  console.error(`Wrong-project guard: SUPABASE_URL is ${url}, not the Goods project (${GOODS_PROJECT_REF}). Refusing to run.`);
+  process.exit(2);
+}
+
+const rows = [];
+for (let from = 0; ; from += 1000) {
+  const res = await fetch(`${url}/rest/v1/assets?select=product,status,quantity,community&limit=1000&offset=${from}`, {
+    headers: { apikey: key, Authorization: `Bearer ${key}` },
+  });
+  if (!res.ok) { console.error('fetch error:', res.status, await res.text()); process.exit(2); }
+  const page = await res.json();
+  rows.push(...page);
+  if (page.length < 1000) break;
+}
+
+const qty = (r) => r.quantity ?? 1;
+const deployed = rows.filter((r) => r.status === 'deployed');
+
+// live per-community aggregation
+const live = {};
+for (const r of deployed) {
+  const c = r.community ?? '(null)';
+  live[c] ??= {};
+  live[c][r.product] = (live[c][r.product] ?? 0) + qty(r);
+}
+
+const failures = [];
+const cite = (msg, ruling) => failures.push(`${msg}\n      RULING: ${ruling}`);
+
+// 1. Banned / unknown products anywhere in the register (any status).
+for (const p of new Set(rows.map((r) => r.product))) {
+  if (!ALLOWED_PRODUCTS.includes(p)) {
+    cite(
+      `product '${p}' is not an allowed register product (${rows.filter((r) => r.product === p).length} rows)`,
+      p && /weave/i.test(p)
+        ? 'Weave Bed was discontinued and never produced at scale; rows should be Stretch Bed (CLAUDE.md products section)'
+        : 'ALLOWED_REGISTER_PRODUCTS in community-canonical.ts',
+    );
+  }
+}
+
+// 2. Per-community bed splits vs canon.
+console.log('Per-community register vs canon (beds, status=deployed):\n');
+console.log('  community            basket  reg    stretch  reg    total  reg    status');
+for (const c of CANON) {
+  const l = live[c.registerName] ?? {};
+  const lb = l['Basket Bed'] ?? 0;
+  const ls = l['Stretch Bed'] ?? 0;
+  const ok = lb === c.basketBeds && ls === c.stretchBeds;
+  const total = c.basketBeds + c.stretchBeds;
+  console.log(
+    `  ${c.registerName.padEnd(20)} ${String(c.basketBeds).padStart(5)} ${String(lb).padStart(5)}  ${String(c.stretchBeds).padStart(6)} ${String(ls).padStart(5)}  ${String(total).padStart(5)} ${String(lb + ls).padStart(5)}    ${ok ? 'OK' : 'FAIL'}`,
+  );
+  if (lb !== c.basketBeds) cite(`${c.registerName}: Basket Beds register=${lb}, canon=${c.basketBeds}`, c.ruling);
+  if (ls !== c.stretchBeds) cite(`${c.registerName}: Stretch Beds register=${ls}, canon=${c.stretchBeds}`, c.ruling);
+}
+
+// 3. Communities in the register that canon doesn't know.
+const canonNames = new Set(CANON.map((c) => c.registerName));
+for (const name of Object.keys(live)) {
+  const beds = (live[name]['Basket Bed'] ?? 0) + (live[name]['Stretch Bed'] ?? 0);
+  if (!canonNames.has(name) && beds > 0 && name !== 'Pending Delivery') {
+    cite(
+      `register has ${beds} deployed bed(s) in '${name}', which has no per-community canon entry`,
+      'New deliveries need a Ben count ruling + a COMMUNITY_BED_CANON entry before public figures move (10-community-counts.md pattern)',
+    );
+  }
+}
+
+// 4. Washer stale-row gap must be EXACTLY the ruled gap, per community.
+const slugByRegisterName = Object.fromEntries(CANON.map((c) => [c.registerName, c.id]));
+console.log('\nWashers (curated canon vs register deployed rows):\n');
+console.log('  community            canon  register  ruled-stale  status');
+let washerHeaderPrinted = false;
+for (const [name, products] of Object.entries(live)) {
+  const regWashers = products['Washing Machine'] ?? 0;
+  const slug = slugByRegisterName[name] ?? name;
+  const canonWashers = WASHERS_BY_COMMUNITY[slug] ?? 0;
+  const ruledStale = WASHER_STALE[slug] ?? 0;
+  if (regWashers === 0 && canonWashers === 0) continue;
+  washerHeaderPrinted = true;
+  const ok = regWashers === canonWashers + ruledStale;
+  console.log(
+    `  ${name.padEnd(20)} ${String(canonWashers).padStart(5)} ${String(regWashers).padStart(9)} ${String(ruledStale).padStart(12)}  ${ok ? 'OK' : 'FAIL'}`,
+  );
+  if (!ok) {
+    cite(
+      `${name}: register has ${regWashers} deployed washer rows; ruling allows ${canonWashers} in community + ${ruledStale} known-stale = ${canonWashers + ruledStale}`,
+      "Ben 2026-07-21: washers in community = 22 (Maningrida 8, Tennant Creek 9, Palm Island 4, Alice Springs 1, Darwin 0); stale rows TC 7 / Alice 2 / Darwin 1 await restatus to 'retired'. If the restatus landed, clear WASHER_STALE_DEPLOYED_ROWS and hard-check washers.",
+    );
+  }
+}
+if (!washerHeaderPrinted) console.log('  (no washer rows found)');
+
+// ── Verdict ──────────────────────────────────────────────────────────────────
+if (failures.length) {
+  console.error(`\nREGISTER INTEGRITY: ${failures.length} FAILURE(S)\n`);
+  failures.forEach((f, i) => console.error(`  ${i + 1}. ${f}\n`));
+  console.error('Fix the process, not the surface: either a bad write landed in the register');
+  console.error('(investigate + correct the register) or a real delivery happened (get a Ben');
+  console.error('ruling, update community-canonical.ts, and let the guards re-verify).');
+  process.exit(1);
+}
+console.log('\nOK — every community in the live register matches its ruled canon.');

--- a/v2/src/lib/data/community-canonical.guards.test.ts
+++ b/v2/src/lib/data/community-canonical.guards.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Lockstep between the two canon layers.
+ *
+ * asset-canonical.ts holds the headline totals; community-canonical.ts holds
+ * the per-community rulings. If either is edited without the other, the
+ * per-community lines could sum to something other than the headline the site
+ * and funder documents state — the Utopia-169 class of error, one level up.
+ * These tests make that state unrepresentable in a green build.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  COMMUNITY_BED_CANON,
+  WASHER_STALE_DEPLOYED_ROWS,
+  communityCanonTotals,
+} from './community-canonical';
+import { CANONICAL_ASSETS, WASHERS_IN_COMMUNITY_BY_COMMUNITY } from './asset-canonical';
+
+describe('community canon sums to headline canon', () => {
+  const totals = communityCanonTotals();
+
+  it('beds tie to CANONICAL_ASSETS', () => {
+    expect(totals.basketBeds).toBe(CANONICAL_ASSETS.basketBedsDeployed);
+    expect(totals.stretchBeds).toBe(CANONICAL_ASSETS.stretchBedsDeployed);
+    expect(totals.beds).toBe(CANONICAL_ASSETS.bedsDeployed);
+  });
+
+  it('washers tie to the 2026-07-21 ruling of 22', () => {
+    expect(totals.washersInCommunity).toBe(CANONICAL_ASSETS.washersInCommunity);
+  });
+
+  it('communities served ties to canon', () => {
+    expect(totals.communitiesServed).toBe(CANONICAL_ASSETS.communitiesServed);
+  });
+
+  it('community ids are unique and slugged', () => {
+    const ids = COMMUNITY_BED_CANON.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(id).toMatch(/^[a-z0-9-]+$/);
+  });
+
+  it('every entry carries a non-empty ruling citation', () => {
+    for (const c of COMMUNITY_BED_CANON) expect(c.ruling.length).toBeGreaterThan(10);
+  });
+
+  it('Utopia is 147, never Community OS’s 169', () => {
+    const utopia = COMMUNITY_BED_CANON.find((c) => c.id === 'utopia')!;
+    expect(utopia.basketBeds + utopia.stretchBeds).toBe(147);
+  });
+
+  it('washer stale rows only name communities that have a washer ruling', () => {
+    for (const id of Object.keys(WASHER_STALE_DEPLOYED_ROWS)) {
+      expect(WASHERS_IN_COMMUNITY_BY_COMMUNITY).toHaveProperty(id);
+    }
+  });
+});

--- a/v2/src/lib/data/community-canonical.ts
+++ b/v2/src/lib/data/community-canonical.ts
@@ -1,0 +1,146 @@
+import { CANONICAL_ASSETS, WASHERS_IN_COMMUNITY_BY_COMMUNITY } from './asset-canonical';
+
+/**
+ * Per-community canonical bed counts — the layer BELOW asset-canonical.ts.
+ *
+ * asset-canonical.ts freezes the headline totals (540/177/363) and
+ * check-asset-drift.mjs guards them against the live register. But every
+ * counting error that has actually reached (or nearly reached) an external
+ * document happened one level down, per community: Community OS claiming
+ * Utopia = 169 when the register and ruling say 147; the Maningrida split
+ * recorded as 0 Basket / 58 Stretch when INV-0303 settled 18/40; Weave Bed
+ * rows re-appearing under stretch counts. Those rulings lived only in
+ * wiki/investor/10-community-counts.md and session memory — nothing failed
+ * when a surface contradicted them.
+ *
+ * This module puts the per-community rulings in code. Each entry carries its
+ * ruling provenance so a drift failure can cite the ruling, not just the
+ * number. scripts/check-register-integrity.mjs asserts the live register
+ * against this map line by line; community-canonical.guards.test.ts asserts
+ * this map sums exactly to CANONICAL_ASSETS, so the two canon layers cannot
+ * drift apart.
+ *
+ * `registerName` is the exact string in the register's `community` column
+ * (the register's real column is `product`/`community`, not `type`).
+ */
+export interface CommunityBedCanon {
+  /** communities.id slug */
+  id: string;
+  /** exact `community` value on register rows */
+  registerName: string;
+  basketBeds: number;
+  stretchBeds: number;
+  /** where the number was settled — cited verbatim by the drift judge */
+  ruling: string;
+}
+
+export const COMMUNITY_BED_CANON: readonly CommunityBedCanon[] = [
+  {
+    id: 'utopia',
+    registerName: 'Utopia Homelands',
+    basketBeds: 60,
+    stretchBeds: 87,
+    ruling: 'Ben 2026-07-19: Utopia = 147 confirmed; Community OS 169 is wrong (wiki/investor/10-community-counts.md)',
+  },
+  {
+    id: 'tennant-creek',
+    registerName: 'Tennant Creek',
+    basketBeds: 130,
+    stretchBeds: 30,
+    ruling: 'Ben 2026-07-19: +1 Stretch to the youth centre, register row GB0-160-1 (total 160)',
+  },
+  {
+    id: 'palm-island',
+    registerName: 'Palm Island',
+    basketBeds: 131,
+    stretchBeds: 0,
+    ruling: 'Reconciled 2026-07-19: register = OS = 131, all Basket',
+  },
+  {
+    id: 'maningrida',
+    registerName: 'Maningrida',
+    basketBeds: 18,
+    stretchBeds: 40,
+    ruling: 'INV-0303 ruling: 40 Stretch FINAL, 18 Basket; OS split 0/58 was wrong',
+  },
+  {
+    id: 'kalgoorlie',
+    registerName: 'Kalgoorlie',
+    basketBeds: 20,
+    stretchBeds: 0,
+    ruling: 'Reconciled 2026-07-19: register = OS = 20, all Basket',
+  },
+  {
+    id: 'alice-springs',
+    registerName: 'Alice Springs',
+    basketBeds: 1,
+    stretchBeds: 15,
+    ruling: 'Reconciled 2026-07-19: 1 Basket / 15 Stretch (Oonchiumpa)',
+  },
+  {
+    id: 'canberra',
+    registerName: 'Canberra',
+    basketBeds: 0,
+    stretchBeds: 2,
+    ruling: 'Reconciled 2026-07-19',
+  },
+  {
+    id: 'mount-isa',
+    registerName: 'Mount Isa',
+    basketBeds: 2,
+    stretchBeds: 0,
+    ruling: 'Reconciled 2026-07-19',
+  },
+  {
+    id: 'darwin',
+    registerName: 'Darwin',
+    basketBeds: 1,
+    stretchBeds: 0,
+    ruling: 'Reconciled 2026-07-19',
+  },
+  {
+    id: 'kununurra',
+    registerName: 'Kununurra',
+    basketBeds: 0,
+    stretchBeds: 2,
+    ruling: 'Ben 2026-07-19: real delivery to Aunty Jean O’Reera, rows GB0-158-1/2 (Miriwoong country); story consent-held, counting is separate',
+  },
+  {
+    id: 'katherine',
+    registerName: 'Katherine',
+    basketBeds: 0,
+    stretchBeds: 1,
+    ruling: 'Ben 2026-07-19: delivered by Nic, row GB0-159-1 (Jawoyn country)',
+  },
+] as const;
+
+/** The only product names allowed on register rows. `Weave Bed` (or any
+ *  weave_bed variant) is a known bad write — the product was discontinued and
+ *  never produced at scale; rows carrying it should be stretch_bed. */
+export const ALLOWED_REGISTER_PRODUCTS = ['Stretch Bed', 'Basket Bed', 'Washing Machine'] as const;
+
+/** Washer rows still marked `deployed` that Ben's 2026-07-21 ruling says are
+ *  stale (await restatus to `retired`): Tennant Creek 7, Alice Springs 2,
+ *  Darwin 1. The judge asserts the gap is EXACTLY this — if it shrinks the
+ *  restatus landed (delete this and hard-check washers); if it grows or moves,
+ *  a new bad write landed. */
+export const WASHER_STALE_DEPLOYED_ROWS: Record<string, number> = {
+  'tennant-creek': 7,
+  'alice-springs': 2,
+  darwin: 1,
+};
+
+export function communityCanonTotals() {
+  const basket = COMMUNITY_BED_CANON.reduce((s, c) => s + c.basketBeds, 0);
+  const stretch = COMMUNITY_BED_CANON.reduce((s, c) => s + c.stretchBeds, 0);
+  const washers = Object.values(WASHERS_IN_COMMUNITY_BY_COMMUNITY).reduce((s, n) => s + n, 0);
+  return {
+    basketBeds: basket,
+    stretchBeds: stretch,
+    beds: basket + stretch,
+    washersInCommunity: washers,
+    communitiesServed: COMMUNITY_BED_CANON.length,
+  };
+}
+
+export { CANONICAL_ASSETS };


### PR DESCRIPTION
## What

The headline totals (540/177/363) were already drift-guarded by `check:asset-drift`, but every real counting error happened one level down: Utopia 147 vs Community OS's 169, the Maningrida 18/40 split, washer restatus lag, Weave Bed rows. Those rulings lived only in `wiki/investor/10-community-counts.md` and session memory.

- **`community-canonical.ts`** — per-community bed splits, each with ruling provenance; `ALLOWED_REGISTER_PRODUCTS`; the ruled washer stale-row map (TC 7 / Alice 2 / Darwin 1)
- **`community-canonical.guards.test.ts`** — locks the per-community lines to `CANONICAL_ASSETS` (must sum to 540/177/363/22/11)
- **`scripts/check-register-integrity.mjs`** (`npm run check:register`, wired into `check:drift`) — asserts the live register per community, prints a scoreboard, cites the violated ruling on failure. Parses the .ts directly, no mirrored numbers.

## Proof

Judge validated in both directions: green against the live register (all 11 communities tie exactly), and falsifying Utopia to the historical 169 error exits 1 citing the 2026-07-19 ruling.

Gates: tsc clean, 376 tests, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)