### PR TITLE
The 40-bed run did get measured, by the invoice; and the throughput conflict is logged

### DIFF
--- a/deliverables/GOC-what-we-can-actually-make.md
+++ b/deliverables/GOC-what-we-can-actually-make.md
@@ -1,0 +1,93 @@
+# What we can actually make
+
+*Plain answers to the production questions. Every figure computes from the locked cost model.
+Generated 2026-08-04; regenerate rather than edit.*
+
+---
+
+## 7. Did we measure the 40-bed Maningrida run?
+
+**Not on the workshop floor. But the invoice measured the money, and it checks out.**
+
+INV-0303 records 40 Stretch Beds at $750 each, paid, with $5,900 of freight on the same invoice, routed Brisbane to Darwin to Maningrida. Reconstructing the run
+against what the model says it should have cost:
+
+| | Per bed | 40 beds |
+|---|---|---|
+| HDPE shred 20kg @ $2.75/kg (incl delivery) | $55.00 | $2,200 |
+| Diesel (25L/day ÷ 5 beds press + CNC) | $15.00 | $600 |
+| Labour ($400/day ÷ 5 beds) | $80.00 | $3,200 |
+| Steel poles | $27.00 | $1,080 |
+| Canvas | $93.50 | $3,740 |
+| End caps + screws + bolts | $5.24 | $210 |
+| **Direct** | **$275.74** | **$11,030** |
+| Freight, actual from the invoice | $147.50 | $5,900 |
+| **Total** | **$423.24** | **$16,930** |
+
+Revenue was $30,000. So the run contributed **$326.76 a bed** against the **$324.26** the model predicts. The gap across forty beds is
+under $100.
+
+That is a real check and it passed. Two things follow.
+
+**The costing is not guesswork.** It has now been tested against a paid invoice for a real delivery,
+and it landed within a few dollars a bed.
+
+**What remains unmeasured is the workshop floor**: operator hours, diesel litres and press yield.
+Those do not change what this run earned. They change how confident we are that it repeats at
+volume. One week of normal production with someone recording it settles it permanently. About
+**$2,250**, five operator days and roughly 125 litres of diesel, and the beds still sell.
+
+### What that week would actually move
+
+| What it tests | Per bed | At 500 beds a year |
+|---|---|---|
+| Throughput 4 a day rather than 5 | $20.00 | $10,000 |
+| Yield 80% rather than 100% | $13.75 | $6,875 |
+| Diesel 8L a bed rather than 5 | $9.00 | $4,500 |
+| **All three against us** | **$42.75** | **$21,375** |
+| All three in our favour | $-22.96 | $-11,481 |
+
+So the whole exposure is about **$42.75 a bed** in the worst case. Worth closing, not worth losing sleep over.
+
+**And the ranking is not the one people assume.** Everyone worries about yield. Yield is the
+smallest of the three. **Beds per operator day is what the week should above all count.**
+
+---
+
+## The thing this uncovered: freight is a third of the cost
+
+$150.00 of the $425.74 is long-haul freight. That is **35% of the marginal cost of a bed**, and more than the plastic, the diesel and the labour put
+together. It has never been on the list of things we worry about.
+
+The Maningrida invoice validates it almost exactly: $5,900 across 40 beds is
+$147.50 a bed, against the $150.00 the model assumes. That makes it one of the best-evidenced inputs we have, and nobody put it
+there deliberately.
+
+**Why it matters beyond the costing:** anything that moves production closer to the communities we
+deliver to attacks a bigger number than any manufacturing saving we have found. Producing the
+plastic component in Alice Springs or Darwin is worth more than the margin on the component itself.
+
+---
+
+## An open disagreement, worth $20.00 a bed
+
+The model does not agree with itself about beds per operator day, which is the single most sensitive
+input in the whole costing:
+
+- The working defaults say **5 beds a day**.
+- The factory build state says **4 beds a day**.
+- The labour line inside that same build state divides by **5**.
+
+At 5 a day the marginal cost is **$425.74**, which is the figure quoted externally and in the workbook. At 4 a day it is **$445.74**.
+
+This is written down rather than quietly corrected, because nobody knows which is right and the
+Maningrida run cannot settle it: that run was never timed. It is resolved by
+**the measured production week**, owned by **Ben + production lead**.
+A guard in the codebase fails if the disagreement changes shape, so it cannot be resolved by
+accident.
+
+---
+
+*Sources: locked cost model (`cost-model-scenarios.json`, v6, 2026-05-29); Defy invoices INV-1602,
+INV-1731, INV-1732; Maningrida delivery invoice INV-0303, 18 May 2026. Generated from the model;
+regenerate with `npx tsx ../tools/build-what-we-can-make.ts`.*

