### PR TITLE
fix(content-gate): unit-suffix false positive, multi-voice frontmatter, true line numbers

### DIFF
--- a/v2/scripts/check-content-gate.mjs
+++ b/v2/scripts/check-content-gate.mjs
@@ -110,7 +110,7 @@ function parseFrontmatter(text) {
     const kv = line.match(/^(\w[\w_]*):\s*(.*)$/);
     if (kv) fm[kv[1]] = kv[2].trim();
   }
-  return { fm, body: m ? text.slice(m[0].length) : text };
+  return { fm, body: m ? text.slice(m[0].length) : text, offset: m ? m[0].split('\n').length : 0 };
 }
 
 /** Strip verbatim quoted speech: those are other people's words, exempt from
@@ -121,19 +121,23 @@ function stripQuotedSpeech(line) {
 
 function gateConsent(fm, body, findings) {
   const rule = 'cleared-voices.ts: DEFAULT-DENY — a voice appears externally only if its name is on the cleared list';
-  if (!fm.storyteller) {
-    findings.push({ stage: 'consent', line: 0, finding: 'no `storyteller:` in frontmatter', rule });
+  // Single-voice units carry `storyteller:`; multi-voice units (newsletters,
+  // month plans) carry `voices:` naming everyone quoted. Either satisfies the
+  // requirement; every name on either must be cleared.
+  const named = fm.storyteller ?? fm.voices;
+  if (!named) {
+    findings.push({ stage: 'consent', line: 0, finding: 'no `storyteller:` (single voice) or `voices:` (multi-voice) in frontmatter', rule });
   } else {
-    for (const name of fm.storyteller.split(/,|&| and /).map((s) => s.trim()).filter(Boolean)) {
+    for (const name of named.split(/,|&| and /).map((s) => s.trim()).filter(Boolean)) {
       if (!CLEARED.has(normaliseName(name))) {
-        findings.push({ stage: 'consent', line: 0, finding: `storyteller '${name}' is NOT on the cleared-voices list`, rule });
+        findings.push({ stage: 'consent', line: 0, finding: `named voice '${name}' is NOT on the cleared-voices list`, rule });
       }
     }
   }
-  if (!fm.consent_source) {
+  if (!fm.consent_source && !fm.consent) {
     findings.push({
       stage: 'consent', line: 0,
-      finding: 'no `consent_source:` in frontmatter — every draft must record where its clearance comes from',
+      finding: 'no `consent_source:` or `consent:` in frontmatter — every draft must record where its clearance comes from',
       rule: 'ledger-story skill: drafts carry consent provenance; /CONTEXT.md consent gate',
     });
   }
@@ -157,7 +161,9 @@ function gateClaims(body, findings) {
     const line = stripQuotedSpeech(raw);
     for (const fig of RETIRED) {
       const escaped = fig.value.replace(',', '[,]');
-      if (new RegExp(`\\b${escaped}(?![0-9%])`).test(line) && fig.context.test(line)) {
+      // (?![\w%]) so "20kg" never matches the retired washer count 20: a unit
+      // suffix means the number counts something else on the same line.
+      if (new RegExp(`\\b${escaped}(?![\\w%])`).test(line) && fig.context.test(line)) {
         findings.push({
           stage: 'claims', line: i + 1,
           finding: `retired ${fig.what}: ${fig.value} (canon is now ${fig.now})`,
@@ -216,11 +222,12 @@ const results = [];
 let failed = false;
 for (const file of files) {
   const text = readFileSync(resolve(file), 'utf8');
-  const { fm, body } = parseFrontmatter(text);
+  const { fm, body, offset } = parseFrontmatter(text);
   const findings = [];
   gateConsent(fm, body, findings);
   gateClaims(body, findings);
   gateVoice(body, findings);
+  for (const f of findings) if (f.line > 0) f.line += offset; // report file lines, not body lines
   const pass = findings.length === 0;
   if (!pass) failed = true;
   results.push({ file: basename(file), storyteller: fm.storyteller ?? null, status: fm.status ?? null, pass, findings });

--- a/v2/src/lib/data/content-gate-report.json
+++ b/v2/src/lib/data/content-gate-report.json
@@ -1,7 +1,7 @@
 {
   "generatedNote": "run npm run check:content-gate -- --report to refresh",
   "gated": 7,
-  "passed": 4,
+  "passed": 5,
   "stages": [
     "consent",
     "claims",
@@ -45,7 +45,7 @@
         {
           "stage": "consent",
           "line": 0,
-          "finding": "storyteller 'Jahvan Oui' is NOT on the cleared-voices list",
+          "finding": "named voice 'Jahvan Oui' is NOT on the cleared-voices list",
           "rule": "cleared-voices.ts: DEFAULT-DENY — a voice appears externally only if its name is on the cleared list"
         }
       ]
@@ -54,21 +54,8 @@
       "file": "2026-08-content-month.md",
       "storyteller": null,
       "status": "draft (nothing publishes without Ben)",
-      "pass": false,
-      "findings": [
-        {
-          "stage": "consent",
-          "line": 0,
-          "finding": "no `storyteller:` in frontmatter",
-          "rule": "cleared-voices.ts: DEFAULT-DENY — a voice appears externally only if its name is on the cleared list"
-        },
-        {
-          "stage": "consent",
-          "line": 0,
-          "finding": "no `consent_source:` in frontmatter — every draft must record where its clearance comes from",
-          "rule": "ledger-story skill: drafts carry consent provenance; /CONTEXT.md consent gate"
-        }
-      ]
+      "pass": true,
+      "findings": []
     },
     {
       "file": "2026-08-newsletter-community-model.md",
@@ -79,20 +66,8 @@
         {
           "stage": "consent",
           "line": 0,
-          "finding": "no `storyteller:` in frontmatter",
+          "finding": "named voice 'Jahvan Oui' is NOT on the cleared-voices list",
           "rule": "cleared-voices.ts: DEFAULT-DENY — a voice appears externally only if its name is on the cleared list"
-        },
-        {
-          "stage": "consent",
-          "line": 0,
-          "finding": "no `consent_source:` in frontmatter — every draft must record where its clearance comes from",
-          "rule": "ledger-story skill: drafts carry consent provenance; /CONTEXT.md consent gate"
-        },
-        {
-          "stage": "claims",
-          "line": 31,
-          "finding": "retired washers in community: 20 (canon is now 22)",
-          "rule": "check-retired-figures.mjs — Ben 2026-07-21"
         }
       ]
     }


### PR DESCRIPTION
Refinements from the gate's first real run against the August drafts.

- **'20kg' false positive**: the number lookahead now rejects any word character, so a unit suffix (`20kg` on a line also mentioning washing machines) can never match the retired washers-in-community figure. The newsletter's copy was correct all along; the gate was wrong. Fixed the gate, not the draft.
- **Multi-voice units**: `voices:` frontmatter (newsletters, month plans) satisfies the naming requirement, every name still default-deny checked; `consent:` counts as provenance alongside `consent_source:`.
- **Line numbers** now include the frontmatter offset, matching what an editor shows.
- Report refreshed: **5/7 drafts pass**; both remaining failures are the same real fact (Jahvan Oui's clearance lives on the unmerged `feat/six-front-doors` branch). The newsletter now honestly names him in `voices:`.

Gates: tsc clean, 379 tests, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)