### PR TITLE
feat(admin): route directory guard + register scoreboard on /admin/assets

### DIFF
--- a/v2/src/app/admin/assets/page.tsx
+++ b/v2/src/app/admin/assets/page.tsx
@@ -3,6 +3,7 @@ import { createServiceClient } from '@/lib/supabase/server';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { AssetTable, type AssetRow } from './asset-table';
+import { RegisterScoreboard } from './register-scoreboard';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -122,6 +123,18 @@ export default async function AssetRegisterPage() {
         <Kpi label="Beds Deployed" value={bedsDeployed.toLocaleString()} sub="in community" />
         <Kpi label="Ready for Next Trip" value={readyForTrip.toLocaleString()} sub="Stretch Beds awaiting allocation" highlight />
         <Kpi label="Washing Machines Deployed" value={machinesDeployed.toLocaleString()} sub="across NT + QLD" />
+      </section>
+
+      {/* Per-community integrity vs ruled canon */}
+      <section>
+        <RegisterScoreboard
+          rows={data.map((r) => ({
+            product: r.product,
+            community: r.community,
+            status: r.status,
+            quantity: r.quantity ?? 1,
+          }))}
+        />
       </section>
 
       {/* Pipeline summary */}

--- a/v2/src/app/admin/assets/register-scoreboard.tsx
+++ b/v2/src/app/admin/assets/register-scoreboard.tsx
@@ -1,0 +1,158 @@
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  COMMUNITY_BED_CANON,
+  WASHER_STALE_DEPLOYED_ROWS,
+} from '@/lib/data/community-canonical';
+import { WASHERS_IN_COMMUNITY_BY_COMMUNITY } from '@/lib/data/asset-canonical';
+
+/**
+ * The on-screen twin of scripts/check-register-integrity.mjs: the live
+ * register's deployed rows against the per-community count rulings in
+ * community-canonical.ts. Same comparison, same ruling citations — this view
+ * is for seeing state daily; the script is the gate that blocks a merge.
+ * A red line here means either a bad write landed in the register or a real
+ * delivery needs a Ben ruling + canon entry. Never patch a surface to hide it.
+ */
+
+export interface ScoreboardRow {
+  product: string | null;
+  community: string | null;
+  status: string | null;
+  quantity: number;
+}
+
+interface Line {
+  name: string;
+  canonBasket: number;
+  regBasket: number;
+  canonStretch: number;
+  regStretch: number;
+  ok: boolean;
+  ruling: string;
+}
+
+export function RegisterScoreboard({ rows }: { rows: ScoreboardRow[] }) {
+  const deployed = rows.filter((r) => r.status === 'deployed');
+  const live = new Map<string, Record<string, number>>();
+  for (const r of deployed) {
+    const c = r.community ?? '(null)';
+    const m = live.get(c) ?? {};
+    m[r.product ?? ''] = (m[r.product ?? ''] ?? 0) + r.quantity;
+    live.set(c, m);
+  }
+
+  const lines: Line[] = COMMUNITY_BED_CANON.map((c) => {
+    const l = live.get(c.registerName) ?? {};
+    const regBasket = l['Basket Bed'] ?? 0;
+    const regStretch = l['Stretch Bed'] ?? 0;
+    return {
+      name: c.registerName,
+      canonBasket: c.basketBeds,
+      regBasket,
+      canonStretch: c.stretchBeds,
+      regStretch,
+      ok: regBasket === c.basketBeds && regStretch === c.stretchBeds,
+      ruling: c.ruling,
+    };
+  });
+
+  // Communities in the register that canon doesn't know about.
+  const canonNames = new Set(COMMUNITY_BED_CANON.map((c) => c.registerName));
+  const unknown = [...live.entries()]
+    .filter(([name, m]) => {
+      const beds = (m['Basket Bed'] ?? 0) + (m['Stretch Bed'] ?? 0);
+      return beds > 0 && !canonNames.has(name) && name !== 'Pending Delivery';
+    })
+    .map(([name]) => name);
+
+  const slugByName = Object.fromEntries(COMMUNITY_BED_CANON.map((c) => [c.registerName, c.id]));
+  const washerLines = [...live.entries()]
+    .map(([name, m]) => {
+      const reg = m['Washing Machine'] ?? 0;
+      const slug = slugByName[name] ?? name;
+      const canon = WASHERS_IN_COMMUNITY_BY_COMMUNITY[slug] ?? 0;
+      const stale = WASHER_STALE_DEPLOYED_ROWS[slug] ?? 0;
+      return { name, canon, reg, stale, ok: reg === canon + stale };
+    })
+    .filter((w) => w.reg > 0 || w.canon > 0);
+
+  const failures = lines.filter((l) => !l.ok);
+  const washerFailures = washerLines.filter((w) => !w.ok);
+  const allGreen = failures.length === 0 && washerFailures.length === 0 && unknown.length === 0;
+
+  return (
+    <Card className={allGreen ? 'border-emerald-200' : 'border-red-300 bg-red-50/30'}>
+      <CardContent>
+        <div className="mb-3 flex items-baseline justify-between">
+          <h2 className="font-display text-base font-semibold">Register integrity — live vs ruled canon</h2>
+          <span className={`text-xs font-semibold ${allGreen ? 'text-emerald-700' : 'text-red-700'}`}>
+            {allGreen ? 'ALL COMMUNITIES TIE' : `${failures.length + washerFailures.length + unknown.length} DISCREPANCIES`}
+          </span>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="py-1.5 pr-3">Community</th>
+                <th className="py-1.5 pr-3 text-right">Basket (canon / live)</th>
+                <th className="py-1.5 pr-3 text-right">Stretch (canon / live)</th>
+                <th className="py-1.5 pr-3 text-right">Total</th>
+                <th className="py-1.5">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lines.map((l) => (
+                <tr key={l.name} className={`border-b border-border/50 ${l.ok ? '' : 'bg-red-100/60'}`}>
+                  <td className="py-1.5 pr-3 font-medium">{l.name}</td>
+                  <td className="py-1.5 pr-3 text-right tabular-nums">
+                    {l.canonBasket} / {l.regBasket}
+                  </td>
+                  <td className="py-1.5 pr-3 text-right tabular-nums">
+                    {l.canonStretch} / {l.regStretch}
+                  </td>
+                  <td className="py-1.5 pr-3 text-right tabular-nums">{l.canonBasket + l.canonStretch}</td>
+                  <td className="py-1.5">
+                    {l.ok ? (
+                      <span className="text-xs font-semibold text-emerald-700">OK</span>
+                    ) : (
+                      <span className="text-xs font-semibold text-red-700" title={l.ruling}>
+                        FAIL
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {failures.map((l) => (
+          <p key={l.name} className="mt-2 text-xs text-red-800">
+            <strong>{l.name}:</strong> register {l.regBasket}B/{l.regStretch}S vs canon {l.canonBasket}B/{l.canonStretch}S.
+            {' '}Ruling: {l.ruling}
+          </p>
+        ))}
+        {unknown.length > 0 && (
+          <p className="mt-2 text-xs text-red-800">
+            <strong>Unruled communities with deployed beds:</strong> {unknown.join(', ')} — a new delivery needs a
+            count ruling and a canon entry before public figures move.
+          </p>
+        )}
+
+        <div className="mt-4 text-xs text-muted-foreground">
+          <span className="font-semibold">Washers</span> (ruled 22 in community; stale rows awaiting restatus are expected):{' '}
+          {washerLines.map((w) => (
+            <span key={w.name} className={`mr-3 ${w.ok ? '' : 'font-semibold text-red-700'}`}>
+              {w.name} {w.canon}
+              {w.stale > 0 && ` (+${w.stale} stale)`} → live {w.reg} {w.ok ? '✓' : '✗'}
+            </span>
+          ))}
+        </div>
+        <p className="mt-2 text-[11px] text-muted-foreground">
+          Same assertion as <code>npm run check:register</code>. Red = a bad register write, or a real delivery that
+          needs a ruling + <code>community-canonical.ts</code> entry. Fix the process, not this table.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/v2/src/lib/data/admin-routes.guards.test.ts
+++ b/v2/src/lib/data/admin-routes.guards.test.ts
@@ -1,0 +1,66 @@
+/**
+ * The route directory calls itself "the complete admin route directory", but
+ * until now nothing failed when a new admin page shipped unregistered — six
+ * routes drifted in within a week of the 2026-07-19 review (/admin/pipeline,
+ * /admin/ask, the three /admin/maps views, /admin/route-review). Same disease
+ * the register judge cures for counts: a registry that only a human sweep
+ * keeps honest isn't a registry.
+ *
+ * Rule: every page.tsx under src/app/admin must be covered by a directory
+ * entry — its own href, or a registered ancestor (children like
+ * /admin/assets/[unique_id] or /admin/el-stories/new ride on their parent) —
+ * or be on the explicit infrastructure exemption list. And the reverse: every
+ * directory href must still exist on disk, so retired screens leave the
+ * directory when they leave the tree.
+ */
+import { describe, it, expect } from 'vitest';
+import { readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { ADMIN_ROUTE_DIRECTORY } from './admin-routes';
+
+const ADMIN_DIR = join(__dirname, '../../app/admin');
+
+/** Auth plumbing, not screens — never belongs in the directory. */
+const EXEMPT = new Set(['/admin/login', '/admin/unauthorized']);
+
+function collectPages(dir: string, href: string, out: string[]): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) collectPages(join(dir, entry.name), `${href}/${entry.name}`, out);
+    else if (entry.name === 'page.tsx') out.push(href || '/admin');
+  }
+  return out;
+}
+
+const pages = collectPages(ADMIN_DIR, '/admin', []);
+const registered = new Set(
+  ADMIN_ROUTE_DIRECTORY.flatMap((g) => g.routes.map((r) => r.href)),
+);
+
+function covered(href: string): boolean {
+  if (EXEMPT.has(href)) return true;
+  // walk up: /admin/assets/batch/[batch] is covered by /admin/assets
+  for (let h = href; h.length >= '/admin'.length; h = h.slice(0, h.lastIndexOf('/'))) {
+    if (registered.has(h)) return true;
+  }
+  return false;
+}
+
+describe('admin route directory is complete', () => {
+  it('every admin page on disk is registered (or covered by a registered ancestor)', () => {
+    const orphans = pages.filter((p) => !covered(p));
+    expect(orphans, `unregistered admin routes: ${orphans.join(', ')} — add them to ADMIN_ROUTE_DIRECTORY with an honest status`).toEqual([]);
+  });
+
+  it('every directory href still exists on disk', () => {
+    const ghosts = [...registered].filter((href) => {
+      const dir = join(ADMIN_DIR, href.replace(/^\/admin\/?/, ''));
+      return !existsSync(join(dir, 'page.tsx'));
+    });
+    expect(ghosts, `directory entries with no page on disk: ${ghosts.join(', ')} — remove them or restore the page`).toEqual([]);
+  });
+
+  it('hrefs are unique across groups', () => {
+    const all = ADMIN_ROUTE_DIRECTORY.flatMap((g) => g.routes.map((r) => r.href));
+    expect(new Set(all).size).toBe(all.length);
+  });
+});

--- a/v2/src/lib/data/admin-routes.ts
+++ b/v2/src/lib/data/admin-routes.ts
@@ -82,6 +82,8 @@ export const ADMIN_ROUTE_DIRECTORY: RouteGroup[] = [
     routes: [
       { href: '/admin/funders', name: 'Funders', status: 'absorbed', note: 'via Raise' },
       { href: '/admin/loi-tracker', name: 'LOI tracker', status: 'absorbed', note: 'the match register' },
+      { href: '/admin/pipeline', name: 'Deal pipeline board', status: 'absorbed', note: 'via Raise' },
+      { href: '/admin/ask', name: 'The Ask', status: 'absorbed', note: 'via Raise' },
       { href: '/admin/reports', name: 'Funder reports', status: 'active' },
       { href: '/admin/reports/impact', name: 'Impact reports', status: 'active' },
       { href: '/admin/orders', name: 'Orders', status: 'active' },
@@ -99,6 +101,9 @@ export const ADMIN_ROUTE_DIRECTORY: RouteGroup[] = [
       { href: '/admin/install-bulk', name: 'Bulk install', status: 'utility' },
       { href: '/admin/install-checklist', name: 'Install checklist', status: 'utility' },
       { href: '/admin/bed-signals', name: 'Bed signals', status: 'active' },
+      { href: '/admin/maps/deployed', name: 'Map: deployed', status: 'active', note: 'register on the map' },
+      { href: '/admin/maps/need', name: 'Map: need', status: 'active' },
+      { href: '/admin/maps/ask', name: 'Map: ask', status: 'active' },
       { href: '/admin/scans', name: 'Scans', status: 'active' },
       { href: '/admin/fleet', name: 'Fleet', status: 'active', note: 'quarterly' },
       { href: '/admin/operating-systems', name: 'Operating systems', status: 'active' },
@@ -116,6 +121,7 @@ export const ADMIN_ROUTE_DIRECTORY: RouteGroup[] = [
       { href: '/admin/brand', name: 'Brand', status: 'stale' },
       { href: '/admin/team', name: 'Team', status: 'stale' },
       { href: '/admin/alice-fill', name: 'Alice fill wizard', status: 'one-off', note: '2026-05-21 trip catch-up' },
+      { href: '/admin/route-review', name: 'Route review', status: 'one-off', note: '2026-07 IA review artifact; produced this directory' },
     ],
   },
 ];


### PR DESCRIPTION
## What

**1. Route directory guard.** Six admin routes drifted in unregistered within a week of the 2026-07-19 IA review (`/admin/pipeline`, `/admin/ask`, the three `/admin/maps` views, `/admin/route-review`). They're registered now with honest statuses, and `admin-routes.guards.test.ts` enforces the directory in both directions: every `page.tsx` under `src/app/admin` must be covered by an entry (or registered ancestor, or the login/unauthorized exemption), and every entry must still exist on disk.

**2. Register scoreboard on `/admin/assets`.** The on-screen twin of `check-register-integrity.mjs` (#167): live register vs ruled canon per community, OK/FAIL per line, ruling citation surfaced on any red line, washers shown as ruled-22 + expected stale rows rather than a raw 32.

Gates: tsc clean, 379 tests (3 new), full `check:drift` chain green, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)