### PR TITLE
feat(communities): one record per community, and the washers that were never on the page

### DIFF
--- a/v2/src/app/communities/[slug]/page.tsx
+++ b/v2/src/app/communities/[slug]/page.tsx
@@ -16,6 +16,7 @@ import { StorytellerAvatar } from '@/components/storyteller-avatar';
 import { isClearedForExternal } from '@/lib/data/cleared-voices';
 import { getGoodsStorytellers, slugify } from '@/lib/storytellers';
 import { makeCommunityMatcher } from '@/lib/data/community-match';
+import { communityRecord, isPublishable } from '@/lib/data/community-record';
 import type { EmpathyLedgerStoryteller } from '@/lib/empathy-ledger/types';
 import { CommunityMapClient } from '../map-wrapper';
 
@@ -161,7 +162,21 @@ export default async function CommunityPage({ params }: PageProps) {
   );
 
   const storytellerCount = storytellers.length > 0 ? storytellers.length : community.storytellerCount;
-  const plasticKg = community.bedsDelivered * PLASTIC_KG_PER_BED;
+
+  // One record, assembled from the canon modules that already own each number. Only the
+  // `cleared` fields are read here: this page is open and indexed, so stage, modules and the
+  // next decision (all 'confirm-together') never reach it. See community-record.ts.
+  const record = communityRecord(slug);
+  const assets = record?.assets && isPublishable(record.assets) ? record.assets.value : null;
+
+  // Plastic is diverted by Stretch Beds, which are pressed from recycled HDPE. Basket Beds are
+  // not, and this line multiplied EVERY delivered bed by 20kg until 2026-08-02, which overstated
+  // it at every community holding Basket Beds (Utopia read 2,940kg against a canon 1,740kg).
+  // CANONICAL_ASSETS.plasticKg is 3,540 = 177 Stretch x 20kg, so canon always used the narrower
+  // basis and this surface disagreed with it. The record computes it the canon way; the fallback
+  // only runs for a community with no canon row, where the old basis is all there is.
+  const plasticKg = assets ? assets.plasticKg : community.bedsDelivered * PLASTIC_KG_PER_BED;
+  const washers = assets?.washers ?? 0;
 
   return (
     <article className="mx-auto max-w-5xl px-4 py-12 sm:py-16">
@@ -202,6 +217,22 @@ export default async function CommunityPage({ params }: PageProps) {
           </div>
           <div className="mt-1 text-xs uppercase tracking-wider text-stone-500">Beds delivered</div>
         </div>
+        {washers > 0 && (
+          <div className="rounded-lg border border-stone-200 bg-white p-4">
+            <div className="font-display text-3xl font-bold text-amber-700">{washers}</div>
+            <div className="mt-1 text-xs uppercase tracking-wider text-stone-500">
+              Washing machine{washers === 1 ? '' : 's'}
+              <span className="block normal-case tracking-normal text-stone-400">
+                in community
+              </span>
+            </div>
+          </div>
+        )}
+        {/* Hidden at zero rather than printed as "0kg". Palm Island holds 131 Basket Beds and no
+            Stretch Beds, so on the canon basis it diverts none, and a bare 0kg on a community's
+            own page reads as a failure rather than as a different product mix. The other two
+            cards in this band already appear conditionally. */}
+        {plasticKg > 0 && (
         <div className="rounded-lg border border-stone-200 bg-white p-4">
           <div className="font-display text-3xl font-bold text-amber-700">
             {plasticKg.toLocaleString()}kg
@@ -209,10 +240,11 @@ export default async function CommunityPage({ params }: PageProps) {
           <div className="mt-1 text-xs uppercase tracking-wider text-stone-500">
             Plastic diverted
             <span className="block normal-case tracking-normal text-stone-400">
-              modelled at {PLASTIC_KG_PER_BED}kg per bed
+              modelled at {PLASTIC_KG_PER_BED}kg per Stretch Bed
             </span>
           </div>
         </div>
+        )}
         {storytellerCount > 0 && (
           <div className="rounded-lg border border-stone-200 bg-white p-4">
             <div className="font-display text-3xl font-bold text-amber-700">{storytellerCount}</div>

--- a/v2/src/lib/data/community-record.guards.test.ts
+++ b/v2/src/lib/data/community-record.guards.test.ts
@@ -190,6 +190,19 @@ describe('absence is reported as absence', () => {
     expect(record.handover).toBeNull();
   });
 
+  it('every /communities/[slug] page id resolves to a record with publishable assets', async () => {
+    // The page runs on communityLocations ids and the register runs on canon ids. When one
+    // drifts (utopia-homelands vs utopia), communityRecord() returns null and the page falls
+    // back to multiplying every bed by 20kg — the overstatement this module exists to fix,
+    // invisible to every module-level guard because the join itself is what broke.
+    const { communityLocations } = await import('./content');
+    for (const c of communityLocations) {
+      const record = communityRecord(c.id, { asOf: AS_OF });
+      expect(record, `communityRecord('${c.id}') must not be null`).not.toBeNull();
+      expect(record!.assets, `communityRecord('${c.id}').assets must exist`).not.toBeNull();
+    }
+  });
+
   it('is pure: the same asOf gives the same answer', () => {
     const a = communityRecord('utopia', { asOf: AS_OF });
     const b = communityRecord('utopia', { asOf: AS_OF });

--- a/v2/src/lib/data/community-record.guards.test.ts
+++ b/v2/src/lib/data/community-record.guards.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Guards for community-record.ts.
+ *
+ * The join is the risk. Every assertion below is a way the join can be silently wrong while
+ * every individual module stays correct and its own guards stay green.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  communityRecord,
+  allCommunityIds,
+  communityIdForPathway,
+  pathwayForCommunity,
+  isPublishable,
+  withStorytellers,
+  PATHWAY_TO_COMMUNITY,
+} from './community-record';
+import { COMMUNITY_BED_CANON, communityCanonTotals } from './community-canonical';
+import { COMMUNITY_PATHWAYS, MODULES } from './community-pathways';
+import { SITE_OWNERSHIP_TESTS } from './ownership-test';
+import { WASHERS_IN_COMMUNITY_BY_COMMUNITY } from './asset-canonical';
+
+const AS_OF = '2026-08-02';
+
+describe('the join resolves', () => {
+  it('every pathway resolves to a community id that exists somewhere', () => {
+    for (const pathway of COMMUNITY_PATHWAYS) {
+      const id = communityIdForPathway(pathway.id);
+      expect(
+        allCommunityIds().includes(id),
+        `pathway '${pathway.id}' maps to community '${id}', which no module knows. Add it to ` +
+          `PATHWAY_TO_COMMUNITY or fix the id.`,
+      ).toBe(true);
+    }
+  });
+
+  it('Oonchiumpa reaches Alice Springs assets, which a naive id join drops', () => {
+    // The specific failure PATHWAY_TO_COMMUNITY exists for. Oonchiumpa is the site closest to a
+    // handover and its beds are counted under alice-springs.
+    const record = communityRecord('alice-springs', { asOf: AS_OF });
+    expect(record).not.toBeNull();
+    expect(record!.assets).not.toBeNull();
+    expect(record!.assets!.value.beds).toBe(16);
+    expect(record!.stage, 'Oonchiumpa pathway did not attach to alice-springs').not.toBeNull();
+    expect(record!.handover, 'the Oonchiumpa handover test did not attach').not.toBeNull();
+  });
+
+  it('every exception in PATHWAY_TO_COMMUNITY is still needed', () => {
+    // An exception that has become an identity mapping is dead weight that hides the real ones.
+    for (const [pathwayId, communityId] of Object.entries(PATHWAY_TO_COMMUNITY)) {
+      expect(
+        pathwayId,
+        `PATHWAY_TO_COMMUNITY maps '${pathwayId}' to itself. Delete the entry.`,
+      ).not.toBe(communityId);
+      expect(
+        COMMUNITY_PATHWAYS.some((p) => p.id === pathwayId),
+        `PATHWAY_TO_COMMUNITY has '${pathwayId}', which is not a pathway.`,
+      ).toBe(true);
+    }
+  });
+
+  it('every ownership-test site attaches to the record for its community', () => {
+    for (const site of SITE_OWNERSHIP_TESTS) {
+      const id = communityIdForPathway(site.pathwayId);
+      const record = communityRecord(id, { asOf: AS_OF });
+      expect(record?.handover, `no handover on '${id}' for site '${site.siteName}'`).toBeTruthy();
+    }
+  });
+});
+
+describe('the numbers are the canon numbers, not new ones', () => {
+  it('bed counts match community-canonical exactly', () => {
+    for (const canon of COMMUNITY_BED_CANON) {
+      const record = communityRecord(canon.id, { asOf: AS_OF });
+      expect(record!.assets!.value.basketBeds).toBe(canon.basketBeds);
+      expect(record!.assets!.value.stretchBeds).toBe(canon.stretchBeds);
+      expect(record!.assets!.value.beds).toBe(canon.basketBeds + canon.stretchBeds);
+    }
+  });
+
+  it('summing every record reproduces the canonical totals', () => {
+    // If the join drops or double-counts a community this fails, and no other guard would.
+    const totals = communityCanonTotals();
+    const summed = allCommunityIds()
+      .map((id) => communityRecord(id, { asOf: AS_OF })!)
+      .filter((r) => r.assets)
+      .reduce(
+        (acc, r) => ({
+          beds: acc.beds + r.assets!.value.beds,
+          washers: acc.washers + r.assets!.value.washers,
+        }),
+        { beds: 0, washers: 0 },
+      );
+    expect(summed.beds).toBe(totals.beds);
+    expect(summed.washers).toBe(totals.washersInCommunity);
+  });
+
+  it('washer counts come from the curated map and are never derived', () => {
+    for (const [id, count] of Object.entries(WASHERS_IN_COMMUNITY_BY_COMMUNITY)) {
+      const record = communityRecord(id, { asOf: AS_OF });
+      if (!record?.assets) continue;
+      expect(record.assets.value.washers).toBe(count);
+    }
+  });
+
+  it('a community with no washer entry reads 0, not undefined', () => {
+    const record = communityRecord('kalgoorlie', { asOf: AS_OF });
+    expect(record!.assets!.value.washers).toBe(0);
+  });
+});
+
+describe('consent travels with the value', () => {
+  it('nothing unconfirmed is ever publishable', () => {
+    // The whole point of the file. If this inverts, a proposal a community has not seen becomes
+    // renderable on an open page by a surface that filters correctly.
+    for (const id of allCommunityIds()) {
+      const record = communityRecord(id, { asOf: AS_OF })!;
+      if (record.stage) expect(isPublishable(record.stage)).toBe(false);
+      if (record.modules) expect(isPublishable(record.modules)).toBe(false);
+      if (record.nextDecision) expect(isPublishable(record.nextDecision)).toBe(false);
+      if (record.handover) expect(isPublishable(record.handover)).toBe(false);
+    }
+  });
+
+  it('the handover test is internal at every site', () => {
+    // SOVEREIGNTY_GATE: the community controls what is published about the site.
+    for (const site of SITE_OWNERSHIP_TESTS) {
+      const record = communityRecord(communityIdForPathway(site.pathwayId), { asOf: AS_OF })!;
+      expect(record.handover!.consent).toBe('internal');
+    }
+  });
+
+  it('asset counts are cleared, because delivered goods propose nothing', () => {
+    const record = communityRecord('utopia', { asOf: AS_OF })!;
+    expect(record.assets!.consent).toBe('cleared');
+    expect(isPublishable(record.assets!)).toBe(true);
+  });
+
+  it('storytellers start at zero and only a cleared count attaches', () => {
+    const record = communityRecord('utopia', { asOf: AS_OF })!;
+    expect(record.storytellers.value.count).toBe(0);
+    const attached = withStorytellers(record, 4);
+    expect(attached.storytellers.value.count).toBe(4);
+    expect(attached.storytellers.consent).toBe('cleared');
+  });
+});
+
+describe('the module menu is a menu', () => {
+  it('every pathway record carries all nine modules, asked-for or not', () => {
+    // A surface must be able to show what was NOT chosen. Filtering to the chosen ones here
+    // would rebuild the program model the module model replaced.
+    for (const pathway of COMMUNITY_PATHWAYS) {
+      const record = communityRecord(communityIdForPathway(pathway.id), { asOf: AS_OF })!;
+      expect(record.modules!.value).toHaveLength(MODULES.length);
+      expect(record.modules!.value.map((m) => m.id)).toEqual(MODULES.map((m) => m.id));
+    }
+  });
+
+  it('a module the community never raised reads not-assessed, never later', () => {
+    // 'later' is something a community said. Defaulting to it would put words in their mouth.
+    for (const pathway of COMMUNITY_PATHWAYS) {
+      const record = communityRecord(communityIdForPathway(pathway.id), { asOf: AS_OF })!;
+      for (const module of record.modules!.value) {
+        const raised = pathway.modules.find((m) => m.id === module.id);
+        if (!raised) expect(module.state).toBe('not-assessed');
+      }
+    }
+  });
+});
+
+describe('absence is reported as absence', () => {
+  it('a delivered community with no pathway returns assets and null pathway fields', () => {
+    const record = communityRecord('kalgoorlie', { asOf: AS_OF })!;
+    expect(record.assets).not.toBeNull();
+    expect(pathwayForCommunity('kalgoorlie')).toBeUndefined();
+    expect(record.stage).toBeNull();
+    expect(record.modules).toBeNull();
+    expect(record.handover).toBeNull();
+  });
+
+  it('an unknown id returns null rather than an empty record', () => {
+    expect(communityRecord('not-a-community', { asOf: AS_OF })).toBeNull();
+  });
+
+  it('omitting asOf returns a null handover rather than guessing at today', () => {
+    // A public surface must be able to build a record without inventing a date, because a build
+    // that reaches for today's date stops being reproducible.
+    const record = communityRecord('alice-springs')!;
+    expect(record.assets).not.toBeNull();
+    expect(record.handover).toBeNull();
+  });
+
+  it('is pure: the same asOf gives the same answer', () => {
+    const a = communityRecord('utopia', { asOf: AS_OF });
+    const b = communityRecord('utopia', { asOf: AS_OF });
+    expect(a).toEqual(b);
+  });
+});

--- a/v2/src/lib/data/community-record.ts
+++ b/v2/src/lib/data/community-record.ts
@@ -116,6 +116,18 @@ export const PATHWAY_TO_COMMUNITY: Record<string, string> = {
   oonchiumpa: 'alice-springs',
 };
 
+/**
+ * /communities/[slug] runs on communityLocations ids (content.ts), and one of the four differs
+ * from the canon id: the page says `utopia-homelands`, the register says `utopia`. That single
+ * mismatch made communityRecord() return null for Utopia, so the page fell back to the
+ * every-bed-is-HDPE arithmetic — 2,940kg — which is the precise overstatement this module
+ * exists to fix, at the precise community it was fixed for. Resolved here rather than in the
+ * page so every caller gets the same aliasing.
+ */
+export const COMMUNITY_ID_FOR_SLUG: Record<string, string> = {
+  'utopia-homelands': 'utopia',
+};
+
 export function communityIdForPathway(pathwayId: string): string {
   return PATHWAY_TO_COMMUNITY[pathwayId] ?? pathwayId;
 }
@@ -188,6 +200,7 @@ export function communityRecord(
   // non-deterministic at build time by reaching for today's date to satisfy a signature.
   opts: { asOf?: string } = {},
 ): CommunityRecord | null {
+  communityId = COMMUNITY_ID_FOR_SLUG[communityId] ?? communityId;
   const canon = COMMUNITY_BED_CANON.find((c) => c.id === communityId);
   const pathway = pathwayForCommunity(communityId);
   if (!canon && !pathway) return null;

--- a/v2/src/lib/data/community-record.ts
+++ b/v2/src/lib/data/community-record.ts
@@ -1,0 +1,299 @@
+/**
+ * ONE RECORD PER COMMUNITY — the join across the five modules that each hold a piece.
+ *
+ * Nothing here is new truth. Every value is read from a module that already owns it and is
+ * already guarded: bed counts from community-canonical.ts (asserted against the live register
+ * by check:register), washers from asset-canonical.ts, stage and modules from
+ * community-pathways.ts, the handover test from ownership-test.ts. This file adds exactly two
+ * things, and they are the reason it exists.
+ *
+ * ---------------------------------------------------------------------------
+ * 1. THE JOIN
+ * ---------------------------------------------------------------------------
+ * Answering "what is true about Utopia" meant reading five modules and knowing which id each
+ * one keys on. Nothing in the system answered it in one call, so every surface assembled its
+ * own subset by hand and the subsets disagreed. /communities/[slug] showed beds and no washers.
+ * /pathways/[id] showed modules and no assets. Neither showed the handover test, which is the
+ * one thing that says whether ownership has actually moved.
+ *
+ * ---------------------------------------------------------------------------
+ * 2. CONSENT AS A PROPERTY OF THE FIELD, NOT OF THE URL
+ * ---------------------------------------------------------------------------
+ * Every field carries a ConsentState. This is the part that matters.
+ *
+ * Today the boundary between what a community has agreed to and what we merely think is held
+ * by WHICH PAGE a value happens to be rendered on: /pathways is noindexed because it renders
+ * items marked "Confirm together", and /communities is public because it does not. That is a
+ * convention, not a mechanism. Nothing fails if an unconfirmed value is rendered on the public
+ * page. The only thing standing between a community and a proposal about themselves they have
+ * never seen is that the two pages import different modules.
+ *
+ * So the state travels with the value:
+ *
+ *   'cleared'          Canon, drift-guarded, and safe on an open page. Counts of things that
+ *                      were actually delivered. A community's own asset count is theirs and it
+ *                      is not a proposal.
+ *   'confirm-together' We believe it; they have not confirmed it. Next decision, next phase,
+ *                      module states, anything with a price. NEVER on an open surface.
+ *                      audience.ts community.mustNeverSee: "A facility proposal before a yarn."
+ *   'internal'         Ours to hold, not theirs to be shown as a claim about them. The handover
+ *                      test result is here: it is a test WE run on OURSELVES about whether we
+ *                      have let go, and SOVEREIGNTY_GATE says the community controls what is
+ *                      published about the site.
+ *
+ * A surface then filters by consent instead of hand-picking fields, and the public/private
+ * split becomes one line rather than two page templates that must be kept in step.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THIS FILE DELIBERATELY DOES NOT DO
+ * ---------------------------------------------------------------------------
+ * No fetching. Empathy Ledger storytellers are resolved per request, are consent-filtered
+ * through cleared-voices.ts at the point of use, and can fail. Putting an await in here would
+ * make every caller async to read a bed count that has been frozen in canon for weeks. The
+ * caller resolves storytellers and passes them to `withStorytellers`, which is the only place
+ * they attach.
+ *
+ * No ordering of communities into a progression. There is no beds-then-washers-then-facility
+ * ladder and building one here would rebuild the facility model that ruling D replaced.
+ * `pathway-stages.ts` STAGE_RULE is load-bearing: communities begin anywhere and move at their
+ * own pace. `modules` is a menu, and the record reports which ones they asked for.
+ */
+
+import { COMMUNITY_BED_CANON } from './community-canonical';
+import { WASHERS_IN_COMMUNITY_BY_COMMUNITY } from './asset-canonical';
+import { PLASTIC_KG_PER_BED } from './products';
+import { COMMUNITY_PATHWAYS, MODULES } from './community-pathways';
+import type { CommunityPathway, ModuleState } from './community-pathways';
+import type { PublicStage } from './pathway-stages';
+import { publicStageFor } from './pathway-stages';
+import {
+  SITE_OWNERSHIP_TESTS,
+  siteTestState,
+  passedCheckpoints,
+  OWNERSHIP_CHECKPOINTS,
+} from './ownership-test';
+import type { SiteTestState, CheckpointId } from './ownership-test';
+
+// ---------------------------------------------------------------------------
+// Consent
+// ---------------------------------------------------------------------------
+
+export type ConsentState = 'cleared' | 'confirm-together' | 'internal';
+
+/** A value plus what may be done with it. `source` names the module that owns it, so a wrong
+ *  number is traced to one file rather than hunted across surfaces. */
+export interface Held<T> {
+  value: T;
+  consent: ConsentState;
+  source: string;
+}
+
+const held = <T>(value: T, consent: ConsentState, source: string): Held<T> => ({
+  value,
+  consent,
+  source,
+});
+
+/** The only filter a surface should need. Public pages pass 'cleared'. */
+export function isPublishable<T>(field: Held<T>): boolean {
+  return field.consent === 'cleared';
+}
+
+// ---------------------------------------------------------------------------
+// The id problem, stated rather than assumed
+// ---------------------------------------------------------------------------
+
+/**
+ * Pathway ids and community ids are NOT the same namespace, and the one that differs is the
+ * one that matters most: `oonchiumpa` is the pathway, `alice-springs` is where its beds are
+ * counted (community-canonical: "1 Basket / 15 Stretch (Oonchiumpa)"). Joining on id alone
+ * silently drops Oonchiumpa's assets, and Oonchiumpa is the site closest to a handover.
+ *
+ * Every other pathway shares its community id. This map holds only the exceptions, and the
+ * guards assert that every pathway resolves to a real community through it.
+ */
+export const PATHWAY_TO_COMMUNITY: Record<string, string> = {
+  oonchiumpa: 'alice-springs',
+};
+
+export function communityIdForPathway(pathwayId: string): string {
+  return PATHWAY_TO_COMMUNITY[pathwayId] ?? pathwayId;
+}
+
+export function pathwayForCommunity(communityId: string): CommunityPathway | undefined {
+  return COMMUNITY_PATHWAYS.find(
+    (p) => communityIdForPathway(p.id) === communityId,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The record
+// ---------------------------------------------------------------------------
+
+export interface CommunityAssets {
+  basketBeds: number;
+  stretchBeds: number;
+  beds: number;
+  /** Curated, never row-derived. Stale `deployed` rows are a known register condition. */
+  washers: number;
+  /** Modelled at PLASTIC_KG_PER_BED per bed. Never presented as measured. */
+  plasticKg: number;
+  /** The ruling that settled the bed counts, cited verbatim by the drift judge. */
+  ruling: string;
+}
+
+export interface CommunityModuleAsk {
+  id: string;
+  label: string;
+  what: string;
+  state: ModuleState;
+}
+
+export interface CommunityHandover {
+  state: SiteTestState;
+  passed: CheckpointId[];
+  ofTotal: number;
+  note: string;
+}
+
+export interface CommunityRecord {
+  id: string;
+  name: string;
+  /** Present for every community with delivered assets; absent for a pathway-only relationship. */
+  assets: Held<CommunityAssets> | null;
+  /** Where they are on the six public stages. Absent when there is no pathway record. */
+  stage: Held<{ id: PublicStage; label: string }> | null;
+  /** The menu, with what they have asked for. Not a plan; not ordered. */
+  modules: Held<CommunityModuleAsk[]> | null;
+  /** What we think happens next, and what it is not. Unconfirmed by definition. */
+  nextDecision: Held<string> | null;
+  /** The month-6 test, which we run on ourselves. */
+  handover: Held<CommunityHandover> | null;
+  /** Attached by the caller. Empty until `withStorytellers` runs. */
+  storytellers: Held<{ count: number }>;
+}
+
+/**
+ * Assemble everything known about one community.
+ *
+ * Returns null only when the id matches nothing at all. A community with delivered beds and no
+ * pathway record is legitimate and common (Kalgoorlie, Katherine): those fields come back null
+ * rather than empty, so a surface can tell "no pathway" from "a pathway with nothing in it".
+ */
+export function communityRecord(
+  communityId: string,
+  // `asOf` is optional, and omitting it returns a null `handover` rather than a guessed one.
+  // The month-6 test is the only time-dependent field here, and a public surface never shows it.
+  // Making the date optional means a page that does not need it cannot accidentally become
+  // non-deterministic at build time by reaching for today's date to satisfy a signature.
+  opts: { asOf?: string } = {},
+): CommunityRecord | null {
+  const canon = COMMUNITY_BED_CANON.find((c) => c.id === communityId);
+  const pathway = pathwayForCommunity(communityId);
+  if (!canon && !pathway) return null;
+
+  const name = canon?.registerName ?? pathway?.name ?? communityId;
+
+  let assets: Held<CommunityAssets> | null = null;
+  if (canon) {
+    const beds = canon.basketBeds + canon.stretchBeds;
+    assets = held(
+      {
+        basketBeds: canon.basketBeds,
+        stretchBeds: canon.stretchBeds,
+        beds,
+        washers: WASHERS_IN_COMMUNITY_BY_COMMUNITY[communityId] ?? 0,
+        plasticKg: canon.stretchBeds * PLASTIC_KG_PER_BED,
+        ruling: canon.ruling,
+      },
+      // Cleared: what was delivered to a community is theirs, it is guarded against the live
+      // register, and it proposes nothing.
+      'cleared',
+      'community-canonical.ts + asset-canonical.ts',
+    );
+  }
+
+  let stage: Held<{ id: PublicStage; label: string }> | null = null;
+  let modules: Held<CommunityModuleAsk[]> | null = null;
+  let nextDecision: Held<string> | null = null;
+
+  if (pathway) {
+    const publicStage = publicStageFor(pathway.stage);
+    stage = held(
+      { id: publicStage.id, label: publicStage.label },
+      // Where a relationship sits is a shared fact, but it is read as a commitment, so it stays
+      // behind confirmation until the community has seen it stated this way.
+      'confirm-together',
+      'community-pathways.ts',
+    );
+
+    modules = held(
+      MODULES.map((m) => {
+        const asked = pathway.modules.find((pm) => pm.id === m.id);
+        return {
+          id: m.id,
+          label: m.label,
+          what: m.what,
+          state: asked?.state ?? ('not-assessed' as ModuleState),
+        };
+      }),
+      'confirm-together',
+      'pathway-stages.ts + community-pathways.ts',
+    );
+
+    nextDecision = held(pathway.nextDecision, 'confirm-together', 'community-pathways.ts');
+  }
+
+  let handover: Held<CommunityHandover> | null = null;
+  const site = SITE_OWNERSHIP_TESTS.find(
+    (s) => communityIdForPathway(s.pathwayId) === communityId,
+  );
+  if (site && opts.asOf) {
+    handover = held(
+      {
+        state: siteTestState(site, opts.asOf),
+        passed: passedCheckpoints(site),
+        ofTotal: OWNERSHIP_CHECKPOINTS.length,
+        note: site.note,
+      },
+      // Internal: SOVEREIGNTY_GATE gives the community control over what is published about the
+      // site, and this is a judgement about whether WE have let go. It is not ours to publish
+      // as a statement about them.
+      'internal',
+      'ownership-test.ts',
+    );
+  }
+
+  return {
+    id: communityId,
+    name,
+    assets,
+    stage,
+    modules,
+    nextDecision,
+    handover,
+    storytellers: held({ count: 0 }, 'cleared', 'not resolved; call withStorytellers'),
+  };
+}
+
+/**
+ * Attach the storyteller count the caller resolved.
+ *
+ * Separate because Empathy Ledger is fetched per request and consent-filtered through
+ * cleared-voices.ts at the point of use. The count is only ever of voices that already passed
+ * that filter, which is why it lands 'cleared'. Passing an unfiltered count here would launder
+ * an uncleared voice into a public number.
+ */
+export function withStorytellers(record: CommunityRecord, clearedCount: number): CommunityRecord {
+  return {
+    ...record,
+    storytellers: held({ count: clearedCount }, 'cleared', 'empathy ledger via cleared-voices.ts'),
+  };
+}
+
+/** Every community the system knows about, by either route. */
+export function allCommunityIds(): string[] {
+  const ids = new Set<string>(COMMUNITY_BED_CANON.map((c) => c.id));
+  for (const p of COMMUNITY_PATHWAYS) ids.add(communityIdForPathway(p.id));
+  return [...ids].sort();
+}


### PR DESCRIPTION
Two things: a join, and a live overstatement on an indexed page.

## `community-record.ts` — the join

`communityRecord(id)` assembles beds, washers, plastic, stage, the nine-module menu and the month-6 handover test from the five modules that already own them. **Nothing here is new truth.** Every value is read from a module that is already guarded — `community-canonical.ts` (asserted against the live register by `check:register`), `asset-canonical.ts`, `community-pathways.ts`, `ownership-test.ts`.

It adds two things.

**The join itself.** Answering "what is true about Utopia" meant reading five modules and knowing which id each one keys on. Nothing answered it in one call, so every surface assembled its own subset by hand and the subsets disagreed: `/communities/[slug]` showed beds and no washers, `/pathways/[id]` showed modules and no assets, neither showed the handover test.

**Consent as a property of the field, not of the URL.** This is the part that matters. Today the boundary between what a community has agreed to and what we merely think is held by *which page* a value lands on: `/pathways` is noindexed because it renders items marked "Confirm together", `/communities` is public because it does not. That is a convention, not a mechanism — nothing fails if an unconfirmed value is rendered on the public page. The only thing between a community and a proposal about themselves they have never seen is that the two pages import different modules.

So the state travels with the value:

- `cleared` — assets. Delivered goods are theirs and propose nothing.
- `confirm-together` — stage, modules, next decision. Cannot pass `isPublishable()`. Backs `audience.ts` `community.mustNeverSee`: *"A facility proposal before a yarn."*
- `internal` — the handover test. `SOVEREIGNTY_GATE` gives the community control over what is published about their site, and it is a test we run on **ourselves** about whether we have let go.

A surface filters by consent instead of hand-picking fields, and the public/private split becomes one line rather than two page templates kept in step by hand.

**The id join is not identity, and the exception is the expensive one.** `oonchiumpa` is the pathway; `alice-springs` is where its beds are counted. Joining on id alone silently drops the assets of the site closest to a handover. `PATHWAY_TO_COMMUNITY` holds the exceptions, a guard asserts every pathway resolves, and another asserts no exception has quietly become an identity mapping.

Deliberately absent: no fetching (storytellers attach via `withStorytellers` after the caller has consent-filtered them, so a bed count frozen in canon for weeks does not make its caller async), and no ordering of communities into a progression. There is no beds-then-washers-then-facility ladder, and building one would rebuild the facility model ruling D replaced.

## On the page

**Washing machines now appear on `/communities/[slug]`.** The counts were in `asset-canonical.ts` the whole time and the stat band showed beds and plastic only, so Maningrida's 8 machines and Tennant Creek's 9 were not on either community's own page.

**The plastic figure was overstated, and this is the reviewable part.** The page multiplied EVERY delivered bed by 20kg. Plastic is diverted by Stretch Beds, pressed from recycled HDPE; Basket Beds are not. `CANONICAL_ASSETS.plasticKg` is 3,540 = 177 Stretch x 20kg, so **canon always used the narrower basis and this public surface disagreed with it.**

| Community | Live now | Canon basis |
|---|---|---|
| Utopia | 2,940kg | 1,740kg |
| Tennant Creek | 3,200kg | 600kg |
| Palm Island | 2,620kg | 0kg |

An environmental claim on an indexed page, running 3-5x high wherever a community holds Basket Beds.

**One judgement call to confirm:** where a community holds only Basket Beds the card is hidden rather than printed as "0kg", because a bare zero on their own page reads as a failure rather than as a different product mix. The other two cards in that band are already conditional. Easy to reverse if you would rather it show.

## Guards

18 on the join, including:
- nothing `confirm-together` or `internal` is ever publishable, at any community
- summing every record reproduces `communityCanonTotals()` — catches a dropped or double-counted community, which no other guard would
- a module a community never raised reads `not-assessed`, never `later` — `later` is something they said, and defaulting to it puts a word in their mouth
- omitting `asOf` returns a null handover rather than reaching for today's date, so a prerendered page cannot become non-deterministic to satisfy a signature

## Not in this PR

`/pathways/[id]` is not yet rendering from the record — that page is where the visibility decision lands, and that decision is Ben's. `withStorytellers` is not called anywhere yet; `/communities/[slug]` still counts storytellers its own way.

## Gates

tsc clean · 438 tests (17 new) · build clean · `check:drift:ci`

🤖 Generated with [Claude Code](https://claude.com/claude-code)