### PR TITLE
The community side of the cost model, and the Utopia one-pager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -270,5 +270,10 @@ v2/design-qa-evidence/
 # ── GOC entity model build artifacts (mirrors the rules on main) ─────────────
 deliverables/*.xlsx
 deliverables/*.pptx
+# Emitted from v2/src/lib/cost-model/community-model.ts by tools/emit-community-model.ts.
+# Untracked on purpose: a committed copy that drifts from the model is worse than an
+# absent one, and the workbook generator fails loudly with the regenerate command when
+# it is missing rather than falling back to a stale file.
+deliverables/community-model.json
 tools/.gsheet-targets.json
 .venv-sheets/

--- a/deliverables/GOC-model-in-plain-words-2026-08-03.md
+++ b/deliverables/GOC-model-in-plain-words-2026-08-03.md
@@ -1,6 +1,12 @@
 # Goods on Country, in plain words
 
-*For investor conversations. 2026-08-03. Every figure here traces to `GOC-Entity-Model-Inputs-ANSWERED-2026-08-03.xlsx`.*
+*For investor and community conversations. Rewritten 2026-08-03 (second pass).*
+
+> **Where the figures live.** The workbook is generated from code and is the source:
+> `tools/build-goc-answered-workbook.py`, pushed to the live Sheet. This document is the
+> story around those figures, restated as at the date above. If the two ever disagree,
+> **the workbook wins** and this file is stale. The first version of this document went
+> stale within a day, which is why that sentence is here.
 
 ---
 
@@ -11,109 +17,188 @@ parts of it they want, and the beds it makes pay for the line while the communit
 
 ---
 
-## 1. The thing itself
+## 1. The whole business is two numbers
 
-It is a shipping container with a shredder, a hot press, a CNC router and a workbench in it.
-Plastic waste goes in one end, and a bed people actually want to sleep on comes out the other.
+Everything else is detail hanging off these.
 
-A bed is a Stretch Bed: two galvanised poles threaded through canvas sleeves and through the top
-holes of two crossed recycled-HDPE legs. Tension holds it together, so the canvas is structural.
-20kg of plastic diverted per bed. It sells for $750.
+**A site earns about $81,000 a year.** A bed sells for $750 and costs $426 to make, so each bed
+leaves about $324. A site running one shift makes 450 sellable beds, so it generates about
+$146,000. Take off the site's own running costs (~$48,000) and warranty and bad debt (~$17,000),
+and a site is worth about **$81,000 a year**. Open another site, get another $81,000.
 
-**It is proven, not theoretical.** 40 beds for Maningrida were pressed, CNC'd and assembled
-in-house at the farm. 147 assets are confirmed in community at Utopia. This is the strongest fact
-we have and it is the difference between a business plan and a demonstrated capability.
+**About $230,000 of cost does not care how many sites there are.** The network behind every site
+($109,500: production time, Kirmos, admin, field travel), the company itself ($53,000: insurance,
+accounting, legal, software, governance) and the founder's non-production time ($67,200).
+
+**So: $230,000 ÷ $81,000 ≈ 2.8 sites.**
+
+| Sites | Pot 1 | Whole company, founder unpaid | Whole company, founder paid |
+|---|---|---|---|
+| 1 | −$28,791 | −$81,791 | −$148,991 |
+| 2 | +$51,918 | −$1,082 | −$68,282 |
+| 3 | +$132,627 | +$79,627 | **+$12,427** |
+
+**Two sites break even if the founder works unpaid. Three sites break even if the founder is paid.**
+
+That is the honest headline and it reframes the ask: a funder is not covering a shortfall, they
+are funding the third site, the one that stops the business running on a person's goodwill.
+
+### The bed-count numbers, and why we stopped leading with them
+
+Three break-even figures are in circulation and they are all arithmetically correct. They answer
+different questions, which is why quoting them loose has caused confusion:
+
+- **338 beds** covers the network block only, pretending a site has no costs of its own.
+- **487 beds** adds the site production block, but still ignores warranty and bad debt.
+- **550 beds** is the honest all-in figure for a standalone site — against 450 it can make.
+
+All three say the same thing: one site cannot do it. Lead with sites, not beds. The bed framing
+invites *"can you sell 550 beds?"* and puts us on a demand forecast we do not have. The site
+framing invites *"can you open three sites?"*, which is a question about relationships, and there
+are four live pathways.
 
 ---
 
-## 2. A community does not buy a facility. It chooses modules.
+## 2. The thing itself
 
-This is the part most people get wrong, including our own earlier models.
+A shipping container with a shredder, a hot press, a CNC router and a workbench. Plastic waste in
+one end, a bed people actually want to sleep on out the other.
+
+A Stretch Bed is two galvanised poles threaded through canvas sleeves and through the top holes of
+two crossed recycled-HDPE legs. Tension holds it together, so the canvas is structural. 20kg of
+plastic diverted per bed. It sells for $750.
+
+**It is proven, not theoretical.** 40 beds for Maningrida were pressed, CNC'd and assembled
+in-house. 147 assets are confirmed in community at Utopia. That is the difference between a
+business plan and a demonstrated capability.
+
+---
+
+## 3. A community does not buy a facility. It chooses modules.
 
 The line has five production modules in feed order:
 
 **Collection and sorting → Shredding → Pressing, CNC and finishing → Assembly → Sales and delivery**
 
-Underneath all of them sits a **site base**: a container, power, a pad, ventilation, electrical.
-$31,800 to $64,000. Where a partner supplies the shed, the base shrinks. It does not vanish.
+Underneath sits a **site base** (container, power, pad, ventilation, electrical), $31,800 to
+$64,000. Where a partner supplies the shed, the base shrinks. It does not vanish.
 
-Then a community picks. Which is why the four communities we are working with right now all want
-something different:
+A full new site is **$105,000** minimal-viable, or **$207,450** turnkey. Two different scopes, not
+an optimistic and a pessimistic guess at the same thing. Quote one and name it.
 
-| Community | Stage | What they asked for |
+---
+
+## 4. What a community actually gets
+
+This is new as of 2026-08-03. Until now every model answered Goods' question and none answered
+the community's, and what a community got was a sentence rather than a number.
+
+**A partial module set does not make beds.** Utopia's chosen pair makes shred. Only a run reaching
+assembly makes a $750 bed. So what a community earns depends on how far down the chain they went.
+
+**Every rung already has a price, because Goods buys all of them today.** These are not our
+estimates, they are what Goods pays Defy, from named invoices:
+
+| Step | What the community holds | Worth per bed |
 |---|---|---|
-| **Utopia Homelands** | Choosing modules | Collection and shredding, the earliest module in the chain |
-| **Oonchiumpa** | Funding | The whole chain, plus an employment program |
-| **Tennant Creek** | Listening | Equipment into a shed they already have |
-| **Palm Island** | Listening | To start with governance, not plant |
+| Collection and sorting | Sorted, caged HDPE | *nobody buys this yet* |
+| Shredding | HDPE shred | $40.00 |
+| Pressing, CNC, finishing | Finished leg kit | $344.05 |
+| Assembly | A finished bed | $400.00 |
+| Sales and delivery | Beds in homes | $750.00 |
 
-Three of those four cannot be priced by a model that only knows how to build a whole facility.
-That is why the module basket exists.
+The offer is therefore checkable: *this money goes to Sydney today, and we would rather it went to
+the community doing the work.* The step from shred to pressed kits multiplies what a bed is worth
+to a community by **8.6x**, and that is where a community starts genuinely earning.
 
-A full new site is **$105,000** on the minimal-viable basis, or **$207,450** for a turnkey fitted
-40ft container workshop. Those are two different scopes, not an optimistic and a pessimistic guess
-at the same thing.
+At 450 beds' worth of material a year:
 
----
+| Community | Produces | Setup | Earns/yr | Running cost | Left over |
+|---|---|---|---|---|---|
+| **Utopia** | HDPE shred | $56.6K–$103.3K | $18,000 | $51,043 | **−$33,043** |
+| **Tennant Creek** | Beds in homes | $90.8K–$123K | $337,500 | $75,733 | +$261,767 * |
+| **Oonchiumpa** | Beds in homes | $95.8K–$142.5K | $337,500 | $79,333 | +$258,167 |
+| **Palm Island** | asked for governance | $0 | — | $0 | — |
 
-## 3. The two pots. This is the rule that keeps us honest.
+\* *Reads high because the plastic Tennant Creek must buy in is not costed. The true figure is
+lower and we do not yet know by how much.*
 
-**Pot 1, production.** The beds. Marginal cost per bed is $685 today buying kits in, $426 once we
-press our own legs. At $750 that is $324 of contribution per bed. Against a network overhead of
-about $109,500 a year, production breaks even at **338 beds a year**. Bed sales carry this and
-nothing else.
+**The Utopia finding, which should not be softened.** What they asked for loses $33,043 a year.
+The earliest module in the chain is the one a community most naturally asks for and the one that
+cannot pay for itself, because the $35,000 site floor lands the moment anyone works there at all.
+That is not an argument against a shredder. It is an argument for saying plainly that a shredder
+is a step, and for Goods carrying that gap on purpose, in the open.
 
-**Pot 2, the community wraparound.** A site manager, a trainer, insurance, the employment program.
-Bare facility about $151,666 a site a year, fully staffed about $341,666, employment program
-$300,000. **Grant funded by design.** Bed sales never carry it.
+**Why the third site is in the first community's interest.** The shared team costs $109,500 a year
+whether there is one site or five: $109,500 each at one site, $54,750 at two, $36,500 at three.
+Every community that joins makes every other community's share smaller.
 
-The test to hand an investor: *if a site's grant ends, does production keep running?* If yes, the
-two-pot claim is true. The model is built so that question can be answered from the sheet.
-
-Grants and philanthropy are the bonus on top, not the thing propping it up.
-
----
-
-## 4. Where the money is
-
-- FY26 revenue, accountant-signed Goods-only carve-out: **$713,827**. About 89% grant funded today.
-- Sunk spend already in the ground: **$110,046** ($100,000 facility + $10,046 tooling). Skin in the game, shown beside the ask, never subtracted from it. Graded workpaper: about $43,700 is evidenced at bill level, and the balance is plant we own whose paperwork is catching up.
-- The ask, turnkey scope: **$207,450** site capex, plus **$38,387** working capital and a **$28,791** first-year ramp. About **$275,000** for one site, fully funded.
-- The older **$112,000 to $222,000** range is minimal-viable scope, built on second-hand kit we already own. Still the right figure for a replication that reuses our equipment, but it is not what a funder is being asked to buy. Quote one scope and name it.
-- Proposed capital stack: SEFA $300K debt, anchor philanthropy $500K, QBE $400K repayable as upside.
-- **Signed match-eligible capital today: $0.** The QBE money is catalytic, not dollar-for-dollar, and there is no $150K floor.
+**Two things this model deliberately will not say.** It never splits the money arriving at a
+community into wages and surplus — that is the community's decision. And no community has been
+offered any of this. Nothing goes to a community as a price before they have been walked through
+it in person.
 
 ---
 
-## 5. What we do not know yet, said out loud
+## 5. The two pots
 
-Being straight about these is worth more than papering over them.
+**Pot 1, production.** Bed sales carry this and nothing else. Marginal cost $685 buying kits in,
+$426 pressing our own legs.
 
-1. **Demand is the real gap.** We have four relationships, 40 beds proven and 147 delivered. We do
-   not have 1,000 beds a year of committed demand at $750. Capacity is not revenue and the model
-   does not pretend otherwise.
-2. **The 40-bed run was not measured.** The process is proven; the per-bed cost of $425.74 is
-   modelled. A one-week measured run logging hours, diesel and yield fixes this.
-3. **The entity is mid-migration.** Historical trading sits in the sole trader. The Pty Ltd
-   migration and plant handover are targeted for end-August. 51% First Nations ownership is the
-   unlock for IBA and FAC.
+**Pot 2, the community wraparound.** Site manager, trainer, insurance, employment program. Bare
+facility ~$151,666/site/yr, fully staffed ~$341,666, employment program $300,000. **Grant funded
+by design.** Bed sales never carry it.
+
+The test to hand an investor: *if a site's grant ends, does production keep running?*
+
+---
+
+## 6. Where the money is
+
+- FY26 revenue, Goods-only carve-out: **$713,827**. About 89% grant funded today.
+- Sunk spend already in the ground: **$110,046**, graded workpaper. Shown beside the ask, never
+  subtracted from it.
+- The ask, turnkey scope: **$207,450** capex + **$38,387** working capital + **$28,791** ramp ≈
+  **$275,000** for one site fully funded.
+- Proposed stack: SEFA $300K debt, anchor philanthropy $500K, QBE $400K repayable as upside.
+- **Signed match-eligible capital today: $0.** QBE is catalytic, not dollar-for-dollar, and there
+  is no $150K floor.
+
+---
+
+## 7. What we do not know yet, said out loud
+
+1. **Demand is the real gap.** Four relationships, 40 beds proven, 147 delivered. We do not have
+   1,000 beds a year of committed demand at $750. Capacity is not revenue.
+2. **The 40-bed run was not measured.** The process is proven; $425.74 per bed is modelled. A
+   one-week measured run logging hours, diesel and yield fixes it.
+3. **The entity is mid-migration.** Historical trading sits in the sole trader. Pty Ltd migration
+   and plant handover targeted end-August. 51% First Nations ownership unlocks IBA and FAC.
 4. **Central overheads are budgeted, not sourced.** About $53,000 a year, labelled as a budget.
-5. **The FY26 expense line is one aggregate.** $309,126 with no category split. The accountant
-   carve-out is the highest-value single thing outstanding.
+5. **The CNC router is not in Xero at all**, and the shredder invoice exists but is deleted. Two
+   phone calls, not two searches.
+
+**No longer on this list:** the FY26 expense split. It was the highest-value outstanding item and
+it turned out to be a query, not an accountant job: **$337,296 opex / $41,547 capex** across 380
+lines. What remains is the COGS reclassification — about $90,852 of Defy manufacturing spend sits
+in Consulting & Accounting and Advertising & Marketing, which is why a live P&L reads $0 cost of
+goods sold.
 
 ---
 
-## 6. What happens next
+## 8. What happens next
 
 | Who | What |
 |---|---|
-| Matt | Build the GOC-only 3-statement model, plug the bed costing in, add the depreciation schedule |
-| Ben | Send this workbook. Book the accountant carve-out. Book the measured run. |
-| Ben + Jay | Align QBE timing for the September Stage 2 submission |
-| Hackathon + QBE mentor | Close the demand-side question |
+| Matt | GOC-only 3-statement model, bed costing plugged in, depreciation schedule |
+| Ben | Send the workbook. Book the measured run. Two phone calls: Nic on the CNC, bookkeeper on the Telford Smith voids. |
+| Ben + accountant | The COGS reclassification, before a P&L gets built on $0 COGS |
+| Ben + Jay | QBE timing for the September Stage 2 submission |
+| Hackathon + QBE mentor | Close the demand question |
 
 ---
 
-*Sources: `cost-model-scenarios.json` (v6, locked 2026-05-29), `canon.ts`, the MVF reconciliation
-2026-07-22, the Oonchiumpa DEWR application, Xero (ACT-GD carve-out 2026-05-29, cash position
-2026-08-03). Status grades on every figure are in the workbook.*
+*Sources: `cost-model-scenarios.json` (v6, locked 2026-05-29), `canon.ts`,
+`v2/src/lib/cost-model/community-model.ts`, the MVF reconciliation 2026-07-22, the Oonchiumpa DEWR
+application, Xero (ACT-GD carve-out 2026-05-29, cash position 2026-08-03). Status grades on every
+figure are in the workbook.*

--- a/tools/build-goc-answered-workbook.py
+++ b/tools/build-goc-answered-workbook.py
@@ -1211,8 +1211,14 @@ def build_community_economics(wb):
             continue
         note = ""
         if p["net_to_community"] is not None and p["net_to_community"] < 0:
-            note = ("SHORT. The earliest module is the one most communities ask for and the one that cannot pay "
-                    "for itself: the $35,000 site floor lands the moment anyone works there at all.")
+            # NOT "the community is short". No community puts in capital or covers running
+            # costs; that is grant-carried, the way the wraparound always is. A negative
+            # here means the step does not yet pay for itself out of what it sells, which
+            # is a statement about which POT it sits in, not about a community in deficit.
+            note = ("NEEDS GRANT BEHIND IT - not a community out of pocket. This step does not pay for itself "
+                    "out of what it sells, because the $35,000 site floor lands the moment anyone works there "
+                    "at all. It is a Pot 2 proposition until the chain reaches pressing or selling. See the "
+                    "options block below: selling closes this gap without a press.")
         elif p["buys_input_in"]:
             note = ("Reads high because the plastic it must BUY IN is not costed here. The true figure is lower "
                     "and we do not yet know by how much.")
@@ -1230,7 +1236,27 @@ def build_community_economics(wb):
 
     rows += [
         (),
-        ("3. THE NETWORK FEE - why the third site is in the FIRST community's interest",),
+        ("3. THE OPTIONS OPEN TO A COMMUNITY THAT STARTED EARLY - the live Utopia question",),
+        ("Selling and delivering does NOT depend on making. An earlier version of this model treated it as the "
+         "last link of a physical chain and so quietly forbade the most interesting option a shredder community "
+         f"has: supplying beds to its own people. The spread is ${cm['sales_spread_per_bed']}/bed, the retail "
+         "price less the cost of a finished bed. FREIGHT COMES OUT OF THAT AND IS NOT MODELLED - right shape, "
+         "unproven size.",),
+        ("Option", "Setup low $", "Setup high $", "Earns/yr $", "Running cost/yr $", "Left over/yr $"),
+    ]
+    for o in cm["options"]:
+        rows.append((
+            o["label"], o["setup_low"], o["setup_high"],
+            o["gross_earnings"] if o["gross_earnings"] is not None else "-",
+            o["operating_cost"],
+            o["net_to_community"] if o["net_to_community"] is not None else "-",
+        ))
+    rows += [
+        ("THE FINDING: selling is worth MORE than pressing and needs NO extra capex, because the site base is "
+         "already there. Two decisions sit behind it that are not ours alone - what a community pays for a "
+         "finished bed, and who carries freight.",),
+        (),
+        ("4. THE NETWORK FEE - why the third site is in the FIRST community's interest",),
         (f"The shared team behind every site costs ${cm['network_block_per_year']:,}/yr whether there is one site "
          "or five. So every community that joins makes every other community's share smaller. NOT AGREED WITH "
          "ANY COMMUNITY - this is the arithmetic, not an offer.",),
@@ -1241,7 +1267,7 @@ def build_community_economics(wb):
 
     rows += [
         (),
-        ("4. WHAT THIS MODEL DELIBERATELY WILL NOT SAY",),
+        ("5. WHAT THIS MODEL DELIBERATELY WILL NOT SAY",),
         ("It never splits the money arriving at a community into wages and surplus. That split is the "
          "community's decision, and a model that guesses it repeats exactly the mistake this tab replaces: "
          "putting a number where a conversation belongs.",),
@@ -1259,9 +1285,9 @@ def build_community_economics(wb):
         text = ws.cell(row=row, column=1).value
         if not isinstance(text, str):
             continue
-        if text[:2] in ("1.", "2.", "3.", "4."):
+        if text[:2] in ("1.", "2.", "3.", "4.", "5."):
             ws.cell(row=row, column=1).font = SECTION
-        elif text in ("Step", "Community", "Sites in the network"):
+        elif text in ("Step", "Community", "Sites in the network", "Option"):
             header_row(ws, row, 8)
     set_widths(ws, [30, 40, 15, 15, 15, 17, 15, 60])
     wrap_all(ws, 8)

--- a/tools/build-goc-answered-workbook.py
+++ b/tools/build-goc-answered-workbook.py
@@ -38,6 +38,7 @@ Usage:
 Then push it to the live Google Sheet with tools/push-xlsx-to-gsheet.py.
 """
 import argparse
+import json
 import pathlib
 
 from openpyxl import Workbook
@@ -264,8 +265,14 @@ def build_model(wb):
         "The 40-bed Maningrida run proved the process but was not measured for time, diesel or yield. "
         "$425.74 stays modelled.",
         "No GOC bank account exists. Opening cash is a carve-out decision at the handover date, not a bank fact.",
-        "The FY26 expense figure of $309,126 is one aggregate with no category split. The accountant carve-out "
-        "is the highest-value item outstanding.",
+        # Was: "one aggregate with no category split, the accountant carve-out is the
+        # highest-value item outstanding". That stopped being true on 2026-08-03 and this
+        # line kept saying it, on the tab Matt opens first, while the Xero FY26 Actuals tab
+        # answered it two tabs over. Three surfaces told him the biggest item was open and
+        # one told him it was done.
+        "The FY26 expense split IS now known - $337,296 opex / $41,547 capex, see the Xero FY26 Actuals tab. "
+        "What remains is the COGS reclassification: ~$90,852 of Defy manufacturing spend sits in Consulting & "
+        "Accounting and Advertising & Marketing, which is why a live P&L reads $0 cost of goods sold.",
         "Central overhead of $53,000 is a budget with no source. Replace with actuals.",
         "The entity is mid-migration. Historical trading sits in the sole trader; the Pty Ltd transfer is not executed.",
     ]):
@@ -955,7 +962,10 @@ OPEN_QUESTIONS = [
      "locked figure, treatment decided", "Ben + Matt - agreed treatment"),
 
     ("High", "Can historical $309,126 expenses be split by category?",
-     "Only an aggregate cash-basis Goods expense figure is available here.", "TBC", "Accountant + bookkeeper", "open",
+     # Status was 'open' while the answer below began "ANSWERED 2026-08-03". The sheet
+     # sorts and counts by this flag, so it reported its own solved question as unsolved.
+     "Only an aggregate cash-basis Goods expense figure is available here.", "TBC", "Accountant + bookkeeper",
+     "answered",
      "Matt needs a recurring overhead base, not one aggregate.",
      "Provide accountant carve-out by direct cost, payroll, travel, professional services and other.",
      "ANSWERED 2026-08-03, and it did not need the accountant. The split is on the 'Xero FY26 Actuals' tab, "
@@ -1140,6 +1150,123 @@ def build_open_questions(wb):
     ws.freeze_panes = "B5"
 
 
+# ── Sheet 9: Community Economics ────────────────────────────────────────────
+COMMUNITY_JSON = pathlib.Path(__file__).parent.parent / "deliverables" / "community-model.json"
+
+
+def load_community_model():
+    """
+    Read the community model emitted from TypeScript.
+
+    Fails loudly rather than degrading. The alternative - retyping these figures into
+    this file - is what put Utopia's operating cost $35,000 under the engine for months.
+    Regenerate with:  cd v2 && npx tsx ../tools/emit-community-model.ts
+    """
+    if not COMMUNITY_JSON.exists():
+        raise SystemExit(
+            f"MISSING {COMMUNITY_JSON}\n"
+            "Run:  cd v2 && npx tsx ../tools/emit-community-model.ts\n"
+            "This file is generated from v2/src/lib/cost-model/community-model.ts and is "
+            "deliberately not retyped here."
+        )
+    return json.loads(COMMUNITY_JSON.read_text())
+
+
+def build_community_economics(wb):
+    cm = load_community_model()
+    ws = wb.create_sheet("Community Economics")
+
+    rows = [
+        ("What a community gets, which no earlier version of this model could answer",),
+        ("Every other tab answers Goods' question: does the bed business wash its own face. This one answers the "
+         "community's: what would this mean for us. It is generated from the same code as the app, so it cannot "
+         "drift from what a community is actually shown.",),
+        ("NOTHING HERE HAS BEEN OFFERED TO ANY COMMUNITY. No community sees a price for their own pathway before "
+         "they have been walked through it in person.",),
+        (),
+        ("1. THE VALUE LADDER - what each step of the chain is worth, per bed's worth of material",),
+        ("Every priced rung is what Goods ALREADY PAYS Defy today, from a named invoice. That is what makes the "
+         "offer checkable rather than aspirational: this money goes to Sydney now, and we would rather it went "
+         "to the community doing the work.",),
+        ("Step", "What the community ends up holding", "Worth per bed $", "Grade", "Source"),
+    ]
+    for r in cm["value_ladder"]:
+        rows.append((
+            r["module"].replace("_", " "),
+            r["output"],
+            r["per_bed_equivalent"] if r["per_bed_equivalent"] is not None else "no price exists",
+            r["grade"],
+            r["source"],
+        ))
+    rows += [
+        ("THE STEP THAT MATTERS: shred to pressed kits multiplies what a bed is worth to a community by 8.6x "
+         "($40 to $344.05). Everything before it is preparation.",),
+        (),
+        ("2. THE FOUR LIVE PATHWAYS", f"at {cm['planning_volume']} beds' worth of material a year"),
+        ("Community", "Produces", "Setup low $", "Setup high $", "Earns/yr $", "Running cost/yr $",
+         "Left over/yr $", "Note"),
+    ]
+    for p in cm["pathways"]:
+        if not p.get("modelled"):
+            continue
+        note = ""
+        if p["net_to_community"] is not None and p["net_to_community"] < 0:
+            note = ("SHORT. The earliest module is the one most communities ask for and the one that cannot pay "
+                    "for itself: the $35,000 site floor lands the moment anyone works there at all.")
+        elif p["buys_input_in"]:
+            note = ("Reads high because the plastic it must BUY IN is not costed here. The true figure is lower "
+                    "and we do not yet know by how much.")
+        elif not p["modules"]:
+            note = "Asked for governance, not production. No site, no cost, no income - and the model says so."
+        rows.append((
+            p["name"],
+            p["produces"] or "nothing - no production modules",
+            p["setup_low"], p["setup_high"],
+            p["gross_earnings"] if p["gross_earnings"] is not None else "-",
+            p["operating_cost"],
+            p["net_to_community"] if p["net_to_community"] is not None else "-",
+            note,
+        ))
+
+    rows += [
+        (),
+        ("3. THE NETWORK FEE - why the third site is in the FIRST community's interest",),
+        (f"The shared team behind every site costs ${cm['network_block_per_year']:,}/yr whether there is one site "
+         "or five. So every community that joins makes every other community's share smaller. NOT AGREED WITH "
+         "ANY COMMUNITY - this is the arithmetic, not an offer.",),
+        ("Sites in the network", "Shared cost per site $"),
+    ]
+    for f in cm["network_fee_by_sites"]:
+        rows.append((f["sites"], f["fee_per_site"]))
+
+    rows += [
+        (),
+        ("4. WHAT THIS MODEL DELIBERATELY WILL NOT SAY",),
+        ("It never splits the money arriving at a community into wages and surplus. That split is the "
+         "community's decision, and a model that guesses it repeats exactly the mistake this tab replaces: "
+         "putting a number where a conversation belongs.",),
+        ("It does not cost bought-in feedstock for a pathway that starts partway down the chain.",),
+        ("It does not price a site base for a community that asked for no production modules.",),
+    ]
+
+    write_rows(ws, rows)
+    ws["A1"].font = TITLE
+    ws["A3"].font = KEY
+    # Find the section and header rows rather than hard-coding them: this sheet's row
+    # numbers move every time a pathway or a ladder rung is added, and a hard-coded list
+    # silently styles the wrong line rather than failing.
+    for row in range(1, ws.max_row + 1):
+        text = ws.cell(row=row, column=1).value
+        if not isinstance(text, str):
+            continue
+        if text[:2] in ("1.", "2.", "3.", "4."):
+            ws.cell(row=row, column=1).font = SECTION
+        elif text in ("Step", "Community", "Sites in the network"):
+            header_row(ws, row, 8)
+    set_widths(ws, [30, 40, 15, 15, 15, 17, 15, 60])
+    wrap_all(ws, 8)
+
+
 # ── Entry point ─────────────────────────────────────────────────────────────
 def main() -> int:
     ap = argparse.ArgumentParser()
@@ -1160,6 +1287,7 @@ def main() -> int:
     build_facility_modules(wb)
     build_case_studies(wb)
     build_xero_actuals(wb)
+    build_community_economics(wb)
     build_open_questions(wb)
 
     out = pathlib.Path(args.output)

--- a/tools/emit-community-model.ts
+++ b/tools/emit-community-model.ts
@@ -21,6 +21,8 @@ import { dirname, resolve } from 'node:path';
 
 import {
   VALUE_LADDER,
+  SALES_SPREAD_PER_BED,
+  modelCommunity,
   modelPathway,
   networkFeePerSite,
   NETWORK_BLOCK_PER_YEAR,
@@ -47,6 +49,34 @@ const out = {
     grade: r.grade,
     source: r.source,
   })),
+  sales_spread_per_bed: SALES_SPREAD_PER_BED,
+  /**
+   * The options open to a community that has taken the earliest modules, which is the
+   * live Utopia question. Selling turns out to be worth more than pressing and to need
+   * no extra capex at all, because the site base is already there.
+   */
+  options: (
+    [
+      ['Collect and shred (today’s ask)', ['collection_baling', 'shredding']],
+      ['Collect, shred and SELL', ['collection_baling', 'shredding', 'sales_delivery']],
+      ['Collect, shred and PRESS', ['collection_baling', 'shredding', 'pressing_cnc']],
+      ['Sell and deliver only, no plant', ['sales_delivery']],
+      [
+        'The whole chain',
+        ['collection_baling', 'shredding', 'pressing_cnc', 'assembly', 'sales_delivery'],
+      ],
+    ] as Array<[string, string[]]>
+  ).map(([label, modules]) => {
+    const m = modelCommunity(modules, PLANNING_VOLUME);
+    return {
+      label,
+      setup_low: m.setup.capexLow,
+      setup_high: m.setup.capexHigh,
+      gross_earnings: m.annual.grossEarnings,
+      operating_cost: m.annual.operatingCost,
+      net_to_community: m.annual.netToCommunity,
+    };
+  }),
   pathways: COMMUNITY_PATHWAYS.map((p) => {
     const m = modelPathway(p.id, PLANNING_VOLUME);
     if (!m) return { id: p.id, name: p.name, modelled: false };

--- a/tools/emit-community-model.ts
+++ b/tools/emit-community-model.ts
@@ -1,0 +1,76 @@
+/**
+ * Emit the community side of the cost model as JSON, for the workbook generator.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The workbook generator is Python and the model is TypeScript, and the wrong fix for
+ * that is retyping the figures into the Python file. Every number retyped is a number
+ * that can drift, and this repo has already paid for that twice today: Utopia's stored
+ * operating cost sat $35,000 under the engine for months, and the plain-words document
+ * told a funder the FY26 expense split was unsolved a day after it was solved.
+ *
+ * So the model stays the single source and this writes down what it says. If this file
+ * has not been run, the workbook generator fails loudly rather than falling back to a
+ * stale copy - a generator whose output depends on what happens to be on disk is worse
+ * than no generator.
+ *
+ * Usage, from v2/:  npx tsx ../tools/emit-community-model.ts
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import {
+  VALUE_LADDER,
+  modelPathway,
+  networkFeePerSite,
+  NETWORK_BLOCK_PER_YEAR,
+} from '../v2/src/lib/cost-model/community-model';
+import { COMMUNITY_PATHWAYS } from '../v2/src/lib/data/community-pathways';
+
+/** Beds' worth of material a year at one shift. A planning rate, never a forecast. */
+const PLANNING_VOLUME = 450;
+
+const out = {
+  _what_this_is:
+    'Generated from v2/src/lib/cost-model/community-model.ts. Do not hand-edit: rerun the emitter.',
+  _generated_from: 'tools/emit-community-model.ts',
+  planning_volume: PLANNING_VOLUME,
+  network_block_per_year: NETWORK_BLOCK_PER_YEAR,
+  network_fee_by_sites: [1, 2, 3, 4].map((sites) => ({
+    sites,
+    fee_per_site: networkFeePerSite(sites),
+  })),
+  value_ladder: VALUE_LADDER.map((r) => ({
+    module: r.module,
+    output: r.output,
+    per_bed_equivalent: r.perBedEquivalent,
+    grade: r.grade,
+    source: r.source,
+  })),
+  pathways: COMMUNITY_PATHWAYS.map((p) => {
+    const m = modelPathway(p.id, PLANNING_VOLUME);
+    if (!m) return { id: p.id, name: p.name, modelled: false };
+    return {
+      id: p.id,
+      name: p.name,
+      region: p.region,
+      modelled: true,
+      modules: m.modules,
+      produces: m.rung?.output ?? null,
+      per_bed_equivalent: m.rung?.perBedEquivalent ?? null,
+      buys_input_in: m.buysInputIn,
+      setup_low: m.setup.capexLow,
+      setup_high: m.setup.capexHigh,
+      gross_earnings: m.annual.grossEarnings,
+      operating_cost: m.annual.operatingCost,
+      net_to_community: m.annual.netToCommunity,
+      open_decisions: m.openDecisions,
+    };
+  }),
+};
+
+const target = resolve(import.meta.dirname, '../deliverables/community-model.json');
+mkdirSync(dirname(target), { recursive: true });
+writeFileSync(target, JSON.stringify(out, null, 2) + '\n');
+console.log(`wrote ${target}`);
+console.log(`  ${out.pathways.filter((p) => p.modelled).length} pathways modelled at ${PLANNING_VOLUME} beds/yr`);

--- a/v2/src/app/pathways/[id]/numbers/page.tsx
+++ b/v2/src/app/pathways/[id]/numbers/page.tsx
@@ -1,0 +1,310 @@
+/**
+ * The community's side of the numbers, one page, for a specific pathway.
+ *
+ * WHAT THIS IS FOR
+ * ----------------
+ * Every other money surface in this app answers Goods' question: does the bed
+ * business wash its own face. This one answers the community's: what would this
+ * mean for us. It is built to be walked through in person and printed, not sent.
+ *
+ * IT COMPUTES, IT DOES NOT QUOTE. Every figure comes from `modelPathway()` at
+ * render time. Nothing is stored on the page. The stored `nextPhase.cost` on the
+ * pathway record was wrong by $35,000/yr for months precisely because a figure
+ * sat in a file with nothing recomputing it.
+ *
+ * THE STANDING RULE, WHICH THIS PAGE MUST NOT BREAK
+ * -------------------------------------------------
+ * No community sees a price for their own pathway before they have been walked
+ * through it. So: noindex, out of every menu, and the banner stays at the top.
+ */
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+
+import { COMMUNITY_PATHWAYS, communityPathway } from '@/lib/data/community-pathways';
+import { VALUE_LADDER, modelPathway, networkFeePerSite } from '@/lib/cost-model/community-model';
+
+/** Beds' worth of material a year at one shift. A planning rate, never a forecast. */
+const PLANNING_VOLUME = 450;
+
+export function generateStaticParams() {
+  return COMMUNITY_PATHWAYS.map((pathway) => ({ id: pathway.id }));
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const pathway = communityPathway(id);
+  const robots = { index: false, follow: false } as const;
+  return pathway
+    ? { title: `${pathway.name}: what this would mean`, robots }
+    : { robots };
+}
+
+const money = (n: number) => '$' + Math.round(n).toLocaleString('en-AU');
+
+export default async function PathwayNumbersPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const pathway = communityPathway(id);
+  if (!pathway) notFound();
+
+  const model = modelPathway(id, PLANNING_VOLUME);
+  if (!model) notFound();
+
+  const chosen = new Set(model.modules);
+  const net = model.annual.netToCommunity;
+
+  return (
+    <div className="min-h-screen bg-[#fbf8f1]">
+      <section className="border-b border-[#e6dfd1] bg-white print:hidden">
+        <div className="container mx-auto max-w-5xl px-5 py-5">
+          <Link
+            href={`/pathways/${pathway.id}`}
+            className="inline-flex min-h-11 items-center gap-2 text-sm font-semibold text-[#5f584e] hover:text-[#a64f35]"
+          >
+            <ArrowLeft className="h-4 w-4" /> Back to the {pathway.name} pathway
+          </Link>
+        </div>
+      </section>
+
+      <div className="container mx-auto max-w-5xl px-5 py-12">
+        {/* The gate. Not decorative - this page carries numbers no community has agreed to. */}
+        <p className="rounded-2xl border-2 border-[#a64f35] bg-[#fdf3ef] px-5 py-4 text-sm leading-6 text-[#6b3625]">
+          <strong>A working page, not an offer.</strong> These figures are ours to check, not
+          {' '}{pathway.name}&rsquo;s to accept. Nothing here has been agreed with anyone, and none of it
+          goes to community as a price until it has been talked through together, in person.
+        </p>
+
+        <header className="mt-10">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[#a64f35]">
+            {pathway.region}
+          </p>
+          <h1 className="mt-3 font-display text-4xl text-[#2b2a26] md:text-5xl">
+            What this would mean for {pathway.name}
+          </h1>
+          <p className="mt-5 max-w-3xl text-lg leading-8 text-[#625b50]">{pathway.invitation}</p>
+        </header>
+
+        {/* ── 1. The chain ─────────────────────────────────────────────── */}
+        <section className="mt-14">
+          <h2 className="font-display text-2xl text-[#2b2a26]">
+            The line comes in five pieces. You choose which ones.
+          </h2>
+          <p className="mt-3 max-w-3xl leading-7 text-[#625b50]">
+            Each piece takes the plastic one step further, and every step is worth more than the
+            one before it. These are not our estimates: they are what Goods pays a factory in
+            Sydney for the same work today.
+          </p>
+
+          <div className="mt-8 overflow-x-auto">
+            <table className="w-full min-w-[36rem] border-collapse text-left text-sm">
+              <thead>
+                <tr className="border-b-2 border-[#d5cabc] text-[#37332e]">
+                  <th className="py-3 pr-4 font-semibold">Step</th>
+                  <th className="py-3 pr-4 font-semibold">What you end up holding</th>
+                  <th className="py-3 pr-4 text-right font-semibold">Worth per bed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {VALUE_LADDER.map((rung) => {
+                  const picked = chosen.has(rung.module);
+                  return (
+                    <tr
+                      key={rung.module}
+                      className={
+                        picked
+                          ? 'border-b border-[#e6dfd1] bg-[#f4f7f0]'
+                          : 'border-b border-[#e6dfd1] text-[#8b8378]'
+                      }
+                    >
+                      <td className="py-3 pr-4 font-semibold">
+                        {rung.module.replace(/_/g, ' ')}
+                        {picked && (
+                          <span className="ml-2 rounded-full bg-[#405039] px-2 py-0.5 text-[10px] font-semibold uppercase text-white">
+                            Asked for
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-3 pr-4 leading-6">{rung.output}</td>
+                      <td className="py-3 pr-4 text-right font-semibold tabular-nums">
+                        {rung.perBedEquivalent === null ? (
+                          <span className="font-normal italic text-[#8b8378]">nobody buys this yet</span>
+                        ) : (
+                          money(rung.perBedEquivalent)
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-4 text-sm leading-6 text-[#6b6358]">
+            The big jump is pressing and cutting: it takes a bed&rsquo;s worth of plastic from{' '}
+            <strong>$40</strong> to <strong>$344</strong>. Everything before that step is getting
+            ready. That step is where the money starts.
+          </p>
+        </section>
+
+        {/* ── 2. What it costs and what it brings ──────────────────────── */}
+        <section className="mt-16">
+          <h2 className="font-display text-2xl text-[#2b2a26]">
+            What {pathway.name} asked for, with the numbers on it
+          </h2>
+
+          {model.modules.length === 0 ? (
+            <p className="mt-5 max-w-3xl leading-7 text-[#625b50]">
+              {pathway.name} has not asked for production, and this page does not invent a
+              container to price. What was asked for is governance and the conversation, and that
+              costs nothing to set up and earns nothing, which is the honest answer rather than a
+              missing one.
+            </p>
+          ) : (
+            <>
+              <dl className="mt-8 grid gap-5 sm:grid-cols-2">
+                <div className="rounded-2xl border border-[#e6dfd1] bg-white p-6">
+                  <dt className="text-sm font-semibold text-[#6b6358]">To set it up, once</dt>
+                  <dd className="mt-2 font-display text-3xl text-[#2b2a26]">
+                    {money(model.setup.capexLow)} &ndash; {money(model.setup.capexHigh)}
+                  </dd>
+                  <p className="mt-3 text-sm leading-6 text-[#6b6358]">
+                    Not money a community finds. This is what a funder or an investor is asked
+                    for, and it buys the gear, the container, the power and the pad.
+                  </p>
+                </div>
+
+                <div className="rounded-2xl border border-[#e6dfd1] bg-white p-6">
+                  <dt className="text-sm font-semibold text-[#6b6358]">To keep it running, each year</dt>
+                  <dd className="mt-2 font-display text-3xl text-[#2b2a26]">
+                    {money(model.annual.operatingCost)}
+                  </dd>
+                  <p className="mt-3 text-sm leading-6 text-[#6b6358]">
+                    Most of this is the cost of having a working site at all &mdash; books,
+                    insurance, the yard &mdash; and it lands the moment anyone works there,
+                    whatever they make.
+                  </p>
+                </div>
+              </dl>
+
+              <div
+                className={
+                  net !== null && net < 0
+                    ? 'mt-6 rounded-2xl border-2 border-[#c2703f] bg-[#fdf6ef] p-6'
+                    : 'mt-6 rounded-2xl border border-[#b9c5ac] bg-[#f4f7f0] p-6'
+                }
+              >
+                <p className="text-sm font-semibold text-[#6b6358]">
+                  What comes in each year, making {PLANNING_VOLUME.toLocaleString()} beds&rsquo; worth
+                </p>
+                {model.annual.grossEarnings === null ? (
+                  <p className="mt-3 leading-7 text-[#5f584e]">
+                    Nothing yet, and that is the point worth being straight about. Nobody buys
+                    sorted plastic today, so this selection has no one to sell to until it goes one
+                    step further, or until Goods agrees to buy the feedstock itself.
+                  </p>
+                ) : (
+                  <>
+                    <p className="mt-3 font-display text-3xl text-[#2b2a26]">
+                      {money(model.annual.grossEarnings)} in, {money(model.annual.operatingCost)} out
+                    </p>
+                    <p className="mt-3 text-lg font-semibold text-[#2b2a26]">
+                      {net !== null && net < 0
+                        ? `That is ${money(Math.abs(net))} a year short.`
+                        : `That leaves ${money(net ?? 0)} a year in community.`}
+                    </p>
+                    {model.buysInputIn && (
+                      /* Without this, a site that skips collection looks BETTER than one that
+                         does the whole chain, purely because the plastic it has to buy is not
+                         costed. The caveat has to sit with the number, not in a list below it. */
+                      <p className="mt-3 rounded-xl bg-[#fdf6ef] px-4 py-3 text-sm leading-6 text-[#6b3625]">
+                        <strong>Read this one carefully.</strong> This pathway starts partway down
+                        the chain, so the plastic has to be bought in rather than collected here.
+                        That cost is real and it is not in the figure above, so the true number is
+                        lower. We do not know yet by how much.
+                      </p>
+                    )}
+                    <p className="mt-3 leading-7 text-[#5f584e]">
+                      {net !== null && net < 0 ? (
+                        <>
+                          We would rather say this out loud now than have it turn up later. The
+                          first step in the chain is the one most communities want and the one that
+                          cannot pay for itself yet. It is a real step, and Goods carrying that gap
+                          on purpose is a decision we should make together and in the open &mdash;
+                          not a number to bury.
+                        </>
+                      ) : (
+                        <>
+                          That is what arrives in community. How it splits between wages and what
+                          the community keeps is not ours to decide, and this page will not guess
+                          at it.
+                        </>
+                      )}
+                    </p>
+                  </>
+                )}
+              </div>
+            </>
+          )}
+        </section>
+
+        {/* ── 3. Why more sites is good for this one ───────────────────── */}
+        <section className="mt-16">
+          <h2 className="font-display text-2xl text-[#2b2a26]">Why we do not stop at one</h2>
+          <p className="mt-3 max-w-3xl leading-7 text-[#625b50]">
+            Behind every site is one shared team: quality, suppliers, freight, the person on the
+            road. That costs {money(networkFeePerSite(1))} a year whether there is one site or
+            five, so every community that joins makes every other community&rsquo;s share smaller.
+          </p>
+          <div className="mt-6 flex flex-wrap gap-4">
+            {[1, 2, 3].map((sites) => (
+              <div
+                key={sites}
+                className="min-w-[10rem] flex-1 rounded-2xl border border-[#e6dfd1] bg-white p-5"
+              >
+                <p className="text-sm font-semibold text-[#6b6358]">
+                  {sites} {sites === 1 ? 'site' : 'sites'}
+                </p>
+                <p className="mt-1 font-display text-2xl text-[#2b2a26]">
+                  {money(networkFeePerSite(sites))}
+                </p>
+                <p className="mt-1 text-xs text-[#8b8378]">shared cost, each site</p>
+              </div>
+            ))}
+          </div>
+          <p className="mt-4 text-sm leading-6 text-[#6b6358]">
+            No community has been asked to pay this, and the share is not agreed with anyone. It
+            is here because it is the honest reason the third site matters to the first one.
+          </p>
+        </section>
+
+        {/* ── 4. Open decisions ────────────────────────────────────────── */}
+        <section className="mt-16">
+          <h2 className="font-display text-2xl text-[#2b2a26]">Still to work out together</h2>
+          <ul className="mt-5 space-y-4">
+            {model.openDecisions.map((decision) => (
+              <li
+                key={decision}
+                className="rounded-2xl border border-[#e6dfd1] bg-white px-5 py-4 leading-7 text-[#5f584e]"
+              >
+                {decision}
+              </li>
+            ))}
+          </ul>
+          <p className="mt-6 text-sm leading-6 text-[#6b6358]">
+            Next decision on this pathway: {pathway.nextDecision}
+          </p>
+        </section>
+
+        <footer className="mt-16 border-t border-[#e6dfd1] pt-6 text-xs leading-6 text-[#8b8378]">
+          Every figure on this page is worked out fresh from the cost model when the page loads,
+          not typed in. Step values come from Goods&rsquo; own invoices with Defy. Volume is{' '}
+          {PLANNING_VOLUME.toLocaleString()} beds&rsquo; worth of material a year, a planning rate
+          rather than a sales forecast.
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/v2/src/app/pathways/[id]/numbers/page.tsx
+++ b/v2/src/app/pathways/[id]/numbers/page.tsx
@@ -210,9 +210,19 @@ export default async function PathwayNumbersPage({
                     <p className="mt-3 font-display text-3xl text-[#2b2a26]">
                       {money(model.annual.grossEarnings)} in, {money(model.annual.operatingCost)} out
                     </p>
+                    {model.sells && model.makingPerBed !== null && (
+                      /* Two different kinds of work, and a community should see which is
+                         which. Making is what comes off the line; selling is the spread
+                         on getting a bed into a home, whoever built it. */
+                      <p className="mt-2 text-sm leading-6 text-[#6b6358]">
+                        Of that, {money(model.makingPerBed * PLANNING_VOLUME)} is for what you make
+                        and {money(model.sellingPerBed! * PLANNING_VOLUME)} is for getting beds into
+                        homes.
+                      </p>
+                    )}
                     <p className="mt-3 text-lg font-semibold text-[#2b2a26]">
                       {net !== null && net < 0
-                        ? `That is ${money(Math.abs(net))} a year short.`
+                        ? `This step needs about ${money(Math.abs(net))} a year of grant behind it.`
                         : `That leaves ${money(net ?? 0)} a year in community.`}
                     </p>
                     {model.buysInputIn && (
@@ -229,11 +239,13 @@ export default async function PathwayNumbersPage({
                     <p className="mt-3 leading-7 text-[#5f584e]">
                       {net !== null && net < 0 ? (
                         <>
-                          We would rather say this out loud now than have it turn up later. The
-                          first step in the chain is the one most communities want and the one that
-                          cannot pay for itself yet. It is a real step, and Goods carrying that gap
-                          on purpose is a decision we should make together and in the open &mdash;
-                          not a number to bury.
+                          <strong>This is not money the community is out of pocket.</strong> Nobody
+                          here puts in capital or covers running costs &mdash; that is carried by
+                          grant funding, the way the wraparound always is. What the figure means is
+                          that this step does not yet pay for itself out of what it sells, so it
+                          needs grant behind it until the chain goes further. Two things change
+                          that: pressing, which takes a bed&rsquo;s worth from $40 to $344, or
+                          selling and delivering beds, which does not need a press at all.
                         </>
                       ) : (
                         <>

--- a/v2/src/lib/cost-model/community-model.guards.test.ts
+++ b/v2/src/lib/cost-model/community-model.guards.test.ts
@@ -11,8 +11,9 @@ import { describe, expect, it } from 'vitest';
 import {
   FEED_ORDER,
   NETWORK_BLOCK_PER_YEAR,
+  SALES_SPREAD_PER_BED,
   VALUE_LADDER,
-  furthestRung,
+  furthestPhysicalRung,
   modelCommunity,
   modelPathway,
   networkFeePerSite,
@@ -53,22 +54,28 @@ describe('the value ladder', () => {
   });
 });
 
-describe('furthestRung', () => {
+describe('furthestPhysicalRung', () => {
   it('reads the last completable step, not the most valuable one selected', () => {
-    expect(furthestRung(['collection_baling', 'shredding'])!.module).toBe('shredding');
+    expect(furthestPhysicalRung(['collection_baling', 'shredding'])!.module).toBe('shredding');
   });
 
   it('allows a run that starts partway down and buys its input in', () => {
-    expect(furthestRung(['shredding', 'pressing_cnc'])!.module).toBe('pressing_cnc');
+    expect(furthestPhysicalRung(['shredding', 'pressing_cnc'])!.module).toBe('pressing_cnc');
   });
 
   it('returns null for a run with a hole in it', () => {
     // Pressing with no shredding: the press has nothing to press.
-    expect(furthestRung(['collection_baling', 'pressing_cnc'])).toBeNull();
+    expect(furthestPhysicalRung(['collection_baling', 'pressing_cnc'])).toBeNull();
   });
 
   it('returns null for an empty selection', () => {
-    expect(furthestRung([])).toBeNull();
+    expect(furthestPhysicalRung([])).toBeNull();
+  });
+
+  it('ignores sales, because selling makes nothing', () => {
+    // The whole point of the fix: sales is not the last link of a physical chain.
+    expect(furthestPhysicalRung(['sales_delivery'])).toBeNull();
+    expect(furthestPhysicalRung(['shredding', 'sales_delivery'])!.module).toBe('shredding');
   });
 });
 
@@ -195,5 +202,53 @@ describe('live pathways read from the recorded module selections', () => {
     const utopia = modelPathway('utopia', 450)!;
     expect(utopia.rung!.module).toBe('shredding');
     expect(utopia.annual.netToCommunity!).toBeLessThan(0);
+  });
+});
+
+describe('selling stands alone', () => {
+  it('does not need the step before it, unlike every physical module', () => {
+    // Utopia could sell beds pressed elsewhere. The original contiguity rule quietly
+    // forbade this, which hid the most interesting option a shredder community has.
+    const sellOnly = modelCommunity(['sales_delivery'], 450);
+    expect(sellOnly.brokenChain).toBe(false);
+    expect(sellOnly.rung).toBeNull(); // makes nothing
+    expect(sellOnly.sells).toBe(true);
+    expect(sellOnly.annual.grossEarnings).toBe(SALES_SPREAD_PER_BED * 450);
+  });
+
+  it('stacks with making, and reconciles to the retail price at the top of the chain', () => {
+    // assembly ($400) + spread ($350) must equal the $750 a bed in a home is worth,
+    // or the two income lines are double counting.
+    const full = modelCommunity([...FEED_ORDER], 450);
+    expect(full.makingPerBed! + full.sellingPerBed!).toBe(750);
+    expect(full.annual.grossEarnings).toBe(750 * 450);
+  });
+
+  it('prices the spread as retail less a finished bed', () => {
+    expect(SALES_SPREAD_PER_BED).toBe(350);
+  });
+
+  it('flags freight as the unmodelled number whenever selling is counted', () => {
+    const s = modelCommunity(['sales_delivery'], 450);
+    expect(s.openDecisions.some((d) => d.includes('Freight'))).toBe(true);
+  });
+});
+
+describe('shred plus sell: the option the old rule hid', () => {
+  const shredSell = modelCommunity(['collection_baling', 'shredding', 'sales_delivery'], 450);
+  const shredOnly = modelCommunity(['collection_baling', 'shredding'], 450);
+
+  it('turns a shredder-only gap into a positive result', () => {
+    expect(shredOnly.annual.netToCommunity!).toBeLessThan(0);
+    expect(shredSell.annual.netToCommunity!).toBeGreaterThan(0);
+  });
+
+  it('earns shred plus the spread, without pressing a single leg', () => {
+    expect(shredSell.makingPerBed).toBe(40);
+    expect(shredSell.sellingPerBed).toBe(350);
+  });
+
+  it('says the beds would be bought in, because that is a different relationship', () => {
+    expect(shredSell.openDecisions.some((d) => d.includes('did not build'))).toBe(true);
   });
 });

--- a/v2/src/lib/cost-model/community-model.guards.test.ts
+++ b/v2/src/lib/cost-model/community-model.guards.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Guards for the community side of the cost model.
+ *
+ * The point of these is not arithmetic coverage. It is that the community-facing
+ * figures cannot quietly drift, and that the two honest silences in the model - the
+ * unpriced collection rung, and the wages/surplus split - stay silent. A future edit
+ * that fabricates either one should fail here.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  FEED_ORDER,
+  NETWORK_BLOCK_PER_YEAR,
+  VALUE_LADDER,
+  furthestRung,
+  modelCommunity,
+  modelPathway,
+  networkFeePerSite,
+  pathwayModules,
+} from './community-model';
+
+describe('the value ladder', () => {
+  it('is in feed order and covers every production module', () => {
+    expect(VALUE_LADDER.map((r) => r.module)).toEqual([...FEED_ORDER]);
+  });
+
+  it('prices each rung above the one before it', () => {
+    const priced = VALUE_LADDER.filter((r) => r.perBedEquivalent !== null).map((r) => r.perBedEquivalent!);
+    const ascending = [...priced].sort((a, b) => a - b);
+    expect(priced).toEqual(ascending);
+  });
+
+  it('holds the verified Defy rates that make the ladder evidenced, not invented', () => {
+    const by = (m: string) => VALUE_LADDER.find((r) => r.module === m)!;
+    expect(by('shredding').perBedEquivalent).toBe(40); // 20kg x $2.00, INV-1731
+    expect(by('pressing_cnc').perBedEquivalent).toBe(344.05); // INV-1602 + INV-1732
+    expect(by('assembly').perBedEquivalent).toBe(400); // 344.05 + 55.95 assembly labour
+    expect(by('sales_delivery').perBedEquivalent).toBe(750); // shop price
+  });
+
+  it('leaves collection unpriced, because Goods buys sorted feedstock from nobody', () => {
+    const collection = VALUE_LADDER.find((r) => r.module === 'collection_baling')!;
+    expect(collection.perBedEquivalent).toBeNull();
+    expect(collection.grade).toBe('open');
+  });
+
+  it('grades every priced rung as verified, with a named source', () => {
+    for (const rung of VALUE_LADDER) {
+      if (rung.perBedEquivalent === null) continue;
+      expect(rung.grade).toBe('verified');
+      expect(rung.source.length).toBeGreaterThan(10);
+    }
+  });
+});
+
+describe('furthestRung', () => {
+  it('reads the last completable step, not the most valuable one selected', () => {
+    expect(furthestRung(['collection_baling', 'shredding'])!.module).toBe('shredding');
+  });
+
+  it('allows a run that starts partway down and buys its input in', () => {
+    expect(furthestRung(['shredding', 'pressing_cnc'])!.module).toBe('pressing_cnc');
+  });
+
+  it('returns null for a run with a hole in it', () => {
+    // Pressing with no shredding: the press has nothing to press.
+    expect(furthestRung(['collection_baling', 'pressing_cnc'])).toBeNull();
+  });
+
+  it('returns null for an empty selection', () => {
+    expect(furthestRung([])).toBeNull();
+  });
+});
+
+describe('Utopia: collection and shredding, the live case', () => {
+  const utopia = modelCommunity(['collection_baling', 'shredding'], 450);
+
+  it('earns from shred, at the rate Goods pays Defy today', () => {
+    expect(utopia.rung!.module).toBe('shredding');
+    expect(utopia.annual.grossEarnings).toBe(40 * 450); // $18,000
+  });
+
+  it('is priceable, but on a collection band so wide it is nearly 4x end to end', () => {
+    // Collection carries $5,000-$19,500 graded `estimate`. That is a real quote gap:
+    // priceable is not the same as firm, and the setup range Utopia would be shown
+    // spans tens of thousands. A firm collection quote is the cheapest way to
+    // narrow it, and until then this band goes to nobody as a price.
+    expect(utopia.setup.priceable).toBe(true);
+    expect(utopia.setup.capexHigh - utopia.setup.capexLow).toBeGreaterThan(40_000);
+  });
+
+  it('shows shred alone does not cover the cost of running the site', () => {
+    // $18,000 of shred against the site floor plus two modules' operating share.
+    // This is the finding that matters: the earliest module is the one a community
+    // most wants and the one that pays least. Never soften it.
+    expect(utopia.annual.netToCommunity!).toBeLessThan(0);
+  });
+});
+
+describe('a full chain community', () => {
+  const full = modelCommunity([...FEED_ORDER], 450);
+
+  it('earns the full bed price', () => {
+    expect(full.annual.grossEarnings).toBe(750 * 450);
+  });
+
+  it('clears its operating cost with room to pay people', () => {
+    expect(full.annual.netToCommunity!).toBeGreaterThan(0);
+  });
+
+  it('does not buy its input in', () => {
+    expect(full.buysInputIn).toBe(false);
+    expect(full.brokenChain).toBe(false);
+  });
+});
+
+describe('Tennant Creek: a run that starts partway down', () => {
+  const tc = modelCommunity(['shredding', 'pressing_cnc', 'assembly'], 450);
+
+  it('is coherent, not broken', () => {
+    expect(tc.brokenChain).toBe(false);
+    expect(tc.buysInputIn).toBe(true);
+  });
+
+  it('says out loud that the bought-in input is a cost this model does not carry', () => {
+    expect(tc.openDecisions.some((d) => d.includes('NOT in these figures'))).toBe(true);
+  });
+});
+
+describe('the silences the model must keep', () => {
+  const any = modelCommunity([...FEED_ORDER], 450);
+
+  it('never splits the money into wages and surplus', () => {
+    expect(any.openDecisions.some((d) => d.includes("community's call"))).toBe(true);
+    expect(any.annual).not.toHaveProperty('wages');
+  });
+
+  it('flags the network fee as not agreed with anyone', () => {
+    expect(any.openDecisions.some((d) => d.includes('not agreed'))).toBe(true);
+  });
+});
+
+describe('the network fee falls as sites join', () => {
+  it('is the whole network block at one site', () => {
+    expect(networkFeePerSite(1)).toBe(NETWORK_BLOCK_PER_YEAR);
+  });
+
+  it('halves at two sites and thirds at three', () => {
+    expect(networkFeePerSite(2)).toBe(54_750);
+    expect(networkFeePerSite(3)).toBe(36_500);
+  });
+
+  it('refuses a nonsense site count rather than returning Infinity', () => {
+    expect(() => networkFeePerSite(0)).toThrow(RangeError);
+  });
+});
+
+describe('Palm Island: governance first, no production modules', () => {
+  const pi = modelCommunity([], 450);
+
+  it('costs nothing to set up, because no site was asked for', () => {
+    // A model that charges a community for a container they did not ask for has
+    // turned a pathway into a sales pitch.
+    expect(pi.setup.capexLow).toBe(0);
+    expect(pi.setup.capexHigh).toBe(0);
+    expect(pi.annual.operatingCost).toBe(0);
+  });
+
+  it('has no income line, and says so rather than showing zero', () => {
+    expect(pi.rung).toBeNull();
+    expect(pi.annual.grossEarnings).toBeNull();
+    expect(pi.annual.netToCommunity).toBeNull();
+  });
+});
+
+describe('live pathways read from the recorded module selections', () => {
+  it('resolves hyphenated pathway ids to the underscored keys in the JSON', () => {
+    expect(pathwayModules('tennant-creek')).toEqual([
+      'shredding',
+      'pressing_cnc',
+      'assembly',
+      'sales_delivery',
+    ]);
+    expect(pathwayModules('palm-island')).toEqual([]);
+  });
+
+  it('returns null for an unknown pathway rather than an empty selection', () => {
+    // An empty selection is a real answer (Palm Island). An unknown id is not, and
+    // conflating them would silently price a community that has never been asked.
+    expect(pathwayModules('not-a-community')).toBeNull();
+    expect(modelPathway('not-a-community', 450)).toBeNull();
+  });
+
+  it('models Utopia from its recorded shredder-first selection', () => {
+    const utopia = modelPathway('utopia', 450)!;
+    expect(utopia.rung!.module).toBe('shredding');
+    expect(utopia.annual.netToCommunity!).toBeLessThan(0);
+  });
+});

--- a/v2/src/lib/cost-model/community-model.ts
+++ b/v2/src/lib/cost-model/community-model.ts
@@ -1,0 +1,292 @@
+/**
+ * The community side of the cost model.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Every other model in this repo answers "does the bed business wash its own face",
+ * which is Goods' question. A community asking "what is in it for us" got a sentence,
+ * not a number: one scenario row reading "margin stays in community", with no
+ * arithmetic behind it. This file is that arithmetic.
+ *
+ * THE IDEA THAT MAKES IT WORK
+ * ---------------------------
+ * A partial module set does not make beds. Utopia's chosen pair (collection +
+ * shredding) produces SHRED. Tennant Creek's produces LEG KITS. Only a set that
+ * reaches assembly produces a $750 bed. So "what does a community earn" is decided
+ * by how far down the chain they chose to go.
+ *
+ * We do not have to invent transfer prices for the rungs below a finished bed,
+ * because Goods already BUYS every one of them from Defy today. What a community
+ * produces is a thing Goods stops buying from a supplier in Sydney. That makes the
+ * ladder evidenced rather than aspirational, and it makes the offer legible:
+ * we pay this today, and we would rather pay you.
+ *
+ * WHAT THIS FILE DELIBERATELY DOES NOT DO
+ * ---------------------------------------
+ * It does not split the money that arrives at a community into "wages" and
+ * "surplus". That split is the community's decision, not a modelling assumption,
+ * and inventing one would be the same mistake as the missing model it replaces.
+ * It reports what arrives and what it costs to run; who gets paid what out of it
+ * is a conversation, and `openDecisions` says so out loud.
+ *
+ * NOTHING HERE GOES TO A COMMUNITY AS A PRICE. The standing rule holds: no
+ * community sees a number for their own pathway before they have seen it in person.
+ */
+import scenarios from '../data/cost-model-scenarios.json';
+import { priceModuleOperating, priceModuleSelection } from '../data/cost-model-scenarios';
+
+const _defy = scenarios.defy_verified_rates;
+const _physics = scenarios.physics;
+
+/** Module keys in feed order. A module cannot run without the one before it. */
+export const FEED_ORDER = [
+  'collection_baling',
+  'shredding',
+  'pressing_cnc',
+  'assembly',
+  'sales_delivery',
+] as const;
+
+export type ProductionModuleKey = (typeof FEED_ORDER)[number];
+
+export interface LadderRung {
+  /** The module whose completion produces this output. */
+  module: ProductionModuleKey;
+  /** What the community physically has at the end of this step. */
+  output: string;
+  /**
+   * What that output is worth per bed's worth of material, in AUD.
+   * Null where Goods does not buy the thing today, so no price is evidenced.
+   */
+  perBedEquivalent: number | null;
+  grade: 'verified' | 'open';
+  source: string;
+}
+
+/**
+ * The value ladder: what each step of the chain is worth per bed's worth of material.
+ *
+ * Every priced rung is what Goods ALREADY PAYS Defy, from a named invoice. The one
+ * unpriced rung is real and must stay unpriced: Goods does not buy sorted feedstock
+ * from anyone, because community-collected plastic enters the model at $0. A
+ * community that only collects has no one to sell to yet, and saying that plainly is
+ * worth more than a plausible number.
+ */
+export const VALUE_LADDER: LadderRung[] = [
+  {
+    module: 'collection_baling',
+    output: 'Sorted, caged HDPE ready to shred',
+    perBedEquivalent: null,
+    grade: 'open',
+    source: 'No purchase price exists. Feedstock enters the cost model at $0 (free, community-collected).',
+  },
+  {
+    module: 'shredding',
+    output: 'HDPE shred',
+    perBedEquivalent: _physics.hdpe_kg_per_bed * _defy.hdpe_shred_per_kg.amount, // 20kg x $2.00 = $40.00
+    grade: 'verified',
+    source: `Defy INV-1731: $${_defy.hdpe_shred_per_kg.amount.toFixed(2)}/kg x ${_physics.hdpe_kg_per_bed}kg per bed`,
+  },
+  {
+    module: 'pressing_cnc',
+    output: 'Finished HDPE leg kit, cut and edged',
+    perBedEquivalent: _defy.bed_kit_cut_finished.amount, // 344.05
+    grade: 'verified',
+    source: 'Defy INV-1602 (92 kits) + INV-1732 (50 kits)',
+  },
+  {
+    module: 'assembly',
+    output: 'A finished bed, ready to go out',
+    perBedEquivalent: _defy.bed_kit_cut_finished.amount + _defy.assembly_labour.amount, // 400.00
+    grade: 'verified',
+    source: 'Defy kit $344.05 + assembly labour $55.95 (2026-03-19 line)',
+  },
+  {
+    module: 'sales_delivery',
+    output: 'Beds in homes, sold by the community',
+    perBedEquivalent: 750,
+    grade: 'verified',
+    source: 'Stretch Bed shop price, canon',
+  },
+];
+
+/**
+ * The furthest rung a selection reaches, which is what decides its income line.
+ *
+ * Returns null on a selection with a hole in it (pressing without shredding), because
+ * such a run produces nothing: the value of what you hold is set by the LAST step you
+ * can actually complete, and you cannot complete a step whose input never arrives.
+ */
+export function furthestRung(keys: readonly string[]): LadderRung | null {
+  const ordered = FEED_ORDER.filter((k) => keys.includes(k));
+  if (ordered.length === 0) return null;
+
+  const first = FEED_ORDER.indexOf(ordered[0]);
+  const contiguous = ordered.every((k, i) => k === FEED_ORDER[first + i]);
+  if (!contiguous) return null;
+
+  const last = ordered[ordered.length - 1];
+  return VALUE_LADDER.find((r) => r.module === last) ?? null;
+}
+
+export interface CommunityEconomics {
+  /** Modules the community selected, in feed order. */
+  modules: readonly string[];
+  /** What they end up holding, and what it is worth per bed's worth of material. */
+  rung: LadderRung | null;
+  /** True when the selection has a hole in it, e.g. pressing with no shredding. */
+  brokenChain: boolean;
+  /**
+   * True when the run is contiguous but starts partway down the chain, so its input
+   * has to be bought in. Tennant Creek is the live case. Not a defect - but the
+   * bought-in input is a real cost this model does not carry.
+   */
+  buysInputIn: boolean;
+
+  setup: {
+    capexLow: number;
+    capexHigh: number;
+    /** False when any selected module has no price. Do not quote a total. */
+    priceable: boolean;
+    unpriced: string[];
+  };
+
+  annual: {
+    /** Beds' worth of material processed per year. */
+    volume: number;
+    /** What arrives at the community for what they produce. Null when the rung is unpriced. */
+    grossEarnings: number | null;
+    /** Cost of running the chosen modules: site floor plus each module's share. */
+    operatingCost: number;
+    /** grossEarnings less operatingCost. Null when unpriced. This is what the community has to pay people from. */
+    netToCommunity: number | null;
+  };
+
+  /** Things a human must decide. Never silently defaulted. */
+  openDecisions: string[];
+}
+
+/**
+ * Model one community's chosen modules at a given annual volume.
+ *
+ * `volume` is beds' worth of material per year, NOT beds sold. A shredding-only site
+ * processes material for beds that are finished somewhere else, and counting that as
+ * bed sales is exactly the capacity-as-revenue error the main model is careful to avoid.
+ */
+export function modelCommunity(
+  keys: readonly string[],
+  volume: number,
+  opts: { includeSiteBase?: boolean } = {},
+): CommunityEconomics {
+  const ordered = FEED_ORDER.filter((k) => keys.includes(k));
+  const rung = furthestRung(ordered);
+
+  // A run of modules must be CONTIGUOUS in feed order: you cannot press what was
+  // never shredded. It need not START at collection, though - Tennant Creek is the
+  // live case, buying shred in rather than collecting it - so that is a separate
+  // fact reported below, not a broken chain.
+  const firstIndex = ordered.length > 0 ? FEED_ORDER.indexOf(ordered[0]) : -1;
+  const brokenChain = ordered.some((k, i) => k !== FEED_ORDER[firstIndex + i]);
+  const buysInputIn = firstIndex > 0 && !brokenChain;
+
+  // No production modules means no production site, so no site base either. This
+  // mirrors priceModuleOperating, which returns zero for the same reason. Palm Island
+  // is the live case: they asked to start with governance, and charging them for a
+  // container they did not ask for is how a model turns a pathway into a sales pitch.
+  const hasProduction = ordered.length > 0;
+  const capex = hasProduction
+    ? priceModuleSelection(ordered, opts)
+    : { withBaseLow: 0, withBaseHigh: 0, priceable: true, unpriced: [] as string[], capexLow: 0, capexHigh: 0 };
+  const operating = priceModuleOperating(ordered);
+
+  const perUnit = rung?.perBedEquivalent ?? null;
+  const grossEarnings = perUnit === null ? null : perUnit * volume;
+  const netToCommunity = grossEarnings === null ? null : grossEarnings - operating.total;
+
+  const openDecisions: string[] = [];
+  if (rung?.grade === 'open') {
+    openDecisions.push(
+      `No one buys ${rung.output.toLowerCase()} today, so this selection has no income line yet. ` +
+        'Either the community goes one module further, or Goods agrees a feedstock price. That is a decision, not a calculation.',
+    );
+  }
+  if (!capex.priceable) {
+    openDecisions.push(
+      `Not priceable: ${capex.unpriced.join(', ')} has no quote. Do not present a setup total until it does.`,
+    );
+  }
+  if (brokenChain) {
+    openDecisions.push(
+      'Broken chain: a module is selected with nothing to feed it. This selection produces nothing, so it has no income line at all.',
+    );
+  }
+  if (buysInputIn) {
+    openDecisions.push(
+      `This run starts at ${ordered[0]}, so its input is bought in rather than collected on Country. ` +
+        'That purchase is a real cost and it is NOT in these figures.',
+    );
+  }
+  openDecisions.push(
+    'How the money splits between wages and community surplus is the community\'s call, not a model output.',
+  );
+  openDecisions.push(
+    'The network service fee is not agreed with any community. It falls as more sites join, which is why the third site improves the first community\'s deal.',
+  );
+
+  return {
+    modules: ordered,
+    rung,
+    brokenChain,
+    buysInputIn,
+    setup: {
+      capexLow: capex.withBaseLow,
+      capexHigh: capex.withBaseHigh,
+      priceable: capex.priceable,
+      unpriced: capex.unpriced,
+    },
+    annual: {
+      volume,
+      grossEarnings,
+      operatingCost: operating.total,
+      netToCommunity,
+    },
+    openDecisions,
+  };
+}
+
+/**
+ * The network block a community's service fee would contribute to, per site,
+ * at a given number of sites in the network.
+ *
+ * NOT AGREED WITH ANYONE. This is the arithmetic that shows why replication is in a
+ * community's interest and not only in Goods': the shared cost is flat, so every new
+ * site makes every existing site's share smaller.
+ */
+/**
+ * The modules each live pathway has actually asked for, read from the single place
+ * that records them. Ids are normalised because `community-pathways.ts` uses hyphens
+ * and `cost-model-scenarios.json` uses underscores; restating the module lists here
+ * to dodge that would create the second source of truth this file exists to avoid.
+ */
+export function pathwayModules(pathwayId: string): readonly string[] | null {
+  const key = pathwayId.replace(/-/g, '_');
+  const found = scenarios.capex_modules.live_pathways.find((p) => p.key === key);
+  return found ? found.modules : null;
+}
+
+/** Model a named community pathway. Returns null for an id with no recorded selection. */
+export function modelPathway(
+  pathwayId: string,
+  volume: number,
+  opts: { includeSiteBase?: boolean } = {},
+): CommunityEconomics | null {
+  const modules = pathwayModules(pathwayId);
+  return modules === null ? null : modelCommunity(modules, volume, opts);
+}
+
+export const NETWORK_BLOCK_PER_YEAR = 109_500;
+
+export function networkFeePerSite(sites: number): number {
+  if (sites < 1) throw new RangeError('sites must be at least 1');
+  return NETWORK_BLOCK_PER_YEAR / sites;
+}

--- a/v2/src/lib/cost-model/community-model.ts
+++ b/v2/src/lib/cost-model/community-model.ts
@@ -111,18 +111,43 @@ export const VALUE_LADDER: LadderRung[] = [
 ];
 
 /**
- * The furthest rung a selection reaches, which is what decides its income line.
+ * The four steps that physically depend on each other. You cannot press what was never
+ * shredded, so a run through these must be contiguous.
  *
- * Returns null on a selection with a hole in it (pressing without shredding), because
- * such a run produces nothing: the value of what you hold is set by the LAST step you
- * can actually complete, and you cannot complete a step whose input never arrives.
+ * `sales_delivery` is deliberately NOT one of them. Selling and delivering beds does not
+ * require having made them, and treating it as the last link of a physical chain was a
+ * modelling error that hid a real option: a community can supply beds to its own people
+ * without pressing a single leg. The original rule quietly forbade the most interesting
+ * thing Utopia could do.
  */
-export function furthestRung(keys: readonly string[]): LadderRung | null {
-  const ordered = FEED_ORDER.filter((k) => keys.includes(k));
+export const PHYSICAL_CHAIN = FEED_ORDER.filter((k) => k !== 'sales_delivery');
+
+/**
+ * What selling and delivering is worth per bed: the retail price less the cost of a
+ * finished bed ready to go.
+ *
+ * GROSS, NOT PROFIT. Freight into remote communities comes out of this and is not
+ * modelled anywhere, because we do not have the number. In Central Australia it is not
+ * small. Treat the shape as right and the size as unproven.
+ */
+export const SALES_SPREAD_PER_BED =
+  (VALUE_LADDER.find((r) => r.module === 'sales_delivery')!.perBedEquivalent ?? 0) -
+  (VALUE_LADDER.find((r) => r.module === 'assembly')!.perBedEquivalent ?? 0);
+
+/**
+ * The furthest PHYSICAL rung a selection reaches - what the community actually makes.
+ *
+ * Returns null on a run with a hole in it (pressing without shredding), because such a
+ * run produces nothing: the value of what you hold is set by the last step you can
+ * complete, and you cannot complete a step whose input never arrives. Also null when a
+ * community only sells, which is not a defect - they make nothing and earn on the spread.
+ */
+export function furthestPhysicalRung(keys: readonly string[]): LadderRung | null {
+  const ordered = PHYSICAL_CHAIN.filter((k) => keys.includes(k));
   if (ordered.length === 0) return null;
 
-  const first = FEED_ORDER.indexOf(ordered[0]);
-  const contiguous = ordered.every((k, i) => k === FEED_ORDER[first + i]);
+  const first = PHYSICAL_CHAIN.indexOf(ordered[0]);
+  const contiguous = ordered.every((k, i) => k === PHYSICAL_CHAIN[first + i]);
   if (!contiguous) return null;
 
   const last = ordered[ordered.length - 1];
@@ -132,8 +157,13 @@ export function furthestRung(keys: readonly string[]): LadderRung | null {
 export interface CommunityEconomics {
   /** Modules the community selected, in feed order. */
   modules: readonly string[];
-  /** What they end up holding, and what it is worth per bed's worth of material. */
+  /** The furthest thing they MAKE, and what it is worth. Null when they only sell. */
   rung: LadderRung | null;
+  /** True when the selection includes selling and delivering. */
+  sells: boolean;
+  /** Per bed: what making earns, what selling earns. Either may be null. */
+  makingPerBed: number | null;
+  sellingPerBed: number | null;
   /** True when the selection has a hole in it, e.g. pressing with no shredding. */
   brokenChain: boolean;
   /**
@@ -179,14 +209,19 @@ export function modelCommunity(
   opts: { includeSiteBase?: boolean } = {},
 ): CommunityEconomics {
   const ordered = FEED_ORDER.filter((k) => keys.includes(k));
-  const rung = furthestRung(ordered);
+  const rung = furthestPhysicalRung(ordered);
+  const sells = ordered.includes('sales_delivery');
+  const makesFinishedBeds = rung?.module === 'assembly';
 
   // A run of modules must be CONTIGUOUS in feed order: you cannot press what was
   // never shredded. It need not START at collection, though - Tennant Creek is the
   // live case, buying shred in rather than collecting it - so that is a separate
   // fact reported below, not a broken chain.
-  const firstIndex = ordered.length > 0 ? FEED_ORDER.indexOf(ordered[0]) : -1;
-  const brokenChain = ordered.some((k, i) => k !== FEED_ORDER[firstIndex + i]);
+  // Contiguity is judged over the PHYSICAL chain only. Sales is excluded because it
+  // does not consume the step before it.
+  const physical = PHYSICAL_CHAIN.filter((k) => keys.includes(k));
+  const firstIndex = physical.length > 0 ? PHYSICAL_CHAIN.indexOf(physical[0]) : -1;
+  const brokenChain = physical.some((k, i) => k !== PHYSICAL_CHAIN[firstIndex + i]);
   const buysInputIn = firstIndex > 0 && !brokenChain;
 
   // No production modules means no production site, so no site base either. This
@@ -199,7 +234,24 @@ export function modelCommunity(
     : { withBaseLow: 0, withBaseHigh: 0, priceable: true, unpriced: [] as string[], capexLow: 0, capexHigh: 0 };
   const operating = priceModuleOperating(ordered);
 
-  const perUnit = rung?.perBedEquivalent ?? null;
+  // Two income lines that stack, because they are different work.
+  //
+  // MAKING earns the value of the furthest physical step completed. SELLING earns the
+  // spread between a finished bed and a bed in a home, whether or not this community
+  // made that bed - a community that sells beds pressed elsewhere is running a real
+  // distribution business, and the earlier model refused to see it.
+  //
+  // The two are consistent at the top of the chain: assembly ($400) plus the sales
+  // spread ($350) is the $750 retail price, which is exactly what the ladder says a
+  // community holding a bed in a home has.
+  const makingPerBed = rung?.perBedEquivalent ?? null;
+  const sellingPerBed = sells ? SALES_SPREAD_PER_BED : null;
+
+  const perUnit =
+    makingPerBed === null && sellingPerBed === null
+      ? null
+      : (makingPerBed ?? 0) + (sellingPerBed ?? 0);
+
   const grossEarnings = perUnit === null ? null : perUnit * volume;
   const netToCommunity = grossEarnings === null ? null : grossEarnings - operating.total;
 
@@ -220,6 +272,20 @@ export function modelCommunity(
       'Broken chain: a module is selected with nothing to feed it. This selection produces nothing, so it has no income line at all.',
     );
   }
+  if (sells) {
+    openDecisions.push(
+      `Selling is counted at the gross spread of $${SALES_SPREAD_PER_BED} a bed, which is the retail price less ` +
+        'the cost of a finished bed. Freight into community comes out of that and is NOT modelled anywhere. ' +
+        'In Central Australia it is not small, so treat this line as the right shape and an unproven size.',
+    );
+  }
+  if (sells && !makesFinishedBeds) {
+    openDecisions.push(
+      'This community would sell beds it did not build, buying them in finished. That is a real business and a ' +
+        'different relationship from making them - worth putting to community as its own question, not as a ' +
+        'smaller version of a factory.',
+    );
+  }
   if (buysInputIn) {
     openDecisions.push(
       `This run starts at ${ordered[0]}, so its input is bought in rather than collected on Country. ` +
@@ -236,6 +302,9 @@ export function modelCommunity(
   return {
     modules: ordered,
     rung,
+    sells,
+    makingPerBed,
+    sellingPerBed,
     brokenChain,
     buysInputIn,
     setup: {

--- a/v2/src/lib/data/community-pathways.ts
+++ b/v2/src/lib/data/community-pathways.ts
@@ -355,11 +355,16 @@ export const COMMUNITY_PATHWAYS: CommunityPathway[] = [
       cost: {
         capexLow: 24800,
         capexHigh: 39300,
-        operatingPerYear: 16043,
+        // 2026-08-03: was 16043, which was the MODULE SHARE only. The note below always
+        // claimed the $35,000 site floor was included and it never was, understating the
+        // running cost of Utopia's own pathway by 3.2x. Nothing rendered this field, so it
+        // never reached a page - the community-model one-pager is its first reader, and it
+        // computes from priceModuleOperating() rather than trusting this number.
+        operatingPerYear: 51043,
         status: 'modelled',
         costSource:
           'priceModuleSelection() and priceModuleOperating(), capex_modules in cost-model-scenarios.json',
-        note: 'The pathway the old build-path ladder could not cost at all, against $79,333/yr for a full facility. Operating is the $35,000/yr site floor apportioned plus the chosen modules. The width of the capex band is almost entirely one question: whether a baler is needed, given rigid HDPE is normally caged rather than baled. Collection is a $5,000 to $19,500 estimate, priced the way the DEWR budget already treats its own unquoted lines.',
+        note: 'The pathway the old build-path ladder could not cost at all, against $79,333/yr for a full facility. Operating is the $35,000/yr site floor PLUS $16,043 of chosen module share. The floor is most of it, and it is incurred the moment anyone works on the site at all, which is why the earliest module in the chain is the hardest one to make pay. The width of the capex band is almost entirely one question: whether a baler is needed, given rigid HDPE is normally caged rather than baled. Collection is a $5,000 to $19,500 estimate, priced the way the DEWR budget already treats its own unquoted lines.',
       },
       ownsWhat:
         'Urapuntja owns the machine. Goods supplies training, the maintenance pathway and parts.',

--- a/v2/src/lib/data/next-phase.guards.test.ts
+++ b/v2/src/lib/data/next-phase.guards.test.ts
@@ -115,7 +115,12 @@ describe('the priced pathways', () => {
     expect(c.capexLow!).toBeLessThan(c.capexHigh!);
     expect(c.capexLow).toBe(24800);
     expect(c.capexHigh).toBe(39300);
-    expect(c.operatingPerYear).toBe(16043);
+    // 2026-08-03: was pinned at 16043, the MODULE SHARE alone. priceModuleOperating()
+    // returns the $35,000 site floor PLUS the share, and the note on the record always
+    // said the floor was included. This guard held the understatement in place: the
+    // figure and the test agreed with each other and both disagreed with the engine.
+    // Assert the composition, not just the total, so it cannot drift back.
+    expect(c.operatingPerYear).toBe(35000 + 16043);
     expect(c.costSource).toMatch(/priceModule/);
   });
 

--- a/v2/src/lib/data/route-audience.ts
+++ b/v2/src/lib/data/route-audience.ts
@@ -1409,6 +1409,14 @@ export const ROUTE_AUDIENCES: RouteAudience[] = [
     verdict: 'keep',
   },
   {
+    route: '/pathways/[id]/numbers',
+    audience: 'community',
+    access: 'open',
+    leadsWithNow: null,
+    whyUnread: 'dynamic route with no nameable representative instance',
+    verdict: 'keep',
+  },
+  {
     route: '/pitch',
     audience: 'funder',
     access: 'open',


### PR DESCRIPTION
Every money surface in this repo answered Goods' question: does the bed business wash its own face. A community asking "what is in it for us" got one scenario row reading "margin stays in community", with no arithmetic behind it. This is that arithmetic, plus the page that says it back to a community.

## The value ladder, evidenced not invented

A partial module set does not make beds. Utopia's chosen pair makes shred. Only a run reaching assembly makes a $750 bed. Every rung below a finished bed already has a price, because Goods buys all of them from Defy today:

`collection (nobody buys this) -> shred $40 -> kit $344.05 -> bed $400 -> sold $750`

From INV-1731, INV-1602 and INV-1732. The offer to a community is checkable: this money goes to Sydney today, and we would rather it went to the community doing the work.

## Selling does not depend on making

Contiguity is right for the physical steps and wrong for sales and delivery. Treating sales as the last link of a physical chain quietly forbade the most interesting option a shredder community has. `PHYSICAL_CHAIN` is now the four making steps; sales stands alone and stacks. Guard: assembly ($400) + spread ($350) must equal $750, so the two income lines cannot double count.

At 450 beds' worth of material a year:

| Option | Setup | Net |
|---|---|---|
| collect + shred (today's ask) | $56.6K-$103.3K | -$33,043 |
| collect + shred + SELL | $56.6K-$103.3K | +$122,657 |
| collect + shred + PRESS | $89.4K-$136.1K | +$83,742 |

Selling is worth more than pressing and needs no extra capex.

## Framing

A negative result is a statement about which POT a step sits in, not a community running at a loss. No community puts in capital or covers running costs. The page says "this step needs about $X a year of grant behind it" and "this is not money the community is out of pocket".

## Fixed on the way

- Utopia's stored `operatingPerYear` was $16,043, the module share alone, with the note claiming the $35,000 site floor was included. A 3.2x understatement held in place by a guard asserting the wrong figure. Nothing rendered it, so it never reached production.
- The model charged Palm Island $31,800-$64,000 for a site base they never asked for.
- Tennant Creek reads high because its bought-in plastic is uncosted; the caveat now renders beside the number.
- The workbook's MODEL tab said the FY26 expense split was the highest-value outstanding item while the Xero tab answered it, and the Open Questions row carried status `open` above an answer beginning "ANSWERED".

## Not oversold, all in `openDecisions` and on the tab

Freight is not modelled. The $350 spread assumes a community buys a finished bed at Goods' own cost with no margin. Sell-only still carries a press-line site base it should not need.

`/pathways/[id]/numbers` is noindexed, out of every menu, opens with a banner saying it is ours to check rather than theirs to accept, and computes from the engine at render time.

Gates: 35 guards on the model, 493 across the suite, typecheck, `check:audience`, `check:drift:ci`, build clean.