### PR TITLE
fix(shop): the buyer front door leads with the spec again

### DIFF
--- a/v2/src/app/shop/page.tsx
+++ b/v2/src/app/shop/page.tsx
@@ -4,12 +4,18 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { media } from '@/lib/data/media';
 import { PLASTIC_KG_PER_BED, STRETCH_BED, WASHING_MACHINE, BASKET_BED } from '@/lib/data/products';
+import { SHOP_ANSWERS } from '@/lib/data/shop';
+import { canonValue } from '@/lib/data/canon';
 import { ItemListJsonLd } from '@/components/seo';
+
+// Spec-first rebuild (DECISIONS.md ruling S sweep, 2026-07-26): the page leads with
+// the straight answers — spec, price, lead time, freight, lifespan, who fixes it —
+// before any brand prose. Answers live in lib/data/shop.ts.
 
 export const metadata = {
   title: 'Shop Stretch Beds',
   description:
-    'Browse Stretch Beds, washing machine prototypes and open-source Basket Bed plans made for remote First Nations communities.',
+    'The Stretch Bed spec, price, freight and support up front. Plus washing machine prototypes and open-source Basket Bed plans.',
   alternates: {
     canonical: 'https://www.goodsoncountry.com/shop',
   },
@@ -34,7 +40,7 @@ const products = [
     slug: STRETCH_BED.slug,
     name: STRETCH_BED.name,
     description: `Recycled HDPE plastic legs, galvanised steel poles, heavy-duty canvas. ${STRETCH_BED.specs.weight}, flat-packs, no tools needed.`,
-    price: 750,
+    price: canonValue('stretch-price') as number,
     image: media.product.stretchBedHero,
     badge: 'Available',
     badgeColor: 'bg-primary text-primary-foreground',
@@ -55,7 +61,7 @@ const products = [
   {
     slug: BASKET_BED.slug,
     name: `${BASKET_BED.name} Plans`,
-    description: 'Our first prototype — collapsible baskets with zip ties and toppers. Now open source — download and build your own.',
+    description: 'Our first prototype: collapsible baskets with zip ties and toppers. Now open source. Download and build your own.',
     price: null,
     image: media.product.basketBedHero,
     badge: 'Open Source',
@@ -77,44 +83,62 @@ export default function ShopPage() {
           image: product.image,
         }))}
       />
-      {/* Header */}
+
+      {/* Header + the straight answers, before anything else */}
       <section className="py-16 md:py-20">
         <div className="container mx-auto px-4">
-          <div className="text-center max-w-2xl mx-auto">
+          <div className="max-w-3xl">
             <p className="text-sm uppercase tracking-widest mb-4" style={{ color: '#8B9D77' }}>
-              Our Products
+              The Stretch Bed
             </p>
-            <h1 className="text-4xl md:text-5xl font-light mb-6" style={{ color: '#2E2E2E', fontFamily: 'Georgia, serif' }}>
-              Shop Beds
+            <h1 className="text-4xl md:text-5xl font-light mb-6" style={{ color: '#2E2E2E', fontFamily: 'var(--font-display, Georgia, serif)' }}>
+              The straight answers, before the buy button.
             </h1>
-            <p className="text-lg" style={{ color: '#5E5E5E' }}>
+            <p className="text-lg mb-4" style={{ color: '#5E5E5E' }}>
               Every purchase supports remote First Nations communities across Australia.
               Each bed diverts {PLASTIC_KG_PER_BED}kg of plastic from landfill.
             </p>
           </div>
+
+          <div className="mt-10 grid gap-x-10 gap-y-8 md:grid-cols-2 max-w-5xl">
+            {SHOP_ANSWERS.map((item) => (
+              <div key={item.question} className="border-t pt-5" style={{ borderColor: '#E5DDD2' }}>
+                <h2 className="text-sm uppercase tracking-widest mb-2" style={{ color: '#C45C3E' }}>
+                  {item.question}
+                </h2>
+                <p className="leading-relaxed" style={{ color: '#2E2E2E' }}>{item.answer}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-10 flex flex-wrap gap-4">
+            <Button size="lg" style={{ backgroundColor: '#C45C3E' }} asChild>
+              <Link href="/shop/stretch-bed-single">Buy the Stretch Bed · ${String(canonValue('stretch-price'))}</Link>
+            </Button>
+            <Button size="lg" variant="outline" asChild>
+              <Link href="/contact">Ask about freight or bulk orders</Link>
+            </Button>
+          </div>
         </div>
       </section>
 
-      {/* Products Grid */}
-      <section className="pb-16 md:pb-20">
+      {/* Products grid */}
+      <section className="py-16 md:py-20 bg-white">
         <div className="container mx-auto px-4">
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl mx-auto">
+          <h2 className="text-3xl font-light mb-10" style={{ color: '#2E2E2E', fontFamily: 'var(--font-display, Georgia, serif)' }}>
+            Everything we make
+          </h2>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 max-w-5xl">
             {products.map((product) => (
               <Card key={product.slug} className="overflow-hidden group">
                 <div className="relative aspect-[4/3] overflow-hidden bg-muted">
-                  {product.image ? (
+                  {product.image && (
                     <Image
                       src={product.image}
                       alt={product.name}
                       fill
                       className="object-cover transition-transform group-hover:scale-105"
                     />
-                  ) : (
-                    <div className="flex items-center justify-center h-full">
-                      <svg className="h-16 w-16 text-muted-foreground/30" fill="none" viewBox="0 0 24 24" strokeWidth="1" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z" />
-                      </svg>
-                    </div>
                   )}
                   <div className="absolute top-3 left-3">
                     <span className={`${product.badgeColor} text-xs font-medium px-2 py-1 rounded`}>
@@ -130,7 +154,7 @@ export default function ShopPage() {
                   )}
                   <Button asChild className="w-full" variant={product.price ? 'default' : 'outline'}>
                     <Link href={product.href}>
-                      {product.cta}{product.price ? ` — $${product.price}` : ''}
+                      {product.cta}{product.price ? ` · $${product.price}` : ''}
                     </Link>
                   </Button>
                 </CardContent>
@@ -140,135 +164,21 @@ export default function ShopPage() {
         </div>
       </section>
 
-      {/* Info Section */}
-      <section className="py-16 md:py-20 bg-white">
-        <div className="container mx-auto px-4">
-          <div className="text-center mb-12">
-            <p className="text-sm uppercase tracking-widest mb-4" style={{ color: '#8B9D77' }}>
-              Why Our Products
-            </p>
-            <h2 className="text-3xl font-light" style={{ color: '#2E2E2E', fontFamily: 'Georgia, serif' }}>
-              Built for Remote Australia
-            </h2>
-          </div>
-
-          <div className="grid gap-8 md:grid-cols-3 max-w-4xl mx-auto">
-            {[
-              {
-                title: 'Community-Made Quality',
-                description: 'Each bed is built using modern recycling equipment and precision manufacturing, on country.',
-                icon: (
-                  <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M11.42 15.17L17.25 21A2.652 2.652 0 0021 17.25l-5.877-5.877M11.42 15.17l2.496-3.03c.317-.384.74-.626 1.208-.766M11.42 15.17l-4.655 5.653a2.548 2.548 0 11-3.586-3.586l6.837-5.63m5.108-.233c.55-.164 1.163-.188 1.743-.14a4.5 4.5 0 004.486-6.336l-3.276 3.277a3.004 3.004 0 01-2.25-2.25l3.276-3.276a4.5 4.5 0 00-6.336 4.486c.091 1.076-.071 2.264-.904 2.95l-.102.085m-1.745 1.437L5.909 7.5H4.5L2.25 3.75l1.5-1.5L7.5 4.5v1.409l4.26 4.26m-1.745 1.437l1.745-1.437m6.615 8.206L15.75 15.75M4.867 19.125h.008v.008h-.008v-.008z" />
-                  </svg>
-                ),
-              },
-              {
-                title: 'Built for Conditions',
-                description: 'Designed to withstand extreme heat, humidity, and the demands of remote living.',
-                icon: (
-                  <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-                  </svg>
-                ),
-              },
-              {
-                title: 'Community Ownership',
-                description: 'Our goal is to transfer manufacturing to community-owned enterprises, so a community comes to own the making.',
-                icon: (
-                  <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                  </svg>
-                ),
-              },
-            ].map((item) => (
-              <div key={item.title} className="text-center">
-                <div
-                  className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4"
-                  style={{ backgroundColor: '#C45C3E' }}
-                >
-                  {item.icon}
-                </div>
-                <h3 className="font-medium mb-2" style={{ color: '#2E2E2E' }}>{item.title}</h3>
-                <p className="text-sm" style={{ color: '#5E5E5E' }}>{item.description}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Product Features */}
-      <section className="py-16 md:py-20" style={{ backgroundColor: '#FDF8F3' }}>
-        <div className="container mx-auto px-4">
-          <div className="grid gap-12 lg:grid-cols-2 items-center max-w-6xl mx-auto">
-            {/* Stretch Bed Image */}
-            <div className="relative aspect-square rounded-2xl overflow-hidden">
-              <Image
-                src={media.product.stretchBedInUse || '/images/product/stretch-bed-hero.jpg'}
-                alt="The Stretch Bed in use"
-                fill
-                className="object-cover"
-              />
-            </div>
-
-            <div>
-              <p className="text-sm uppercase tracking-widest mb-4" style={{ color: '#8B9D77' }}>
-                The Stretch Bed
-              </p>
-              <h2 className="text-3xl font-light mb-6" style={{ color: '#2E2E2E', fontFamily: 'Georgia, serif' }}>
-                Designed with Community
-              </h2>
-              <p className="mb-6" style={{ color: '#5E5E5E' }}>
-                500+ minutes of community feedback shapes every product we make.
-                The Stretch Bed is designed to meet the specific needs of remote living.
-              </p>
-
-              <div className="space-y-4 mb-8">
-                {[
-                  `Made from ${PLASTIC_KG_PER_BED}kg recycled plastic`,
-                  '5-minute assembly, no tools required',
-                  'Washable mattress components',
-                  `Designed to last ${STRETCH_BED.specs.designLifespan}`,
-                  'Stackable for easy transport',
-                ].map((feature) => (
-                  <div key={feature} className="flex items-center gap-3">
-                    <div
-                      className="w-6 h-6 rounded-full flex items-center justify-center flex-shrink-0"
-                      style={{ backgroundColor: '#8B9D77' }}
-                    >
-                      <svg className="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                      </svg>
-                    </div>
-                    <span style={{ color: '#2E2E2E' }}>{feature}</span>
-                  </div>
-                ))}
-              </div>
-
-              <Button size="lg" style={{ backgroundColor: '#C45C3E' }} asChild>
-                <Link href="/sponsor">Or Sponsor a Bed Instead</Link>
-              </Button>
-            </div>
-          </div>
-        </div>
-      </section>
-
       {/* Sponsor CTA */}
       <section className="py-16 md:py-20" style={{ backgroundColor: '#2E2E2E' }}>
         <div className="container mx-auto px-4 text-center">
-          <h2 className="text-3xl md:text-4xl font-light text-white mb-6" style={{ fontFamily: 'Georgia, serif' }}>
-            Want to make an even bigger impact?
+          <h2 className="text-3xl md:text-4xl font-light text-white mb-6" style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}>
+            Not buying for yourself?
           </h2>
           <p className="text-white/70 max-w-xl mx-auto mb-8">
-            Sponsor a bed for a family who has asked for one. 100% of your sponsorship goes directly
-            to delivering comfort to remote communities.
+            Sponsor a bed for a family who has asked for one: one bed, one community, one receipt.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Button size="lg" style={{ backgroundColor: '#C45C3E' }} asChild>
               <Link href="/sponsor">Sponsor a Bed</Link>
             </Button>
             <Button size="lg" variant="outline" className="bg-transparent text-white border-white hover:bg-white/10" asChild>
-              <Link href="/stories">Read Community Stories</Link>
+              <Link href="/storytellers">Hear from communities</Link>
             </Button>
           </div>
         </div>

--- a/v2/src/lib/data/route-audience.ts
+++ b/v2/src/lib/data/route-audience.ts
@@ -1640,7 +1640,7 @@ export const ROUTE_AUDIENCES: RouteAudience[] = [
       body: 'Every purchase supports remote First Nations communities across Australia. Each bed diverts',
     },
     verdict: 'rewrite',
-    why: 'buyer.mustNeverSee, verbatim: "The impact story ahead of the spec. A procurement buyer who cannot find the lead time does not stay for the mission." Leads "Shop Beds / Every purchase supports remote First Nations communities across Australia." The spec-first rebuild exists unmerged on origin/feat/six-front-doors.',
+    why: 'buyer.mustNeverSee, verbatim: the impact story ahead of the spec. A procurement buyer who cannot find the lead time does not stay for the mission. FIX WRITTEN 2026-08-02 on fix/shop-spec-first: the page leads "The straight answers, before the buy button" over SHOP_ANSWERS in the ruled order, spec then price then lead time then freight then life then who fixes it. The verdict stays rewrite until it is DEPLOYED and re-read, because leadsWithNow is production truth and production still serves the old page. Re-run scripts/read-route-leads.mjs after merge, then flip to keep.',
   },
   {
     route: '/shop/[slug]',

--- a/v2/src/lib/data/shop.ts
+++ b/v2/src/lib/data/shop.ts
@@ -1,0 +1,47 @@
+/**
+ * SHOP COPY — the spec-first answers ruling S asked for.
+ *
+ * "Rebuild /shop to lead with spec, price, lead time, freight, warranty, who fixes it."
+ * (DECISIONS.md ruling S sweep list, 2026-07-26.)
+ *
+ * Sourcing rule: every answer is either a spec from products.ts, a figure from canon,
+ * or an honest statement of process. Where no sourced figure exists (lead time has no
+ * measured number; there is no formal warranty document), the answer says what actually
+ * happens instead of inventing a number. The 10+ year design life is stated as design
+ * intent, matching its verified: false claim flag elsewhere.
+ */
+import { canonValue } from './canon';
+import { STRETCH_BED, PLASTIC_KG_PER_BED } from './products';
+
+export interface ShopAnswer {
+  question: string;
+  answer: string;
+}
+
+/** The straight answers a buyer needs before the buy button, in the order ruled. */
+export const SHOP_ANSWERS: ShopAnswer[] = [
+  {
+    question: 'The spec',
+    answer: `${STRETCH_BED.specs.dimensions}, ${STRETCH_BED.specs.weight}, supports ${STRETCH_BED.specs.loadCapacity}. Recycled HDPE X-trestle legs, two galvanised steel poles (${STRETCH_BED.materials.frame.detail}), heavy-duty Australian canvas. Assembles in ${STRETCH_BED.specs.assemblyTime} with no tools; the canvas is the structure.`,
+  },
+  {
+    question: 'The price',
+    answer: `$${canonValue('stretch-price')} for a single Stretch Bed. Each bed diverts ${PLASTIC_KG_PER_BED}kg of plastic from landfill.`,
+  },
+  {
+    question: 'Lead time',
+    answer: 'Beds are made in batches, not warehoused. We confirm your dispatch window when you order rather than promise a number we have not measured.',
+  },
+  {
+    question: 'Freight',
+    answer: 'Freight is quoted by destination. Remote deliveries carry real freight costs and we say so up front; for bulk or community orders, contact us for a quote before you buy.',
+  },
+  {
+    question: 'How long it lasts',
+    answer: `Designed to last ${STRETCH_BED.specs.designLifespan} in remote conditions. That is the design intent, not yet a field-proven number, and we will say so until it is.`,
+  },
+  {
+    question: 'Who fixes it',
+    answer: 'We do. Every bed carries a QR code: scan it to report an issue, and we arrange the repair or replacement and stay reachable by SMS. The canvas is washable and replaceable.',
+  },
+];


### PR DESCRIPTION
`/shop` is one of the nine rewrites found by `check:audience`, and the worst of them.

`buyer.mustNeverSee` says verbatim: *"The impact story ahead of the spec. A procurement buyer who cannot find the lead time does not stay for the mission."* The live page leads **"Shop Beds / Every purchase supports remote First Nations communities across Australia."**

## The fix was already written, and lost in a revert

Ruling S's sweep list said *"rebuild /shop to lead with spec, price, lead time, freight, warranty, who fixes it"*. It was built 2026-07-26, merged as PR #171, and **reverted an hour later by PR #173** because the wider six-front-doors change was not wanted on production. The shop rebuild was collateral.

This restores exactly two files from that branch: `src/lib/data/shop.ts` and `src/app/shop/page.tsx`.

The page now leads **"The straight answers, before the buy button"** over `SHOP_ANSWERS` in the ruled order: spec, price, lead time, freight, how long it lasts, who fixes it.

## It is honest where it cannot be precise

Every answer is sourced from `products.ts` or canon. Where no sourced figure exists it says what actually happens rather than inventing one: lead time reads *"we confirm your dispatch window when you order rather than promise a number we have not measured"*, and the 10+ year design life is stated as intent, matching its `verified: false` flag.

## What is deliberately NOT restored

`/shop/[slug]`. PR #191 retired it: it queried Supabase while `products.ts` is canon, and resolved nothing.

## The verdict stays `rewrite` on purpose

`leadsWithNow` is **production truth**, read from the live site, and production still serves the old page. Flipping the verdict now would assert something not yet true, which is the habit this whole model exists to break.

**After this deploys:** re-run `scripts/read-route-leads.mjs`, then flip `/shop` to `keep`. The rewrite count drops from nine to eight, on evidence. The record carries that instruction.

**Gates:** tsc clean · 420 tests · check:audience, check:voice, check:drift:ci, check:content-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)