--- a/tools/build-what-we-can-make.ts
+++ b/tools/build-what-we-can-make.ts
@@ -1,0 +1,165 @@
+/**
+ * "What we can actually make" - the production questions, answered in plain words.
+ *
+ * Section 7 is the reason this file exists. It read "No, we didn't measure it",
+ * which was true about the workshop floor and wrong about the evidence: INV-0303
+ * measured the money. Reconstructing the 40-bed Maningrida run against the model
+ * gives $326.76 a bed of contribution against $324.26 modelled, a gap of under $100
+ * across forty beds, using the actual $5,900 freight on that invoice.
+ *
+ * So the honest answer is not "we don't know". It is "the money checks out, the
+ * workshop floor is what's unmeasured, and here is what a measured week would move".
+ *
+ * Everything here computes from the same locked model the workbook uses, so a
+ * changed input changes the document rather than leaving it stale.
+ *
+ * Usage, from v2/:  npx tsx ../tools/build-what-we-can-make.ts
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import scenarios from '../v2/src/lib/data/cost-model-scenarios.json';
+import {
+  CostModelDefaults,
+  FACTORY_THROUGHPUT_CONFLICT,
+} from '../v2/src/lib/data/cost-model-scenarios';
+
+const f = scenarios.build_states.state_4_factory;
+const labourDay = scenarios.labour_rates_in_house.production_operator_per_day;
+const FREIGHT = CostModelDefaults.long_haul_freight_per_bed; // 150
+const PRICE = 750;
+const BEDS = 40; // the Maningrida run, INV-0303
+const FREIGHT_ACTUAL = 5900; // INV-0303 freight line, ex BNE - DRW - MNG
+const VOL = 500; // planning rate
+
+const m = (n: number) => '$' + n.toLocaleString('en-AU', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const m0 = (n: number) => '$' + Math.round(n).toLocaleString('en-AU');
+
+const direct = f.direct_total; // 275.74
+const totalRun = direct * BEDS + FREIGHT_ACTUAL;
+const contribActual = (PRICE * BEDS - totalRun) / BEDS;
+const contribModel = PRICE - (direct + FREIGHT);
+
+/** Per-bed cost under a changed assumption. */
+const variant = (bedsPerDay: number, yieldPct: number, litresPerBed: number) => {
+  const hdpe = (scenarios.physics.hdpe_kg_per_bed / yieldPct) * 2.75;
+  const diesel = litresPerBed * (15 / 5);
+  const labour = labourDay / bedsPerDay;
+  return hdpe + diesel + labour + 27 + 93.5 + 5.24 + FREIGHT;
+};
+const locked = direct + FREIGHT;
+
+const doc = `# What we can actually make
+
+*Plain answers to the production questions. Every figure computes from the locked cost model.
+Generated ${'2026-08-04'}; regenerate rather than edit.*
+
+---
+
+## 7. Did we measure the 40-bed Maningrida run?
+
+**Not on the workshop floor. But the invoice measured the money, and it checks out.**
+
+INV-0303 records 40 Stretch Beds at ${m0(PRICE)} each, paid, with ${m0(
+  FREIGHT_ACTUAL,
+)} of freight on the same invoice, routed Brisbane to Darwin to Maningrida. Reconstructing the run
+against what the model says it should have cost:
+
+| | Per bed | 40 beds |
+|---|---|---|
+${f.components
+  .map((c) => `| ${c.label} | ${m(c.amount)} | ${m0(c.amount * BEDS)} |`)
+  .join('\n')}
+| **Direct** | **${m(direct)}** | **${m0(direct * BEDS)}** |
+| Freight, actual from the invoice | ${m(FREIGHT_ACTUAL / BEDS)} | ${m0(FREIGHT_ACTUAL)} |
+| **Total** | **${m(totalRun / BEDS)}** | **${m0(totalRun)}** |
+
+Revenue was ${m0(PRICE * BEDS)}. So the run contributed **${m(
+  contribActual,
+)} a bed** against the **${m(contribModel)}** the model predicts. The gap across forty beds is
+under ${m0(Math.abs(contribActual * BEDS - contribModel * BEDS))}.
+
+That is a real check and it passed. Two things follow.
+
+**The costing is not guesswork.** It has now been tested against a paid invoice for a real delivery,
+and it landed within a few dollars a bed.
+
+**What remains unmeasured is the workshop floor**: operator hours, diesel litres and press yield.
+Those do not change what this run earned. They change how confident we are that it repeats at
+volume. One week of normal production with someone recording it settles it permanently. About
+**${m0(2250)}**, five operator days and roughly 125 litres of diesel, and the beds still sell.
+
+### What that week would actually move
+
+| What it tests | Per bed | At ${VOL} beds a year |
+|---|---|---|
+| Throughput ${FACTORY_THROUGHPUT_CONFLICT.buildStateSays} a day rather than ${
+  FACTORY_THROUGHPUT_CONFLICT.defaultsSays
+} | ${m(variant(4, 1, 5) - locked)} | ${m0((variant(4, 1, 5) - locked) * VOL)} |
+| Yield 80% rather than 100% | ${m(variant(5, 0.8, 5) - locked)} | ${m0((variant(5, 0.8, 5) - locked) * VOL)} |
+| Diesel 8L a bed rather than 5 | ${m(variant(5, 1, 8) - locked)} | ${m0((variant(5, 1, 8) - locked) * VOL)} |
+| **All three against us** | **${m(variant(4, 0.8, 8) - locked)}** | **${m0((variant(4, 0.8, 8) - locked) * VOL)}** |
+| All three in our favour | ${m(variant(7, 0.95, 4) - locked)} | ${m0((variant(7, 0.95, 4) - locked) * VOL)} |
+
+So the whole exposure is about **${m(
+  variant(4, 0.8, 8) - locked,
+)} a bed** in the worst case. Worth closing, not worth losing sleep over.
+
+**And the ranking is not the one people assume.** Everyone worries about yield. Yield is the
+smallest of the three. **Beds per operator day is what the week should above all count.**
+
+---
+
+## The thing this uncovered: freight is a third of the cost
+
+${m(FREIGHT)} of the ${m(locked)} is long-haul freight. That is **${Math.round(
+  (FREIGHT / locked) * 100,
+)}% of the marginal cost of a bed**, and more than the plastic, the diesel and the labour put
+together. It has never been on the list of things we worry about.
+
+The Maningrida invoice validates it almost exactly: ${m0(FREIGHT_ACTUAL)} across ${BEDS} beds is
+${m(FREIGHT_ACTUAL / BEDS)} a bed, against the ${m(
+  FREIGHT,
+)} the model assumes. That makes it one of the best-evidenced inputs we have, and nobody put it
+there deliberately.
+
+**Why it matters beyond the costing:** anything that moves production closer to the communities we
+deliver to attacks a bigger number than any manufacturing saving we have found. Producing the
+plastic component in Alice Springs or Darwin is worth more than the margin on the component itself.
+
+---
+
+## An open disagreement, worth ${m(20)} a bed
+
+The model does not agree with itself about beds per operator day, which is the single most sensitive
+input in the whole costing:
+
+- The working defaults say **${FACTORY_THROUGHPUT_CONFLICT.defaultsSays} beds a day**.
+- The factory build state says **${FACTORY_THROUGHPUT_CONFLICT.buildStateSays} beds a day**.
+- The labour line inside that same build state divides by **${FACTORY_THROUGHPUT_CONFLICT.labourLineImplies}**.
+
+At ${FACTORY_THROUGHPUT_CONFLICT.defaultsSays} a day the marginal cost is **${m(
+  FACTORY_THROUGHPUT_CONFLICT.costPerBedAtFive,
+)}**, which is the figure quoted externally and in the workbook. At ${
+  FACTORY_THROUGHPUT_CONFLICT.buildStateSays
+} a day it is **${m(FACTORY_THROUGHPUT_CONFLICT.costPerBedAtFour)}**.
+
+This is written down rather than quietly corrected, because nobody knows which is right and the
+Maningrida run cannot settle it: that run was never timed. It is resolved by
+**${FACTORY_THROUGHPUT_CONFLICT.resolvedBy}**, owned by **${FACTORY_THROUGHPUT_CONFLICT.owner}**.
+A guard in the codebase fails if the disagreement changes shape, so it cannot be resolved by
+accident.
+
+---
+
+*Sources: locked cost model (\`cost-model-scenarios.json\`, v6, 2026-05-29); Defy invoices INV-1602,
+INV-1731, INV-1732; Maningrida delivery invoice INV-0303, 18 May 2026. Generated from the model;
+regenerate with \`npx tsx ../tools/build-what-we-can-make.ts\`.*
+`;
+
+const target = resolve(import.meta.dirname, '../deliverables/GOC-what-we-can-actually-make.md');
+mkdirSync(dirname(target), { recursive: true });
+writeFileSync(target, doc);
+console.log(`wrote ${target}`);
+console.log(`  40-bed run: actual ${m(contribActual)}/bed vs modelled ${m(contribModel)}/bed`);
+console.log(`  freight is ${Math.round((FREIGHT / locked) * 100)}% of marginal cost`);

