### PR TITLE
fix(pitch): /pitch/deck stops publishing the presenter script

### DIFF
--- a/v2/src/app/pitch/deck/deck-public.tsx
+++ b/v2/src/app/pitch/deck/deck-public.tsx
@@ -271,15 +271,27 @@ function SlideSection({
           {slide.body}
         </p>
 
-        {/* The narration: told in the first person, the way it gets told in the room */}
-        {slide.script && (
-          <p
-            className="mt-5 text-lg leading-relaxed text-foreground/90"
-            style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
-          >
-            {slide.script}
-          </p>
-        )}
+        {/*
+         * `slide.script` is DELIBERATELY NOT RENDERED. It is the in-room narration, written in
+         * the first person for a presenter, and it was published here until 2026-08-02 on a
+         * route that carries no `noindex` and that audience.ts points funders at.
+         *
+         * What that published: the money slide's script names every funder in the pipeline with
+         * their amount and stage (Minderoo, Tim Fairfax, Snow, Rotary Eclub, Centrecorp, SEFA,
+         * White Box, LendForGood, Metro Finance), to an audience that includes those same
+         * people. The ask slide's script carried "thirty seven days from a standing start",
+         * a relative date measured from a deadline that no longer exists.
+         *
+         * It also broke the guards. `deck.guards.test.ts` builds PUBLIC_STRINGS from headline,
+         * body, eyebrow, place, chips and steps, and excludes `script` on the stated premise
+         * that no public renderer reads it. That premise was false HERE and only here, so every
+         * claim check ran against a string set that omitted the longest prose on the page.
+         * Removing this render is what makes the premise true; a test in that file now asserts
+         * it rather than trusting a comment.
+         *
+         * /pitch/road has never rendered `script`. If a rehearsal surface is wanted, it belongs
+         * behind the /admin gate, not on an open route.
+         */}
 
         {slide.steps && (
           <ol className="mt-7 grid gap-2 sm:grid-cols-2 xl:grid-cols-3">

--- a/v2/src/lib/data/deck.guards.test.ts
+++ b/v2/src/lib/data/deck.guards.test.ts
@@ -16,12 +16,20 @@
  * inside a chip value), and its term list has no rule for several banned words.
  */
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { deckSlides } from './deck';
 
 /** Every string a viewer can see. `note` and `script` are excluded deliberately:
- *  no public renderer reads `note` (verified against deck-public.tsx and
- *  pitch/road/page.tsx), and it is where retired history is allowed to live. */
+ *  neither is read by a public renderer, and `note` is where retired history is
+ *  allowed to live.
+ *
+ *  That exclusion was ASSERTED here from 2026-08-01 and was false for `script`:
+ *  deck-public.tsx rendered it on /pitch/deck, an open route with no `noindex`
+ *  that audience.ts points funders at, so the longest prose on the page escaped
+ *  every check below. The render was removed 2026-08-02 and the exclusion is now
+ *  enforced by 'no public renderer reads note or script' rather than trusted. */
 const PUBLIC_STRINGS: { where: string; text: string }[] = deckSlides.flatMap((s) => [
   { where: `${s.id}.headline`, text: s.headline ?? '' },
   { where: `${s.id}.body`, text: s.body ?? '' },
@@ -33,6 +41,33 @@ const PUBLIC_STRINGS: { where: string; text: string }[] = deckSlides.flatMap((s)
   ]),
   ...(s.steps ?? []).map((step, i) => ({ where: `${s.id}.steps[${i}]`, text: step })),
 ]);
+
+describe('no public renderer reads note or script', () => {
+  // The premise PUBLIC_STRINGS rests on. A comment cannot hold it: this exact
+  // claim was written down on 2026-08-01 and was already untrue for `script`.
+  const PUBLIC_RENDERERS = [
+    'src/app/pitch/deck/deck-public.tsx',
+    'src/app/pitch/road/page.tsx',
+  ];
+
+  it.each(PUBLIC_RENDERERS)('%s renders neither slide.note nor slide.script', (rel) => {
+    const source = readFileSync(join(process.cwd(), rel), 'utf8');
+    // Strip comments first: this file's own explanation of the removal names the
+    // fields, and a naive grep would fail on the fix that created it.
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^\s*\/\/.*$/gm, '');
+
+    for (const field of ['note', 'script'] as const) {
+      expect(
+        new RegExp(`\\bslide\\.${field}\\b|\\b${field}\\s*:\\s*slide\\.`).test(code),
+        `${rel} references slide.${field}. Both fields are excluded from PUBLIC_STRINGS, so ` +
+          `rendering either publishes prose that no claim guard in this file has checked. ` +
+          `A presenter or rehearsal view belongs behind the /admin gate.`,
+      ).toBe(false);
+    }
+  });
+});
 
 describe('deck.ts: no bed number is offered as a threshold', () => {
   it('publishes no "= N beds" conversion and no beds-per-year rate', () => {


### PR DESCRIPTION
`deck-public.tsx` rendered `slide.script` unconditionally on `/pitch/deck` — a route with no `noindex` that `audience.ts` points funders at. `script` is the in-room narration, written first person for a presenter.

**What that published.** The money slide's script names every funder in the pipeline with amount and stage — Minderoo, Tim Fairfax, Snow, Rotary Eclub, Centrecorp, SEFA, White Box, LendForGood, Metro Finance — to an audience that includes those same people. The ask slide carried "thirty seven days from a standing start", measured from a deadline ruling T struck.

**It also blinded the guards.** `deck.guards.test.ts` builds `PUBLIC_STRINGS` from headline, body, eyebrow, place, chips and steps, and excludes `script` on the stated premise that no public renderer reads it. That premise was false here and only here, so the longest prose on the page escaped every claim check. Re-checked by hand: nothing retired had slipped in — the bed numbers in the scripts are delivered counts (147 Utopia, 540 total), not thresholds.

**The premise is now asserted rather than trusted.** A test reads both public renderers and fails if either references `slide.note` or `slide.script`. Confirmed to fail against the pre-fix file and pass after.

`/pitch/road` has never rendered `script`. A rehearsal surface, if wanted, belongs behind the `/admin` gate.

**Gates:** tsc clean · 417 tests · build clean (208 pages) · drift, voice, qbe-guardrails, retired-figures, register, content-gate all pass.

**Note for whoever executes the route sweep:** wayfinder ticket #183 decided `/pitch/deck` redirects to `/pitch/road`. When that lands and this file is deleted, drop `deck-public.tsx` from `PUBLIC_RENDERERS` in `deck.guards.test.ts` in the same commit, or the test throws on a missing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)