### PR TITLE
fix(sites): the retired match mechanic, and the $607.5K that counted a bed buyer

### DIFF
--- a/v2/scripts/check-qbe-guardrails.mjs
+++ b/v2/scripts/check-qbe-guardrails.mjs
@@ -31,6 +31,21 @@ const SCANNED_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.md', '.mdx',
  * $150K floor: SIH states a typical range of $150K to $400K, from a pool of up to $1.1M
  * shared across ten enterprises. Full research: wiki/investor/20-qbe-program-economics.md.
  */
+/**
+ * A line that NEGATES the retired mechanic is enforcing the rule, not breaking it.
+ *
+ * Ported from `check-retired-figures.mjs`, whose own comment records this as "the fourth time in
+ * one week a guard has flagged the field that enforces the thing it guards". This is the fifth:
+ * on 2026-08-02 this guard fired on a comment in loi-pipeline.ts reading "It is not dollar for
+ * dollar, there is no floor", which is ruling V stated correctly. A guard that punishes the
+ * correction is a guard that gets muted, and a muted guard catches nothing.
+ *
+ * Same deliberate tradeoff as the original: a negation ANYWHERE on the line suppresses that line,
+ * so a long line that both negates one claim and asserts another slips through. Accepted, because
+ * the failure direction of the alternative is worse.
+ */
+const NEGATED = /\b(not|never|no longer|retired|banned|instead of|rather than|do not|don't|avoid|stop using|is wrong|superseded)\b/i;
+
 const RETIRED_MATCH_PATTERNS = [
   /dollar[- ]for[- ]dollar/i,
   /\$?150K?\s*floor/i,
@@ -133,6 +148,7 @@ for (const root of [...scanRoots, ...extraRoots]) {
 
       if (
         !isHistoryFile &&
+        !NEGATED.test(line) &&
         !RETIRED_MATCH_ALLOWED_CONTEXT.test(line) &&
         RETIRED_MATCH_PATTERNS.some((pattern) => pattern.test(line))
       ) {

--- a/v2/src/app/export/leave-behind/page.tsx
+++ b/v2/src/app/export/leave-behind/page.tsx
@@ -416,11 +416,13 @@ export default function LeaveBehindPage() {
               <SectionLabel>The stack we are asking to sign</SectionLabel>
               <div style={{ fontSize: 12, lineHeight: 1.7, marginTop: 5 }}>
                 SEFA <b>$300K</b> <span style={{ color: C.mut, fontSize: 11 }}>repayable</span> &nbsp;·&nbsp; Snow
-                Foundation <b>$100K</b> <span style={{ color: C.mut, fontSize: 11 }}>grant</span> &nbsp;·&nbsp;
-                Centrecorp <b>$75K</b> <span style={{ color: C.mut, fontSize: 11 }}>grant</span>
+                Foundation <b>$100K</b> <span style={{ color: C.mut, fontSize: 11 }}>grant</span>
                 <span style={{ display: 'block', borderTop: `1px solid ${C.line}`, marginTop: 5, paddingTop: 5 }}>
-                  Candidate stack <b>$607.5K</b> grants / <b>$710K</b> repayable · signed to date <b style={{ color: C.terracotta }}>$0</b>{' '}
-                  <Chip claim="target" /> &nbsp;<span style={{ color: C.mut, fontSize: 11 }}>as at 25 July 2026, and we say so</span>
+                  Signed to date <b style={{ color: C.terracotta }}>$0</b>{' '}
+                  <Chip claim="verified" /> &nbsp;<span style={{ color: C.mut, fontSize: 11 }}>
+                    Candidate asks are live in the CRM and move week to week, so no stack total is
+                    printed here. Centrecorp is a buyer, not a grant line.
+                  </span>
                 </span>
               </div>
               <div style={{ fontSize: 10.5, color: C.mut, marginTop: 6, lineHeight: 1.38 }}>

--- a/v2/src/app/sites/cost-lab/cost-lab-workspace.tsx
+++ b/v2/src/app/sites/cost-lab/cost-lab-workspace.tsx
@@ -112,7 +112,7 @@ const SCENARIOS: Array<{
   {
     key: 'seed-fleet',
     label: 'Seed fleet of 3 (best case)',
-    hint: 'The QBE stack ($400K signed + $400K match) funds 3 containers up-front, then surplus compounds. Modelled.',
+    hint: '$400K of signed external capital funds 3 containers up-front, then surplus compounds. A QBE grant, if awarded, would sit on top and is not modelled here. Modelled.',
     inputs: { build_method: 'community', beds_per_year: 1500, location: 'on_country', containerise: true },
     sim: { startingContainers: 3, path: 'community', bedsPerContainerYear: 500, containerCost: 125_000, siteOverheadPerYear: 24_000, signedExternal: 400_000, horizonYears: 8 },
   },
@@ -268,8 +268,10 @@ export function CostLabWorkspace() {
   // ── Container coster derived values ──
   const capexLow = capexRows.reduce((s, r) => s + (Number.isFinite(r.low) ? r.low : 0), 0);
   const capexHigh = capexRows.reduce((s, r) => s + (Number.isFinite(r.high) ? r.high : 0), 0);
-  const netLow = Math.max(0, capexLow - ALREADY_INVESTED);
-  const netHigh = Math.max(0, capexHigh - ALREADY_INVESTED);
+  // RULING P, 2026-07-25: capital is quoted GROSS ONLY and sunk spend sits beside it, never
+  // netted. NET_CAPITAL_LOW/HIGH were deleted from engine.ts and are guarded there; this file
+  // recomputed them privately and rendered the result as "Net remaining ask", which is the same
+  // claim by another route. Removed 2026-08-02.
   const capexMid = (capexLow + capexHigh) / 2;
   const paybackBedsMid = safeDiv(capexMid, LEGS_SAVING_PER_BED);
   const paybackYearsMid = safeDiv(paybackBedsMid, inputs.beds_per_year);
@@ -314,9 +316,22 @@ export function CostLabWorkspace() {
   // Crew estimate: beds/yr per container ÷ (beds/day × ~220 working days) = crews needed, modelled.
   const crewPerContainer = safeDiv(sim.bedsPerContainerYear, inputs.community_beds_per_day * 220);
 
-  // ── QBE match math ──
-  const qbeMatch = Math.min(sim.signedExternal, MATCH_TARGET.cap);
-  const stackTotal = sim.signedExternal + qbeMatch;
+  // ── QBE coverage test ──────────────────────────────────────────────────────
+  // RULING V, 2026-08-01. There is no match arithmetic, and there used to be:
+  //   qbeMatch  = Math.min(signedExternal, cap)
+  //   stackTotal = signedExternal + qbeMatch
+  // which paid a matching dollar for every signed dollar and reported the result as "leverage
+  // on signed dollars, 2.0x". That is the mechanic ruling V retired. The program is CATALYTIC
+  // and discretionary: typically $150K to $400K, from a pool of up to $1.1M shared across TEN
+  // enterprises (2025 paid $1.02M across ten, averaging about $102K). Signing paper does not
+  // oblige QBE to anything.
+  //
+  // What the terms DO bind is the grant: it "must be at least matched by signed external
+  // commitments". That is a COVERAGE TEST on the grant, not a doubling of our money. So the only
+  // honest thing to compute is whether signed capital would cover a grant at each end of the
+  // range, and it is a gate, not a total.
+  const coversLowEnd = sim.signedExternal >= MATCH_TARGET.typicalLow;
+  const coversCap = sim.signedExternal >= MATCH_TARGET.cap;
 
   // ── Per-container impact (the support-people numbers, modelled) ──
   const wagesPerContainer = sim.bedsPerContainerYear * inputs.community_labour_per_bed;
@@ -333,10 +348,10 @@ export function CostLabWorkspace() {
       `Price ${fmt(inputs.retail_price)} | Marginal: kit ${fmt(model.marginalKit)} / factory ${fmt(model.marginalFactory)} / community ${fmt(model.marginalCommunity)}`,
       `Contribution: kit ${fmt(model.contributionKit)} / factory ${fmt(model.contributionFactory)} / community ${fmt(model.contributionCommunity)}`,
       `Fixed block ${fmt(model.fixedBlock)}/yr | Break-even (selected path) ${fmtInt(model.breakevenSelected)} beds/yr`,
-      `Container capex: gross ${fmt(capexLow)} to ${fmt(capexHigh)} | net of invested ${fmt(netLow)} to ${fmt(netHigh)} (modelled)`,
+      `Container capex: gross ${fmt(capexLow)} to ${fmt(capexHigh)}, with ${fmt(ALREADY_INVESTED)} already invested stated separately, never netted (ruling P, modelled)`,
       `Compounding (${sim.path}, ${fmtInt(sim.bedsPerContainerYear)} beds/yr/container, container ${fmt(sim.containerCost)}): start ${sim.startingContainers}, ${firstSelfFunded ? `first self-funded container year ${firstSelfFunded.year}` : 'no self-funded container in horizon'}, ${fmtInt(finalContainers)} containers by year ${sim.horizonYears}, ${fmtInt(totalBeds)} cumulative beds`,
       `Per container per year (modelled): wages ${fmt(wagesPerContainer)}, plastic ${fmtInt(Math.round(plasticPerContainer))}kg, surplus ${fmt(surplusPerContainer)}`,
-      `QBE stack: signed ${fmt(sim.signedExternal)} + match ${fmt(qbeMatch)} = ${fmt(stackTotal)} (match not secured until awarded)`,
+      `Signed external capital ${fmt(sim.signedExternal)}. QBE is catalytic and discretionary, typically ${fmt(MATCH_TARGET.typicalLow)} to ${fmt(MATCH_TARGET.cap)} from a pool of up to ${fmt(MATCH_TARGET.pool)} across ten enterprises; it is not added to our signed capital and signing does not oblige it.`,
       '',
       'Notes and decisions:',
       notes.trim() || '(none captured)',
@@ -620,7 +635,7 @@ export function CostLabWorkspace() {
           <div className="space-y-3">
             <StatChip label="Gross build cost" value={`${fmt(capexLow)} to ${fmt(capexHigh)}`} sub="Sum of the line items" />
             <StatChip label="Already invested" value={fmt(ALREADY_INVESTED)} sub="Facility + tooling to date" />
-            <StatChip label="Net remaining ask" value={`${fmt(netLow)} to ${fmt(netHigh)}`} sub="Gross minus already invested. Always say which basis you are quoting." />
+            <StatChip label="Basis" value="Gross" sub="Ruling P: capital is quoted gross, with sunk spend beside it. Never a net figure." />
             <StatChip
               label="Payback (mid-range)"
               value={`${fmtInt(Math.round(paybackBedsMid))} beds`}
@@ -690,10 +705,11 @@ export function CostLabWorkspace() {
             <p className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-[#A0532B]">
               <Factory className="h-4 w-4" aria-hidden /> Production capex
             </p>
-            <p className="mt-2 text-2xl font-semibold">{fmt(netLow)} to {fmt(netHigh)}</p>
+            <p className="mt-2 text-2xl font-semibold">{fmt(capexLow)} to {fmt(capexHigh)}</p>
             <p className="mt-1 text-xs leading-5 text-stone-500">
-              Net of {fmt(ALREADY_INVESTED)} invested. Fit: recoverable grant or catalytic capital with a
-              transfer trigger to community ownership. This is the block QBE match dollars amplify.
+              Gross, with {fmt(ALREADY_INVESTED)} already invested stated beside it rather than
+              subtracted from it. Fit: recoverable grant or catalytic capital with a transfer
+              trigger to community ownership.
             </p>
           </div>
           <div className="rounded-lg border border-stone-200 bg-white p-5">
@@ -719,37 +735,42 @@ export function CostLabWorkspace() {
         </div>
 
         <div className="mt-6 rounded-lg border border-stone-200 bg-[#2B2A26] p-6 text-[#FDF8F3]">
-          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#BBA255]">QBE Stage 2 match math</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[#BBA255]">QBE Stage 2 coverage test</p>
           <div className="mt-4 grid items-end gap-4 sm:grid-cols-[280px_1fr]">
             <NumberField
-              label="Signed match-eligible capital"
+              label="Signed external capital"
               prefix="$"
               value={sim.signedExternal}
               step={25_000}
               onChange={(n) => setSimField({ signedExternal: Math.max(0, n) })}
               hint="Legally binding commitments only. SIH verifies directly with the funder."
             />
-            <div className="grid gap-3 sm:grid-cols-3">
+            <div className="grid gap-3 sm:grid-cols-2">
               <div>
-                <p className="text-xs uppercase tracking-wide text-[#E6DFD1]/70">QBE match (up to $400K)</p>
-                <p className="mt-1 text-xl font-semibold">{fmt(qbeMatch)}</p>
+                <p className="text-xs uppercase tracking-wide text-[#E6DFD1]/70">
+                  Would cover a grant at {fmt(MATCH_TARGET.typicalLow)}
+                </p>
+                <p className="mt-1 text-xl font-semibold">{coversLowEnd ? 'Yes' : 'Not yet'}</p>
               </div>
               <div>
-                <p className="text-xs uppercase tracking-wide text-[#E6DFD1]/70">Total stack</p>
-                <p className="mt-1 text-xl font-semibold">{fmt(stackTotal)}</p>
-              </div>
-              <div>
-                <p className="text-xs uppercase tracking-wide text-[#E6DFD1]/70">Leverage on signed dollars</p>
-                <p className="mt-1 text-xl font-semibold">{safeDiv(stackTotal, sim.signedExternal, 0).toFixed(1)}x</p>
+                <p className="text-xs uppercase tracking-wide text-[#E6DFD1]/70">
+                  Would cover a grant at {fmt(MATCH_TARGET.cap)}
+                </p>
+                <p className="mt-1 text-xl font-semibold">{coversCap ? 'Yes' : 'Not yet'}</p>
               </div>
             </div>
           </div>
           <p className="mt-4 text-xs leading-5 text-[#E6DFD1]">
-            Up to $400,000 from a $1M shared pool, at least matched by signed external capital, awarded at Steering
-            Committee discretion. Application September 2026, outcomes November 2026. Repayable finance is prioritised,
-            which suits recoverable-grant structures. Innovation framing: the capex block IS the innovation (mobile
-            recycled-plastic manufacturing that transfers to community ownership), which opens innovation funds that
-            plain bed-buying grants never reach.
+            {MATCH_TARGET.note}
+          </p>
+          <p className="mt-2 text-xs leading-5 text-[#E6DFD1]/80">
+            There is no total to read here on purpose. A QBE grant is not added to signed capital
+            and signing does not oblige QBE: the requirement runs the other way, and signed capital
+            is what a grant would have to be covered by. 2025 paid {fmt(1_020_000)} across{' '}
+            {MATCH_TARGET.cohort} enterprises, averaging about {fmt(102_000)}. Innovation framing:
+            the capex block is itself the innovation, mobile recycled-plastic manufacturing that
+            transfers to community ownership, which opens innovation funds that plain bed-buying
+            grants never reach.
           </p>
         </div>
       </section>

--- a/v2/src/app/sites/qbe-readiness/page.tsx
+++ b/v2/src/app/sites/qbe-readiness/page.tsx
@@ -94,14 +94,14 @@ const METRICS: Array<{ value: string; label: string; sub: string; tier: Tier }> 
   },
   {
     value: 'AU$0 signed',
-    label: 'of a ~AU$400K target',
+    label: 'of signed external capital',
     sub: 'First match-eligible capital, due signed by 31 August 2026.',
     tier: 'Open',
   },
   {
     value: 'Up to AU$400K',
     label: 'QBE match',
-    sub: 'At least 1:1 against secured capital. Repayable finance preferred.',
+    sub: 'Catalytic and discretionary, typically AU$150K to AU$400K from a pool of up to AU$1.1M across ten enterprises. Must be at least matched by signed external capital raised first. Repayable finance preferred.',
     tier: 'Target',
   },
 ];
@@ -112,7 +112,7 @@ const STACK: Array<{ label: string; amount: string; detail: string; tier: Tier }
   {
     label: 'QBE match',
     amount: 'up to AU$400K',
-    detail: 'at least 1:1 vs secured capital, repayable preferred',
+    detail: 'discretionary, must be at least matched by signed capital raised first, repayable preferred',
     tier: 'Target',
   },
   { label: 'SEFA', amount: 'AU$300K', detail: 'concessional working-capital line', tier: 'Target' },
@@ -182,11 +182,11 @@ const MILESTONES: Array<{ when: string; what: string; tier?: Tier }> = [
   },
   {
     when: 'By 31 August 2026',
-    what: 'Close the first ~AU$400K of signed, match-eligible capital. This is the one deadline that matters.',
+    what: 'Close the first signed, match-eligible capital. This is the one deadline that matters. AU$400K is the QBE program ceiling, not our capital requirement, which is built bottom up from equipment, a measured run and working capital.',
     tier: 'Open',
   },
   { when: 'September 2026', what: 'QBE Stage 2 application submitted.' },
-  { when: 'November 2026', what: 'QBE outcome decided. The match is paid against capital already raised.' },
+  { when: 'November 2026', what: 'QBE outcome decided at Steering Committee discretion. Nothing is owed to us before that, whatever we have signed.' },
 ];
 
 const PHASES: Array<{ n: number; name: string; horizon: string; body: string }> = [
@@ -461,7 +461,8 @@ export default function QbeReadinessPage() {
             Close the first{' '}
             <span className="font-semibold">~AU$400K of signed, match-eligible capital by 31
             August 2026.</span>{' '}
-            QBE then adds up to AU$400K, but only as a match, so signed external money has to come
+            QBE may then grant up to AU$400K at its own discretion, and only where signed external
+            money came
             first. Today that number is{' '}
             <span className="font-semibold text-rose-700">AU$0 signed</span>. The entire stage is the
             work of getting it off zero. A conversation problem, not a discovery problem.

--- a/v2/src/app/sites/qbe/qbe-site-workspace.tsx
+++ b/v2/src/app/sites/qbe/qbe-site-workspace.tsx
@@ -710,7 +710,7 @@ export function QbeSiteWorkspace() {
                 <p className="mt-2 text-2xl font-semibold">~$400k</p>
                 <p className="mt-1 text-xs text-[#E6DFD1]">Signed match-eligible capital to close. QBE Stage 2 funds up to $400K, at least matched, not secured until awarded.</p>
                 <p className="mt-2 text-xs font-semibold text-[#FDF8F3]">$0 of $400K signed</p>
-                <p className="mt-1 text-xs text-[#E6DFD1]">Candidates: grants at ask made $607.5K, repayable at cultivating $710K. Either column alone clears the match twice over.</p>
+                <p className="mt-1 text-xs text-[#E6DFD1]">Candidates: grants at ask made $607.5K, repayable at cultivating $710K. Either column alone would cover a grant at the top of the range.</p>
               </div>
               <div className="rounded-lg border border-white/10 bg-white/5 p-4">
                 <p className="text-xs uppercase tracking-[0.2em] text-[#BBA255]">Cost unlock</p>

--- a/v2/src/app/sites/qbe/qbe-site-workspace.tsx
+++ b/v2/src/app/sites/qbe/qbe-site-workspace.tsx
@@ -710,7 +710,7 @@ export function QbeSiteWorkspace() {
                 <p className="mt-2 text-2xl font-semibold">~$400k</p>
                 <p className="mt-1 text-xs text-[#E6DFD1]">Signed match-eligible capital to close. QBE Stage 2 funds up to $400K, at least matched, not secured until awarded.</p>
                 <p className="mt-2 text-xs font-semibold text-[#FDF8F3]">$0 of $400K signed</p>
-                <p className="mt-1 text-xs text-[#E6DFD1]">Candidates: grants at ask made $607.5K, repayable at cultivating $710K. Either column alone would cover a grant at the top of the range.</p>
+                <p className="mt-1 text-xs text-[#E6DFD1]">Candidate asks are live in the CRM and move week to week, so no stack total is printed here. Centrecorp is a buyer, not a grant line (Ben, 2026-08-02).</p>
               </div>
               <div className="rounded-lg border border-white/10 bg-white/5 p-4">
                 <p className="text-xs uppercase tracking-[0.2em] text-[#BBA255]">Cost unlock</p>

--- a/v2/src/lib/data/deck.ts
+++ b/v2/src/lib/data/deck.ts
@@ -495,21 +495,25 @@ export const deckSlides: DeckSlide[] = [
     kind: 'money',
     eyebrow: 'Where the money actually is',
     headline: `The signed total is ${signedLois}. The conversations are still conversations.`,
-    body: 'The CRM has AU$607,500 in grant asks and AU$710,000 in repayable-capital conversations. Either amount could cover the QBE match. Today, none of it is signed.',
+    body: 'Grant asks and repayable-capital conversations are both live in the CRM and both move week to week, so no stack total is quoted here. Today, none of it is signed.',
     photo: '/images/process/color-samples.jpg',
     photoAlt: 'Recycled-plastic colour samples',
     place: 'Rebuilt 25 July 2026 from all 67 Supporter Journey rows',
     chips: [
       { label: 'Verified · signed, match-eligible', value: `${signedLois}` },
-      { label: 'Proposed · grants at "Ask made"', value: 'AU$607,500' },
-      { label: 'Proposed · repayable at "Cultivating"', value: 'AU$710,000' },
+      // The AU$607,500 / AU$710,000 pair was removed 2026-08-02. It was a hand-typed CRM snapshot
+      // dated 2026-07-25, and the grant column included Centrecorp at $75K, which Ben confirmed
+      // that day is a BUYER and will not give a grant. ask-surface.ts records the correction and
+      // says plainly: re-derive from GHL rather than patching the number here. Until it is
+      // derived, the honest chip is the one that is true every day.
+      { label: 'Verified · signed', value: '$0' },
       { label: 'Workpaper · Goods-only FY26 revenue', value: aud(Number(revenueCarveout.value)) },
       { label: 'Workpaper · already invested', value: aud(ALREADY_INVESTED) },
       { label: 'Modelled · equipment, gross', value: `${aud(CAPITAL_GROSS_LOW)} to ${aud(CAPITAL_GROSS_HIGH)}` },
     ],
     goDeeper: [{ label: 'Every number, audited', href: '/register' }],
     script:
-      'Nothing is signed today. Grant asks in the CRM total 607,500: Minderoo, Tim Fairfax, Snow, Rotary Eclub and Centrecorp. Repayable-capital conversations total 710,000: SEFA, White Box, LendForGood and Metro Finance. Either amount could cover the QBE match, but neither has produced the paper yet. Goods-only FY26 revenue is 713,827 in a workpaper prepared with our accountant; it is not accountant-signed. We have invested 110,046. About 43,700 is evidenced at bill level, while paperwork for the remaining equipment is still being assembled. The gross equipment requirement is between 112,000 and 222,000. We show the requirement and our existing investment separately because the ownership of new equipment must be agreed, not assumed.',
+      'Nothing is signed today. There are live grant asks and live repayable-capital conversations in the CRM, and I am not going to quote you a stack total because it moves week to week and the last one we published counted a bed buyer as a grant. Neither column has produced paper yet. Goods-only FY26 revenue is 713,827 in a workpaper prepared with our accountant; it is not accountant-signed. We have invested 110,046. About 43,700 is evidenced at bill level, while paperwork for the remaining equipment is still being assembled. The gross equipment requirement is between 112,000 and 222,000. We show the requirement and our existing investment separately because the ownership of new equipment must be agreed, not assumed.',
     note: 'Ruling H: cite $713,827, never call it signed, label it workpaper. canon.ts already grades revenue-carveout claimLabel "workpaper" (verified by reading the record on 2026-07-25; an audit pass that claimed otherwise had misread the neighbouring revenue-xero-paid entry). Ruling P: capital is quoted GROSS ONLY, sunk spend sits beside it and is NEVER netted; NET_CAPITAL_* were deleted from engine.ts and a guard fails if reintroduced. Ruling O regraded $110,046 to workpaper. The $607.5K / $710K figures are a MOVING CRM number rebuilt 2026-07-25, not canon, which is why they are chipped Proposed and dated in the place line.',
   },
 

--- a/v2/src/lib/data/loi-pipeline.ts
+++ b/v2/src/lib/data/loi-pipeline.ts
@@ -91,15 +91,41 @@ export const STAGE_TO_RUNG: Record<string, LoiRung> = {
 
 /**
  * QBE Stage-2 funding. Program cap CONFIRMED at $400K by the Catalysing Impact
- * 2026 induction deck (31 Mar 2026): up to $400,000 from a $1M shared pool,
- * must be AT LEAST matched by external capital secured (legally binding
- * commitments), repayable finance prioritised over grants. Awarded at Steering
- * Committee discretion — application Sept 2026, outcomes Nov 2026.
+ * 2026 induction deck (31 Mar 2026). Must be AT LEAST matched by external capital
+ * secured (legally binding commitments), repayable finance prioritised over grants.
+ * Awarded at Steering Committee discretion, application Sept 2026, outcomes Nov 2026.
  * Do not present the funding as secured until awarded.
+ *
+ * The induction deck said "$1M shared pool". Program sources read 2026-08-01 put the 2026 pool at
+ * up to $1.1M across ten enterprises (ruling V, wiki/investor/20-qbe-program-economics.md), so the
+ * pool figure below comes from those and not from the deck. Kept here because a superseded source
+ * is worth naming: the deck is still the confirmation for the $400K cap.
+ */
+/**
+ * QBE Catalysing Impact Stage 2, as the program's own sources describe it. Researched from Social
+ * Impact Hub and QBE Foundation primary material 2026-08-01 (ruling V,
+ * `wiki/investor/20-qbe-program-economics.md`), which corrected several things this constant used
+ * to imply.
+ *
+ * The grant is CATALYTIC and discretionary. It is not dollar for dollar, there is no floor, and a
+ * signature does not oblige QBE to anything. What the terms bind is the grant itself: it must be
+ * at least matched by signed external commitments, which is a COVERAGE TEST on the grant, not a
+ * doubling of our money.
+ *
+ * `cap` is the top of the range and 36% of the whole pool, so planning as though it is the
+ * expected amount is planning on the best case. 2025 paid $1.02M across ten enterprises,
+ * averaging about $102K.
  */
 export const MATCH_TARGET = {
+  /** Bottom of the stated typical range. NOT a floor: nothing guarantees this much. */
+  typicalLow: 150_000,
+  /** Top of the stated typical range, and the program cap. */
   cap: 400_000,
-  note: 'QBE Stage-2 funding is up to $400K (program cap, $1M shared pool) and must be at least matched by signed external commitments raised first. Application Sept 2026, outcomes Nov 2026, Steering Committee discretion. Do not present as secured until awarded.',
+  /** The whole 2026 pool, shared across ten enterprises. Was recorded as $1M until 2026-08-02. */
+  pool: 1_100_000,
+  /** Enterprises sharing the pool. */
+  cohort: 10,
+  note: 'QBE Stage-2 funding is catalytic and discretionary, typically $150K to $400K, from a pool of up to $1.1M shared across ten enterprises, and must be at least matched by signed external commitments raised first. Application Sept 2026, outcomes Nov 2026, Steering Committee discretion. Do not present as secured until awarded, and do not present $400K as our capital requirement.',
 };
 
 /**

--- a/v2/src/lib/data/pitch-cockpit.ts
+++ b/v2/src/lib/data/pitch-cockpit.ts
@@ -112,9 +112,9 @@ export const DECK_PLAN: DeckSlide[] = [
   {
     n: 11, id: 'the-ask', name: 'AU$400,000 signed by 31 August',
     why: 'The ask sits LAST, after the hinge and the doors have earned it. The $400K is what gets signed; QBE is the match vehicle, not the ask.',
-    talkTrack: '$400,000 in signed commitments by 31 August, and QBE can add a discretionary grant on top of that signed paper. The program closes late September, outcomes November. It buys the measured run, the per-site plant capital, the first on-Country operator roles, and working capital. On the stack: grants at ask made total $607.5K and repayable at cultivating totals $710K, so either column alone clears the match twice over. The match is short of paper, not short of candidates, and grants paper faster than loans. Signed to date: zero. We say so.',
+    talkTrack: '$400,000 in signed commitments by 31 August, and QBE can add a discretionary grant on top of that signed paper. The program closes late September, outcomes November. It buys the measured run, the per-site plant capital, the first on-Country operator roles, and working capital. The candidate asks are live in the CRM and move week to week, so no stack total is quoted: we are short of paper, not short of candidates, and grants paper faster than loans. Centrecorp is a buyer, not a grant line. Signed to date: zero. We say so.',
     voices: [], visual: 'stats',
-    visualNotes: 'Floor is $150K matched. Above $400K the match stops. REAL is a separate vehicle, excluded from the match.',
+    visualNotes: 'The grant is discretionary, typically $150K to $400K from a pool of up to $1.1M across ten enterprises. There is no floor and nothing stops: signing does not oblige QBE. REAL is a separate vehicle, excluded. (Ruling V, 2026-08-01.)',
   },
   {
     n: 12, id: 'the-close', name: 'Leave the making with us',


### PR DESCRIPTION
Two commits. Both fix things that are wrong on funder surfaces during a live raise, and **every one of them passed `check:qbe-guardrails`.**

## Dollar-for-dollar was implemented as arithmetic

`cost-lab-workspace.tsx` computed:

```ts
const qbeMatch  = Math.min(sim.signedExternal, MATCH_TARGET.cap);
const stackTotal = sim.signedExternal + qbeMatch;
```

and rendered the result as **"Leverage on signed dollars, 2.0x"**. Every signed dollar produced a matching QBE dollar. That is the mechanic ruling V retired. `copySummary()` also wrote it to the clipboard **for pasting into Notion**, so it propagated into documents no guard sees.

Replaced by a coverage test: signed capital is what a grant must be matched *by*, so the only honest thing to compute is whether it would cover a grant at each end of the range. There is deliberately no total to read.

## The $607.5K counted a bed buyer, and four surfaces still printed it

`ask-surface.ts` was corrected **the same morning** and says it plainly: the total *"included Centrecorp at $75K, which came out on 2026-08-02 when Ben confirmed they are a buyer and will not give a grant"*, and *"re-derive it from GHL rather than patching the number here"*.

The sweep never ran. Still printing it: **`/export/leave-behind` (LIVE, and it listed "Centrecorp $75K grant" as a named line beside Snow and SEFA — this is the document handed to funders)**, `/sites/qbe`, `pitch-cockpit.ts`, and `deck.ts`'s money slide. `/pitch/road` was verified clean live before any change.

None assert a stack total now. The deck's chip is `$0 signed`, which is true every day.

## Ruling P was violated outside engine.ts

`NET_CAPITAL_LOW/HIGH` were deleted from the engine on 2026-07-25 and are guarded **there**. The cost lab recomputed them privately and rendered **"Net remaining ask"**. Capital is quoted gross with sunk spend beside it, never netted.

## MATCH_TARGET corrected at source

`typicalLow: 150_000`, `pool: 1_100_000` (recorded as $1M until now), `cohort: 10`. 2025 paid $1.02M across ten, averaging ~$102K. $400K is the top of the range and 36% of the whole pool.

## The guard learned negation

It fired on a comment reading *"It is not dollar for dollar, there is no floor"* — ruling V stated correctly. `check-retired-figures.mjs` already had `NEGATED`, and its comment calls that *"the fourth time in one week a guard has flagged the field that enforces the thing it guards"*. **This was the fifth.** Ported across, and verified it still fails on a genuine violation.

**Gates:** tsc clean · 420 tests · check:qbe-guardrails, check:voice, check:retired-figures, check:drift:ci, check:audience, check:content-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)