### PR TITLE
The Maningrida bed count, traced to the invoices that produce it

### DIFF
--- a/v2/src/lib/data/canon.ts
+++ b/v2/src/lib/data/canon.ts
@@ -88,7 +88,9 @@ export const CANON: CanonFact[] = [
     id: 'beds-deployed', label: 'Beds deployed', value: CANONICAL_ASSETS.bedsDeployed, unit: 'units',
     domain: 'assets', claimLabel: 'verified', dataClass: 'green',
     source: 'v2 Supabase `assets` (status=deployed) via asset-canonical.ts', check: 'auto', asAt: '2026-07-18', owner: 'Ben',
-    definition: 'Deployed bed units in the register: 363 Basket (legacy) + 177 Stretch (flagship; incl. Maningrida +40 Jul 2026, and Kununurra +2 / Katherine +1 / Tennant youth centre +1, Ben rulings 2026-07-19).',
+    // Date corrected 2026-08-04: said "Jul 2026", INV-0303 is dated 18 May 2026 (PAID).
+    // Invoice-level provenance for Maningrida lives on COMMUNITY_BED_CANON.
+    definition: 'Deployed bed units in the register: 363 Basket (legacy) + 177 Stretch (flagship; incl. Maningrida +40, INV-0303 18 May 2026, and Kununurra +2 / Katherine +1 / Tennant youth centre +1, Ben rulings 2026-07-19).',
   },
   {
     id: 'stretch-beds-deployed', label: 'Stretch Beds deployed', value: CANONICAL_ASSETS.stretchBedsDeployed, unit: 'units',

--- a/v2/src/lib/data/community-canonical.guards.test.ts
+++ b/v2/src/lib/data/community-canonical.guards.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
+  COMMUNITY_INVOICE_PROVENANCE,
   COMMUNITY_BED_CANON,
   WASHER_STALE_DEPLOYED_ROWS,
   communityCanonTotals,
@@ -50,6 +51,56 @@ describe('community canon sums to headline canon', () => {
   it('washer stale rows only name communities that have a washer ruling', () => {
     for (const id of Object.keys(WASHER_STALE_DEPLOYED_ROWS)) {
       expect(WASHERS_IN_COMMUNITY_BY_COMMUNITY).toHaveProperty(id);
+    }
+  });
+});
+
+describe('invoice provenance', () => {
+  const maningrida = { invoices: COMMUNITY_INVOICE_PROVENANCE.maningrida };
+
+  it('traces the 40 Stretch Beds to a real, PAID invoice', () => {
+    // "How many Maningrida beds" kept coming back different. It has three answers
+    // because there are two invoices for two products. This pins the flagship one.
+    const line = maningrida.invoices!.find((i) => i.invoice === 'INV-0303')!;
+    expect(line.quantity).toBe(40);
+    expect(line.unitAmount).toBe(750);
+    expect(line.status).toBe('PAID');
+    expect(line.date).toBe('2026-05-18');
+    expect(line.description).toMatch(/Stretch Bed/);
+  });
+
+  it('records the OTHER Maningrida invoice, which is the source of the confusion', () => {
+    const line = maningrida.invoices!.find((i) => i.invoice === 'INV-0283')!;
+    expect(line.quantity).toBe(13);
+    expect(line.description).toMatch(/Basket Bed/);
+    // The contact is Mala'la, not Maningrida. Searching Xero for the community
+    // name returns nothing, which is exactly how this stayed unresolved.
+    expect(line.contact).not.toMatch(/Maningrida/i);
+  });
+
+  it('never lets an invoiced quantity exceed the register count for that product', () => {
+    // The register counts assets in community; an invoice records a sale. The
+    // register is always the larger number. If it ever is not, either a sale was
+    // not delivered or the register is missing rows, and both need a human.
+    for (const c of COMMUNITY_BED_CANON) {
+      const invoices = COMMUNITY_INVOICE_PROVENANCE[c.id];
+      if (!invoices) continue;
+      const sold = (re: RegExp) =>
+        invoices
+          .filter((i) => (i.status === 'PAID' || i.status === 'AUTHORISED') && re.test(i.description))
+          .reduce((t, i) => t + i.quantity, 0);
+      expect(sold(/Stretch Bed/), `${c.id} stretch`).toBeLessThanOrEqual(c.stretchBeds);
+      expect(sold(/Basket Bed/), `${c.id} basket`).toBeLessThanOrEqual(c.basketBeds);
+    }
+  });
+
+  it('gives every traced invoice line a number, a date and a status', () => {
+    for (const lines of Object.values(COMMUNITY_INVOICE_PROVENANCE)) {
+      for (const i of lines) {
+        expect(i.invoice).toMatch(/^INV-\d+$/);
+        expect(i.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(['PAID', 'AUTHORISED', 'VOIDED', 'DELETED']).toContain(i.status);
+      }
     }
   });
 });

--- a/v2/src/lib/data/community-canonical.ts
+++ b/v2/src/lib/data/community-canonical.ts
@@ -23,6 +23,42 @@ import { CANONICAL_ASSETS, WASHERS_IN_COMMUNITY_BY_COMMUNITY } from './asset-can
  * `registerName` is the exact string in the register's `community` column
  * (the register's real column is `product`/`community`, not `type`).
  */
+/**
+ * A line on a real Xero invoice, recorded so a bed count can be traced to paper.
+ *
+ * THE DISTINCTION THAT KEEPS BEING LOST, and the reason this type exists:
+ * the register counts ASSETS IN COMMUNITY, an invoice records A SALE. They are
+ * not the same measure and they are not supposed to tie. Beds and machines reach
+ * a community as prototypes, in-kind, replacements and earlier deliveries that
+ * never appear as a sold line, so the register is always the larger number.
+ *
+ * Maningrida is the worked example. The register holds 18 Basket, 40 Stretch and
+ * 8 washers. The invoices evidence 13 Basket, 40 Stretch and 2 washers. The
+ * washer gap is already explained in asset-canonical.ts ("8 = 6 existing + 2
+ * new") and INV-0303 is exactly those 2 new, which confirms the pattern rather
+ * than contradicting it. The 5 uninvoiced Basket Beds are the same shape and
+ * have not been individually traced.
+ *
+ * So: quote the REGISTER for what is in community, quote the INVOICE for what was
+ * sold and what it fetched. Never present one as a check on the other.
+ */
+export interface CommunityInvoiceLine {
+  /** Xero invoice number, e.g. INV-0303 */
+  invoice: string;
+  /** Xero contact. Often NOT the community's name, which is why searches miss it. */
+  contact: string;
+  /** Invoice date, ISO. */
+  date: string;
+  /** Xero status. DELETED and VOIDED lines are evidence of nothing. */
+  status: 'PAID' | 'AUTHORISED' | 'VOIDED' | 'DELETED';
+  /** Line description, verbatim from the invoice. */
+  description: string;
+  quantity: number;
+  unitAmount: number;
+  /** Anything that makes the line hard to find or easy to misread. */
+  note?: string;
+}
+
 export interface CommunityBedCanon {
   /** communities.id slug */
   id: string;
@@ -118,6 +154,56 @@ export const COMMUNITY_BED_CANON: readonly CommunityBedCanon[] = [
  *  weave_bed variant) is a known bad write — the product was discontinued and
  *  never produced at scale; rows carrying it should be stretch_bed. */
 export const ALLOWED_REGISTER_PRODUCTS = ['Stretch Bed', 'Basket Bed', 'Washing Machine'] as const;
+
+/**
+ * The commercial paper trail, per community, where it has been traced.
+ *
+ * Kept OUT of COMMUNITY_BED_CANON on purpose: check-register-integrity.mjs parses
+ * that array as text and splits entries on the first `},`, so a nested object
+ * inside an entry breaks the judge. It is also a different concern - that array is
+ * what is in community, this is what was sold.
+ *
+ * A community missing here has NOT been traced. It does not mean no invoice exists.
+ */
+export const COMMUNITY_INVOICE_PROVENANCE: Record<string, readonly CommunityInvoiceLine[]> = {
+  // Traced against the Xero mirror 2026-08-04, because "how many Maningrida beds"
+  // kept coming back with a different answer. It has three answers because there are
+  // TWO invoices, seven months apart, for TWO different products. Whoever finds one
+  // says 13 or 40; whoever finds both says 53. The register says 58 beds, because 5
+  // Basket Beds arrived by a route that was never invoiced.
+  maningrida: [
+    {
+      invoice: 'INV-0283',
+      contact: 'Mala’la Health Service Aboriginal Corporation',
+      date: '2025-10-21',
+      status: 'PAID',
+      description: 'Goods Basket Bed v2.1',
+      quantity: 13,
+      unitAmount: 380,
+      note:
+        'Mala’la IS Maningrida. The community name appears nowhere on the invoice, which is why a ' +
+        'Xero search for "Maningrida" returns nothing and why this stayed unresolved. Shipping was ' +
+        'listed at $3,200 and charged at $0. Total $5,434 = $4,940 + GST. The register holds 18 ' +
+        'Basket, so 5 arrived by some route other than this sale and are not individually traced.',
+    },
+    {
+      invoice: 'INV-0303',
+      contact: 'Homeland School Company',
+      date: '2026-05-18',
+      status: 'PAID',
+      description: 'Goods Stretch Bed - Single Bed, Poles, Canvas',
+      quantity: 40,
+      unitAmount: 750,
+      note:
+        'THE 40, at the canonical $750. Destination is provable from the freight line "Delivery of ' +
+        'Goods ex BNE - DRW - MNG": Brisbane to Darwin to Maningrida. The same invoice carries 2 ' +
+        'washing machines at $4,500 (the "+2 new" in asset-canonical.ts), an $8,000 program-support ' +
+        'trip, $5,900 freight and a -$14,190 in-kind credit, tying to $44,000 exactly. This invoice ' +
+        'evidences the SALE and the delivery. It cannot evidence where the beds were pressed, ' +
+        'because in-house production raises no invoice - do not cite it for the in-house claim.',
+    },
+  ],
+};
 
 /** Washer rows still marked `deployed` that Ben's 2026-07-21 ruling says are
  *  stale (await restatus to `retired`): Tennant Creek 7, Alice Springs 2,


### PR DESCRIPTION
"How many Maningrida beds" kept coming back with a different answer. There are **two** invoices, seven months apart, for **two** different products:

| Invoice | Date | Status | Line | Qty | Unit |
|---|---|---|---|---|---|
| INV-0283 | 2025-10-21 | PAID | Goods Basket Bed v2.1 | 13 | $380 |
| INV-0303 | 2026-05-18 | PAID | Goods Stretch Bed | 40 | $750 |

Whoever finds one says 13 or 40. Whoever finds both says 53. The register says 58.

**Why nobody could find them.** Neither invoice carries the word Maningrida. INV-0283 is billed to Mala'la Health Service (which is Maningrida); INV-0303 to Homeland School Company, tied to Maningrida only by the freight line `Delivery of Goods ex BNE - DRW - MNG`.

**The 40 holds.** 40 Stretch Beds at the canonical $750, PAID, tying to $44,000 to the cent alongside 2 washing machines, a trip, freight and a -$14,190 in-kind credit.

**The distinction the new type protects.** The register counts assets IN COMMUNITY; an invoice records a SALE. Different measures, not supposed to tie, register always larger. Maningrida shows it twice: 18 Basket vs 13 invoiced, 8 washers vs 2 invoiced, where the washer gap was already documented as "6 existing + 2 new".

**No counts changed** — canon already matched the live register exactly. Corrected one date: canon said "Jul 2026", the invoice says 18 May 2026.

**Noted so it is not cited wrongly:** the invoice evidences the sale and delivery, not where the beds were pressed. In-house production raises no invoice.

Gates: 462 tests, typecheck, `check:register` (every community matches), `check:drift:ci`, build clean.