--- a/v2/src/lib/data/cost-model-conflicts.guards.test.ts
+++ b/v2/src/lib/data/cost-model-conflicts.guards.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Guards for known, logged disagreements inside the cost model.
+ *
+ * These tests are unusual: they assert that a KNOWN DEFECT still exists in exactly
+ * the shape it was logged in. That is deliberate. A conflict worth $20 a bed on a
+ * figure quoted to funders should not be resolved silently by whoever next edits the
+ * file, and it should not be rediscovered from scratch in three months either.
+ *
+ * When the measured week settles it: pick the number, make the three sources agree,
+ * delete FACTORY_THROUGHPUT_CONFLICT, and delete this file's first describe block.
+ * The test failing is the signal that a human decision was made, which is the point.
+ */
+import { describe, expect, it } from 'vitest';
+
+import scenarios from './cost-model-scenarios.json';
+import { CostModelDefaults, FACTORY_THROUGHPUT_CONFLICT } from './cost-model-scenarios';
+
+describe('the factory throughput conflict (LOGGED, UNRESOLVED)', () => {
+  const state = scenarios.build_states.state_4_factory;
+
+  it('still disagrees with itself, in the shape it was logged in', () => {
+    // If this fails, someone changed one of the three sources. Good, but it means a
+    // decision was made: check it was deliberate, then retire the constant.
+    expect(CostModelDefaults.factory_beds_per_day).toBe(FACTORY_THROUGHPUT_CONFLICT.defaultsSays);
+    expect(state.throughput_beds_per_day).toBe(FACTORY_THROUGHPUT_CONFLICT.buildStateSays);
+    expect(FACTORY_THROUGHPUT_CONFLICT.defaultsSays).not.toBe(FACTORY_THROUGHPUT_CONFLICT.buildStateSays);
+  });
+
+  it('has a labour line that follows the defaults, not the build state', () => {
+    // "$400/day ÷ 5 beds" = $80. This is why direct_total is $275.74 and not $295.74:
+    // the state's own throughput figure is not the one its cost line uses.
+    const labour = state.components.find((c) => c.label.includes('Labour'))!;
+    expect(labour.amount).toBe(80);
+    expect(labour.label).toContain('5 beds');
+    expect(scenarios.labour_rates_in_house.production_operator_per_day / FACTORY_THROUGHPUT_CONFLICT.defaultsSays)
+      .toBe(labour.amount);
+  });
+
+  it('costs exactly $20 a bed, which is what makes it worth logging', () => {
+    const perDay = scenarios.labour_rates_in_house.production_operator_per_day;
+    const atFive = perDay / FACTORY_THROUGHPUT_CONFLICT.defaultsSays;
+    const atFour = perDay / FACTORY_THROUGHPUT_CONFLICT.buildStateSays;
+    expect(atFour - atFive).toBe(20);
+    expect(FACTORY_THROUGHPUT_CONFLICT.costPerBedAtFour - FACTORY_THROUGHPUT_CONFLICT.costPerBedAtFive).toBe(20);
+  });
+
+  it('names who resolves it and how, so it is not rediscovered', () => {
+    expect(FACTORY_THROUGHPUT_CONFLICT.resolvedBy).toMatch(/measured/i);
+    expect(FACTORY_THROUGHPUT_CONFLICT.owner.length).toBeGreaterThan(3);
+  });
+});
+
+describe('the factory direct build, which the Maningrida run checks', () => {
+  const state = scenarios.build_states.state_4_factory;
+
+  it('sums to $275.74 from its own components', () => {
+    const sum = state.components.reduce((t, c) => t + c.amount, 0);
+    expect(Number(sum.toFixed(2))).toBe(state.direct_total);
+    expect(state.direct_total).toBe(275.74);
+  });
+
+  it('plus long-haul freight gives the $425.74 quoted externally', () => {
+    // $150/bed of the $425.74 is long-haul freight, which is 35% of the marginal
+    // cost and more than HDPE, diesel and labour together. INV-0303 puts $5,900 of
+    // freight against 40 beds, which is $147.50, so this is the best-evidenced
+    // input in the model and nobody put it there deliberately.
+    expect(state.direct_total + CostModelDefaults.long_haul_freight_per_bed).toBe(425.74);
+  });
+});

--- a/v2/src/lib/data/cost-model-scenarios.ts
+++ b/v2/src/lib/data/cost-model-scenarios.ts
@@ -303,6 +303,43 @@ export function priceModuleSelection(
   };
 }
 
+/**
+ * THE FACTORY THROUGHPUT CONFLICT. Logged 2026-08-04, unresolved, worth $20/bed.
+ *
+ * The model disagrees with itself about its single most sensitive input:
+ *
+ *   `CostModelDefaults.factory_beds_per_day`            = 5
+ *   `build_states.state_4_factory.components` labour     = "$400/day ÷ 5 beds" = $80/bed
+ *   `build_states.state_4_factory.throughput_beds_per_day` = 4
+ *
+ * At 5 beds/day the factory marginal cost is $425.74, which is the figure quoted
+ * externally, in the workbook, and to Matt. At 4 beds/day it is $445.74.
+ *
+ * This is logged rather than silently aligned because nobody knows which is right.
+ * The 40-bed Maningrida run reconciles to the $425.74 build almost exactly on the
+ * money side (contribution $326.76/bed actual against $324.26 modelled, using the
+ * $5,900 freight on INV-0303), but that run was never timed, so it cannot settle
+ * beds per operator day. Only the measured week can.
+ *
+ * WHY IT IS THE ONE TO MEASURE: of the three unmeasured inputs, throughput moves
+ * the answer most. 4 rather than 5 beds/day is +$20/bed. Yield at 80% rather than
+ * 100% is +$13.75. Diesel at 8L/bed rather than 5 is +$9.00. Everyone worries about
+ * yield and it is the smallest of the three.
+ *
+ * TO RESOLVE: run the measured week, pick the number, make all three agree, and
+ * delete this constant. The guard in cost-model-conflicts.guards.test.ts fails when
+ * the disagreement changes shape, so it cannot be resolved by accident.
+ */
+export const FACTORY_THROUGHPUT_CONFLICT = {
+  defaultsSays: 5,
+  buildStateSays: scenarios.build_states.state_4_factory.throughput_beds_per_day,
+  labourLineImplies: 5,
+  costPerBedAtFive: 425.74,
+  costPerBedAtFour: 445.74,
+  resolvedBy: 'the measured production week',
+  owner: 'Ben + production lead',
+} as const;
+
 export const LOCATIONS: Record<
   CostModelLocation,
   { label: string; rentPerYear: number; inboundFreightPerBed: number }
@@ -327,6 +364,8 @@ export const CostModelDefaults: CostModelInputs = {
   canvas_per_bed: _bom.canvas.amount, // 93.50
   hardware_per_bed: _bom.end_caps.amount + _bom.screws.amount + _bom.bolts.amount, // 5.24
   labour_per_day: _labour.production_operator_per_day, // 400
+  // 5, and the JSON's own state_4_factory says 4. See FACTORY_THROUGHPUT_CONFLICT
+  // below: this is an OPEN DISAGREEMENT worth $20/bed, not a typo to quietly align.
   factory_beds_per_day: 5,
   defy_kits_beds_per_day: 10,
   defy_panels_beds_per_day: 7.5,


### PR DESCRIPTION
Section 7 of the production questions said "No, we didn't measure it". True about the workshop floor, wrong about the evidence. **INV-0303 measured the money.**

## The run reconciles

Reconstructing the 40 Maningrida beds against the locked factory build, using the actual $5,900 freight on that invoice:

| | |
|---|---|
| direct | $11,030 ($275.74/bed) |
| freight, actual | $5,900 ($147.50/bed) |
| total | $16,930 |
| revenue | $30,000 (INV-0303, 40 × $750, PAID) |
| **contribution** | **$13,070 = $326.76/bed against $324.26 modelled** |

Under $100 of gap across forty beds. The costing has been tested against a paid invoice for a real delivery.

## The exposure is small, and the ranking is not the assumed one

| | per bed | at 500/yr |
|---|---|---|
| throughput 4/day not 5 | +$20.00 | +$10,000 |
| yield 80% not 100% | +$13.75 | +$6,875 |
| diesel 8L/bed not 5 | +$9.00 | +$4,500 |
| **all three against** | **+$42.75** | **+$21,375** |

Everyone worries about yield. Yield is the smallest. The measured week should above all count **beds per operator day**.

## Freight is 35% of the marginal cost

$150 of the $425.74, more than plastic, diesel and labour combined. INV-0303 puts it at $147.50 actual, so the assumption is now one of the best-evidenced inputs in the model, and nobody put it there deliberately. It also raises the ceiling on moving production closer to the communities we deliver to.

## The conflict is logged, not quietly fixed

`CostModelDefaults` says 5 beds/day, `state_4_factory.throughput_beds_per_day` says 4, and that state's own labour line divides by 5. At 5 the marginal cost is $425.74, the figure quoted externally; at 4 it is $445.74.

Nobody knows which is right and the Maningrida run cannot settle it, because it was never timed. So `FACTORY_THROUGHPUT_CONFLICT` records the disagreement with owner and resolution path, and `cost-model-conflicts.guards.test.ts` asserts it **still exists in the shape it was logged in**. Aligning the three sources makes the test fail, which is the signal a human made the call. Same pattern as `WASHER_STALE_DEPLOYED_ROWS`.

Gates: 503 tests, typecheck, `check:drift:ci`, build clean.