### PR TITLE
NT Corrections: the one-pager, the decision note, and the background pack

### DIFF
--- a/deliverables/NT-Corrections-decision-note.md
+++ b/deliverables/NT-Corrections-decision-note.md
@@ -1,0 +1,169 @@
+# NT Corrections: decision note
+
+**For: Ben, Nic, Defy. Internal. Not the proposal.**
+*Prepared 2026-08-04, after the call with Bodie and the follow-up with Defy. Every rate is from a
+paid Defy invoice. The one unknown is named in section 3 and it decides the rest.*
+
+---
+
+## 1. What is being decided
+
+Whether to put a two-station production proposal to NT Correctional Industries, at what scope, on
+whose paper, and where it sits against everything else competing for August. Five specific
+decisions are listed in section 8.
+
+---
+
+## 2. What this opportunity actually is, now that the scope has narrowed
+
+The first version of this idea had Corrections running the line through to finished beds, and
+answering the demand question at the same time. The call with Defy narrowed it, correctly, to two
+stations producing **inputs**: washing and shredding, and utility panel pressing.
+
+**That change moves NT Corrections from the demand side to the supply side.**
+
+It is worth being blunt about what that means. Goods is not short of ways to make a bed. Goods is
+short of people who have agreed to buy one. This partnership does not touch that. It is a **cost and
+capability play**, and judging it as a revenue play will lead to the wrong decision.
+
+The separate question, whether NT Corrections might **buy** beds for its own facilities, is still
+open and is worth its own conversation. Note they already list bedding manufacture among their
+industries, which cuts both ways.
+
+---
+
+## 3. The number that decides everything: panel yield
+
+Goods buys a cut and finished leg kit for **$344.05** per bed today. The alternative is
+to buy a pressed panel from Corrections and pay to cut and finish it. Both halves of that are
+invoiced rates, so the only unknown is **how many bed sets come out of one panel**.
+
+| Bed sets per panel | Panel cost per bed | Plus cut and finish | Landed leg cost | Saving vs $344.05 | At 500 beds/yr |
+|---|---|---|---|---|---|
+| 1 | $200.00 | $121.00 | **$321.00** | $23.05 | $11,525 |
+| 2 | $100.00 | $121.00 | **$221.00** | $123.05 | $61,525 |
+| 3 | $66.67 | $121.00 | **$187.67** | $156.38 | $78,192 |
+
+**If one panel makes one bed set, this is not worth doing.** $23.05 a bed does not justify a government procurement process, an advisory council, months of founder
+time and a reputational exposure. If a panel makes two or more, it is a serious saving and worth
+pursuing properly.
+
+**This is one question to Defy and it should be answered before anything else moves.** A panel is
+1200 × 1200 × 19mm, which is 1.44m². Two crossed X-trestles per bed is four planks. Whether that
+nests at two sets a panel or one is a cutting-diagram question Defy can answer from experience.
+
+*(The rough area estimate suggests two is plausible. That is an estimate from panel dimensions, not
+a nesting diagram, and it is not good enough to decide on.)*
+
+Shred, if that is all Corrections does, is worth **$40 per bed's worth** at
+$2.00/kg. Real, but small.
+
+---
+
+## 4. The costs
+
+**Equipment.** Shredder $19,800, pressing and CNC $32,780. About **$52,580 per station set**, and twice that if both Darwin and Alice. Goods
+has $0 of signed capital today, so this is funded by Corrections, by Defy, or it waits for the raise.
+
+**Founder time.** A proposal, an advisory council process, possibly an expression of interest,
+training, specification and quality management. Months of attention. Ben's unpaid time is already the
+$67,200 line that decides whether the business breaks even at two sites or three, so this is not free.
+
+**Ongoing.** Quality control against specification, the relationship, and freight of shred or panels
+to wherever the cutting happens.
+
+---
+
+## 5. The benefits
+
+**Freight, which is the strongest one.** INV-0303 records $5,900 to move beds Brisbane to Darwin to Maningrida. Producing the plastic component in Darwin or Alice
+Springs largely removes that leg. Freight was the biggest unmodelled cost in the community model.
+
+**A second supply route.** Today a single supplier in Sydney makes the only structural component
+Goods cannot buy off a shelf. That is a single point of failure for the entire product.
+
+**The skills pipeline**, which is the actual point rather than a benefit. Someone who has run a
+primary recycling and remanufacturing line has exactly what a community production site needs.
+
+**Local inputs.** Steel and canvas are already bought in Alice Springs. This brings the third input
+home too.
+
+**Credibility with government**, which matters for procurement generally.
+
+---
+
+## 6. The risks, ranked by what would actually hurt
+
+**1. Reputational, and it is the one that could end the organisation.** The great majority of people
+in NT prisons are Aboriginal. A social enterprise whose supply chain runs through that, selling at
+$750, needs to be able to explain itself in one sentence to a journalist. Paying full cost helps, and
+is now aligned with published policy, but it does not remove the need for that sentence.
+
+**2. What community thinks, which nobody has asked.** Utopia, Oonchiumpa, Tennant Creek and Palm
+Island may have family inside in Darwin or Alice Springs. That could be the most powerful part of
+this, people making things for home, or it could be something communities want no part of. **Only
+they can say. This should be treated as a gate, not a consultation.** Designing a community
+ownership pathway and then routing production through a prison without asking would be a strange
+inversion of the whole model.
+
+**3. Scale and reach.** The beast risk. Reduced by the narrow scope, by choosing an input rather than
+a product, and by the exclusivity clause. Worth knowing that published correctional industry policy
+requires full cost recovery and forbids marginal costing, so the risk is capacity and reach rather
+than being undercut on price.
+
+**4. Supply dependency.** A lockdown, an incident or a policy change stops the line and stops Goods'
+supply with it. This must never become the only route.
+
+**5. Opportunity cost.** This is not on the QBE critical path. The raise turns on demand, the entity
+migration and the COGS reclassification. If this consumes August, that is a real cost with a
+deadline attached.
+
+**6. Entity.** Goods trades through a sole trader. Government contracting wants an ABN, insurances
+and WHS documentation. This is now a commercial blocker rather than an administrative one.
+
+---
+
+## 7. Watch-outs
+
+- **Do not accept free product.** Their own policy language on not exploiting cheap labour supports
+  paying properly. Free product is the version that looks generous and is actually dangerous.
+- **Do not let scope creep to finished goods.** The panel is safe precisely because nobody can put it
+  on a shelf.
+- **Do not sign anything until the entity question is resolved.**
+- **Do not promise the washing machine or anything beyond the bed.**
+- **Have a fallback if exclusivity cannot be granted.** Government may be unable to give it. The
+  fallback is a specification and quality bar only Goods and Defy can meet, plus a right of first
+  refusal rather than exclusivity.
+
+---
+
+## 8. The decisions
+
+| # | Decision | Options | Note |
+|---|---|---|---|
+| 1 | Counterparty | Goods, Defy, or joint | Defy prefers the panel comes through them as host of the scaled tech. That also puts the reputational exposure on their name, which cuts both ways. |
+| 2 | Who funds equipment | Corrections, Defy, Goods, or wait for the raise | Goods has $0 signed capital. |
+| 3 | Community consultation | Before sending, after sending, or not a gate | Recommendation: before, and treat it as a gate. |
+| 4 | Pilot scope | Shred only, or shred plus panel | Shred only is safer and worth $40/bed. Panel is where the money is, if the yield supports it. |
+| 5 | Timing | Now, or after QBE closes 31 August | Depends on how much founder attention August can spare. |
+
+---
+
+## 9. Recommended sequence
+
+1. **Ask Defy the yield question.** One question. It decides whether the rest is worth doing, and it
+   costs nothing to ask.
+2. **Ask one community what they think.** Oonchiumpa is the natural first, given the relationship and
+   the Alice Springs proximity.
+3. **Then send the one-pager**, if both answers are good.
+
+**If the yield turns out to be one panel per bed set**, the recommendation flips: keep the
+relationship warm, park the supply idea, and pursue NT Corrections as a **buyer** of beds instead,
+which is where the actual gap in the business is.
+
+---
+
+*Rates: Defy invoices INV-1602, INV-1731, INV-1732. Freight: INV-0303. Equipment: Goods capital
+module model. Policy: NT.GOV.AU "Correctional industries and private business"; NSW Corrective
+Services Industries policy 6.1. Generated from the Goods cost model; regenerate with
+`npx tsx ../tools/build-corrections-decision-note.ts`.*

--- a/deliverables/NT-Corrections-one-pager.md
+++ b/deliverables/NT-Corrections-one-pager.md
@@ -1,0 +1,141 @@
+# A production partnership with NT Correctional Industries
+
+**Goods on Country · Defy Manufacturing · NT Correctional Industries**
+*Draft for discussion. Not a tender response. Every rate below is from a paid invoice.*
+
+---
+
+## What we are proposing
+
+Two stations inside a correctional facility, producing **inputs to a manufacturing process**,
+sold exclusively back to Goods on Country and Defy Manufacturing.
+
+**Station 1 · Washing and shredding.** Post-consumer HDPE is sorted, washed to remove
+contaminants, and shredded to a consistent flake. Output: clean HDPE shred.
+
+**Station 2 · Utility panel pressing.** Shred is heat-pressed into a flat panel. A utility panel
+is structurally consistent, clean and free of contaminants, without the aesthetic demands of an
+architectural surface. Output: a pressed utility panel, 1200 × 1200 × 19mm.
+
+Optionally, and later, **CNC cutting** as a downstream service.
+
+That is the whole scope. We are deliberately not proposing that the facility assemble or produce
+finished goods, for reasons set out below.
+
+---
+
+## What it is worth
+
+Goods and Defy buy both of these today. The rates are not estimates:
+
+| Output | Current rate | Source |
+|---|---|---|
+| Clean HDPE shred | **$2.00 per kg** ($40 per bed's worth at 20kg) | Defy invoice INV-1731 |
+| Pressed utility panel | **$200 each** | Defy invoice INV-1731, 20 panels bulk |
+
+There is an existing, continuing demand for both. This is not a program hoping to find a customer.
+
+---
+
+## The commercial condition
+
+**Panels and shred produced by the facility are sold exclusively to Goods on Country and Defy
+Manufacturing, and are not sold to any other retailer or manufacturer.**
+
+We ask for this openly and we think it serves NTCI as much as us.
+
+NT Correctional Industries states that its partnerships exist to grow local capacity and compete
+with **interstate and overseas** suppliers. That is precisely this case: the panel component of our
+product is currently made in **Sydney**, 3,000km away. This partnership replaces an interstate
+supplier, not a Territory one.
+
+The exclusivity clause is what keeps it that way. Without it, a government-backed facility operating
+at scale could displace the very community enterprises this program is meant to feed people into,
+including Aboriginal-owned operations in Alice Springs. NTCI's own stated position is that it steps
+back from work that competes with local business. This clause simply writes that commitment into
+the arrangement so both parties can rely on it.
+
+There is precedent in other jurisdictions for exactly this structure: NSW correctional industries
+fabricating for Street Furniture Australia, and Queensland producing for Street Swags. In both,
+exclusive supply back to a single partner funded the training and the facility.
+
+---
+
+## Why this scope, and not a wider one
+
+The utility panel is chosen because it is **an input, not a product**. It is not sold in retail, it
+has no consumer market, and it is not a thing anyone can put on a shelf. That makes the scope
+self-limiting in a way a finished-goods scope would not be.
+
+Goods exists to move manufacturing onto Country and into community ownership. If a correctional
+facility became a major independent producer and seller, it would reverse that purpose rather than
+serve it. We would rather say that plainly at the start than discover it later.
+
+Assembly work is possible in principle, but only on a subcontract basis where the facility works to
+the order of Goods or Defy rather than producing on its own account.
+
+---
+
+## What the facility gains
+
+**Certified, transferable skills**, which is the point rather than a by-product:
+
+- **Washing and shredding:** industrial machine operation, guarding and isolation, lockout and
+  tagout, contamination control, routine maintenance, output quality checks.
+- **Panel pressing:** heat press operation and temperature control, measurement and tolerance,
+  material handling, finishing and inspection.
+
+These map onto real jobs in recycling and resource recovery, plastics fabrication, machine
+operation and plant maintenance. Major recyclers recognise this pathway, and someone leaving the
+facility can say they have run a primary recycling and remanufacturing line.
+
+**Environmental outcome:** 20kg of HDPE diverted from landfill for every
+bed's worth of material processed, with the finished product going to remote communities.
+
+---
+
+## What Goods and Defy provide
+
+Equipment specification, supply and commissioning. Operator training and written procedures.
+Quality standards and inspection criteria. Maintenance pathway, spares and consumables. A standing
+purchase arrangement for the output. All sales, freight and distribution.
+
+Indicative equipment cost, subject to walking the space and to firm vendor quotes:
+
+| Station | Equipment |
+|---|---|
+| Washing and shredding | $19,800 |
+| Pressing | within $32,780 for press, CNC and finishing together |
+
+A facility with an existing workshop, three-phase power and extraction needs materially less than a
+greenfield site. We would want to see the space before putting a number on it.
+
+---
+
+## What we suggest first
+
+**A pilot at Alice Springs.** Tight scope, one station or two, a fixed quantity, and a review before
+anything expands. Alice is the natural place to start: two of the three material inputs for our
+product, the steel and the canvas, are already bought there, and the communities we serve are close.
+
+---
+
+## What we need to know from you
+
+1. The direct-purchase threshold before this must go to open tender.
+2. Whether the Correctional Industries Advisory Council must approve a new venture of this kind, and
+   what that process involves.
+3. What participants are paid, and whether that can be funded from trade revenue.
+4. Floor space, available power and existing extraction at Alice Springs and Darwin.
+5. Whether an exclusive supply arrangement can be written into a contract, and in what form.
+6. Whether any funding can follow a person into a community placement after release.
+
+That last question is the one we care most about. Skills learned inside are worth most when there is
+somewhere for them to go, and we have four community pathways under way in the NT and Queensland
+that need exactly this capability.
+
+---
+
+*Prepared by Goods on Country with Defy Manufacturing. Rates from Defy invoices INV-1602, INV-1731
+and INV-1732. Generated from the Goods cost model; regenerate with
+`npx tsx ../tools/build-corrections-onepager.ts`.*

--- a/deliverables/NT-Corrections-one-pager.md
+++ b/deliverables/NT-Corrections-one-pager.md
@@ -51,13 +51,46 @@ supplier, not a Territory one.
 
 The exclusivity clause is what keeps it that way. Without it, a government-backed facility operating
 at scale could displace the very community enterprises this program is meant to feed people into,
-including Aboriginal-owned operations in Alice Springs. NTCI's own stated position is that it steps
-back from work that competes with local business. This clause simply writes that commitment into
-the arrangement so both parties can rely on it.
+including Aboriginal-owned operations in Alice Springs.
+
+We understand this sits alongside an existing safeguard rather than replacing it. The Correctional
+Industries Advisory Council already exists, in NT.GOV.AU's words, to ensure Correctional Industries
+projects "function prudently and sensitively in parallel with private sector businesses". The clause
+we are proposing is that principle written into a single arrangement, so both parties can rely on it
+without returning to the Council every time the question arises.
 
 There is precedent in other jurisdictions for exactly this structure: NSW correctional industries
 fabricating for Street Furniture Australia, and Queensland producing for Street Swags. In both,
 exclusive supply back to a single partner funded the training and the facility.
+
+---
+
+## How we think this fits the framework
+
+We have looked at how correctional industries structure private sector work, and we would put this
+proposal in the most conventional category rather than asking for something unusual.
+
+**This is subcontract work on a continuing basis.** In the NSW policy that is a Level 3 arrangement,
+the middle of five levels, well short of a private operator managing a business unit. Goods and Defy
+supply the specification, the equipment and the offtake. The facility runs the work. We are not
+seeking to manage or staff anything, and we are not seeking access to public assets below commercial
+terms.
+
+**We expect to pay full cost, and we would rather you did not discount.** We understand correctional
+industries are required to recover full cost and to avoid marginal costing. That suits us: a rate
+that reflects the real cost of the work is what makes the arrangement durable, and it is what keeps
+the program from being read as cheap labour by anyone looking at it later. We would rather pay
+properly and have this survive scrutiny than pay less and have it questioned.
+
+**We will provide an industry impact statement.** We understand a proposal of this kind is expected
+to set out its likely effect on other Australian businesses. We would rather write that early and
+honestly than have it requested. Our short version: the component in question is currently made
+interstate, no Territory business currently supplies it, and the exclusivity clause is designed
+specifically to protect emerging Aboriginal-owned enterprises in Central Australia from being
+displaced.
+
+**Term.** We would suggest a pilot, then a two year term with a two year option, which we understand
+is the usual shape.
 
 ---
 
@@ -122,13 +155,16 @@ product, the steel and the canvas, are already bought there, and the communities
 
 ## What we need to know from you
 
-1. The direct-purchase threshold before this must go to open tender.
-2. Whether the Correctional Industries Advisory Council must approve a new venture of this kind, and
-   what that process involves.
+1. Whether an unsolicited proposal is the right pathway here, or whether this needs to go through an
+   expression of interest process.
+2. What the Correctional Industries Advisory Council requires from us, and whether an industry impact
+   statement should be prepared for it before anything else proceeds.
 3. What participants are paid, and whether that can be funded from trade revenue.
 4. Floor space, available power and existing extraction at Alice Springs and Darwin.
 5. Whether an exclusive supply arrangement can be written into a contract, and in what form.
-6. Whether any funding can follow a person into a community placement after release.
+6. NTCI already lists bedding manufacture among its industries. We would want to understand what that
+   covers before proposing anything adjacent to it.
+7. Whether any funding can follow a person into a community placement after release.
 
 That last question is the one we care most about. Skills learned inside are worth most when there is
 somewhere for them to go, and we have four community pathways under way in the NT and Queensland
@@ -137,5 +173,7 @@ that need exactly this capability.
 ---
 
 *Prepared by Goods on Country with Defy Manufacturing. Rates from Defy invoices INV-1602, INV-1731
-and INV-1732. Generated from the Goods cost model; regenerate with
+and INV-1732. Policy references: NT.GOV.AU, "Correctional industries and private business"; NSW
+Corrective Services Industries policy 6.1, "Private Sector Correctional Industry Programs".
+Generated from the Goods cost model; regenerate with
 `npx tsx ../tools/build-corrections-onepager.ts`.*

--- a/deliverables/NT-Corrections-production-pack.md
+++ b/deliverables/NT-Corrections-production-pack.md
@@ -1,0 +1,289 @@
+# Goods on Country and NT Corrective Services
+
+## A production and training capability: products, equipment and process
+
+*Prepared for Bodie, NT Corrective Services. Generated from the Goods cost model, so every figure
+traces to a source named in the last section. A working document for discussion, not a quotation.*
+
+---
+
+## 1. In one page
+
+NT Corrective Services is building industry and training capacity at Darwin and Alice Springs, and
+cannot sell what it produces. Goods designs and sells a product that is in demand across remote
+Australia and is currently manufactured in Sydney.
+
+The fit is straightforward. **Corrections runs the industrial middle of the process. Goods buys the
+output at the price it already pays a manufacturer today, and takes it to market.** Neither
+organisation can do the other's half, so this is a supply relationship rather than a competition.
+
+Three things make it worth doing beyond the training value:
+
+- **The customer already exists.** Goods buys these components every month. This is not a program
+  hoping to find a market.
+- **The materials are already local.** The steel and the canvas are both bought in Alice Springs
+  today. Only the plastic component is made interstate, and that is the part this partnership moves.
+- **The freight economics improve sharply.** Getting beds from Brisbane to a remote community
+  currently costs about $5,900 a load. From Darwin or Alice Springs it is a fraction of that.
+
+**What we would ask Corrections to do:** run collection, shredding, pressing and assembly.
+**What Goods does:** design, materials specification, equipment supply and commissioning, training,
+maintenance pathway, quality standards, and all sales and distribution.
+
+---
+
+## 2. The product
+
+**The Stretch Bed.** A flat-packable, washable bed built for remote Australia. It is in market now,
+it has been delivered to communities across the NT, Queensland and WA, and it sells for $750.
+
+| | |
+|---|---|
+| Weight | 26kg |
+| Load capacity | 200kg |
+| Dimensions | 188 × 92 × 25cm |
+| Assembly | About 5 minutes, no tools |
+| Design life | 10+ years (intent, not yet field-proven) |
+| Plastic diverted | 20kg of HDPE per bed |
+
+**How it is built.** Two galvanised steel poles thread through sleeves along the long edges of a
+canvas sheet, and through the top holes of two crossed recycled-plastic X-trestle legs. Tensioning
+pulls the poles into the leg holes. The canvas is structural: the bed does not stand without it.
+There are no fixed joints and no tools.
+
+**The three inputs, and who supplies them today:**
+
+| Component | Detail | Currently from |
+|---|---|---|
+| Galvanised steel pipe | 26.9mm OD × 2.6mm wall, 1950mm | DNA Steel Direct, **Alice Springs** |
+| Heavy-duty canvas | Australian, fully washable, quick-drying | Centre Canvas, **Alice Springs** |
+| Recycled HDPE X-trestle legs | Pressed from collected plastic waste | Defy Design, **Sydney** |
+
+The third row is the opportunity. Two of the three inputs are already sourced within the Territory.
+The plastic component is the one made 3,000km away, and it is the one this partnership brings home.
+
+**A note on the rest of the range, so nothing is over-promised.** Goods also has a washing machine
+built for remote communities. It is at prototype stage, deployed in several communities, and is not
+a production line we would propose starting with. Other products are ideas, not designs. The bed is
+the one that is proven, sells, and has a customer waiting.
+
+---
+
+## 3. The process
+
+Plastic waste goes in one end and a finished bed comes out the other, through four stations that
+must run in order. Each one feeds the next.
+
+**Collection and sorting → Shredding → Pressing, CNC and finishing → Assembly**
+
+A fifth stage, sales and delivery, sits outside the facility and stays with Goods and community
+partners.
+
+Each station can be run on its own or added over time. A facility does not have to start with the
+whole line, and there is a case for starting with pressing and CNC, because that is the step that
+turns low-value material into the component Goods currently buys interstate.
+
+### Station 1. Collection and sorting
+
+**Produces:** Sorted, caged HDPE ready to shred
+**What it teaches:** Material identification and sorting, contamination control, safe manual handling, stock records
+**Pathways it points at:** Recycling and waste operations, warehousing, logistics
+**Equipment cost:** $5,000 to $19,500 (estimate, firm quote required)
+**Running cost per year:** about $3,600, excluding labour and the site itself
+**Site requirements:** Covered, ventilated storage. Cages rather than bales for rigid HDPE. Forklift or pallet access.
+
+### Station 2. Shredding
+
+**Produces:** HDPE shred
+**What it teaches:** Industrial machine operation, guarding and isolation, lockout and tagout, routine maintenance, output quality checks
+**Pathways it points at:** Machine operation, plant maintenance, recycling and resource recovery
+**Equipment cost:** $19,800
+**Running cost per year:** about $12,443, excluding labour and the site itself
+**Site requirements:** Three-phase power. Noise separation or hearing protection zone. Dust extraction. Guarded machine footprint.
+
+### Station 3. Pressing, CNC and finishing
+
+**Produces:** Finished HDPE leg kit, cut and edged
+**What it teaches:** Heat press operation and temperature control, CNC setup and toolpath basics, measurement and tolerance, finishing
+**Pathways it points at:** CNC machine operation, manufacturing, cabinetmaking and joinery, plastics fabrication
+**Equipment cost:** $32,780
+**Running cost per year:** about $20,038, excluding labour and the site itself
+**Site requirements:** Three-phase power. Fume extraction over the hot press. Dust extraction on the router. Fire separation and a heat-safe work zone.
+
+### Station 4. Assembly and workshop
+
+**Produces:** A finished bed, ready to go out
+**What it teaches:** Reading assembly instructions, fastening and torque, quality inspection, packing for freight
+**Pathways it points at:** Production assembly, quality control, warehousing
+**Equipment cost:** $6,387
+**Running cost per year:** about $6,452, excluding labour and the site itself
+**Site requirements:** Bench space, hand tools, packing area. No special services.
+
+
+**Throughput.** One line running a single shift is planned at about 500 beds a year, which is
+roughly 10 a week. Short bursts run considerably faster: our own facility has produced at about 30
+beds a week over a two month deployment. We would model 500 for planning and treat anything above
+it as upside, because a planning rate has to survive a bad week.
+
+**A caution we would rather state than have you discover.** Our per-bed cost figure of $425.74 is
+calculated, not measured. The process is proven, and 40 beds were pressed, cut and assembled in
+house for a delivery to Maningrida in May 2026. What that run did not capture was operator hours,
+diesel and yield. A measured week of production would settle it, and we would be glad to do that
+jointly.
+
+---
+
+## 4. The equipment, and what a facility costs to stand up
+
+Costs are shown as bands because they depend on what a site already has. Where Corrections supplies
+the building, the power or the extraction, those lines come out.
+
+### The site base, needed before any station runs
+
+| Item | Cost |
+|---|---|
+| 40ft shipping container | $13,000 to $16,000 |
+| 20ft shipping container | $6,000 to $10,000 |
+| Diesel generator (press-line sized) | $6,600 to $20,000 |
+| Crane placement + transport | $1,200 to $2,500 |
+| Electrical fit-out (board, three-phase) | $3,000 to $8,000 |
+| Ventilation / fume extraction | $1,000 to $3,000 |
+| Site prep (pad, levelling) | $500 to $3,000 |
+| PPE + startup consumables | $500 to $1,500 |
+| **Site base total** | **$31,800 to $64,000** |
+
+Much of this is aimed at putting a line somewhere with no building and no power. An existing
+workshop inside a correctional facility already has the shell, the slab and the electrical
+infrastructure, so a realistic site base for Darwin or Alice Springs is materially lower than the
+figures above. The lines that stay are extraction, the electrical connection to the machines, and
+startup consumables.
+
+### The production stations
+
+| Station | Equipment cost | Running cost per year |
+|---|---|---|
+| Collection and sorting | $5,000 to $19,500 | $3,600 |
+| Shredding | $19,800 | $12,443 |
+| Pressing, CNC and finishing | $32,780 | $20,038 |
+| Assembly and workshop | $6,387 | $6,452 |
+| **All four stations** | **$63,967 to $78,467** | **$42,533** |
+
+There is also a site floor of about $35,000 a year that is incurred as soon
+as anyone works on a site at all, covering administration, insurance and the yard. Inside an
+existing correctional facility most of that is already carried, and it should be struck out rather
+than passed on.
+
+### Two ways to scope it
+
+| Scope | Cost | What it is |
+|---|---|---|
+| Minimum viable line | about $105,000 | A working line using the equipment set Goods already runs, second hand where sensible |
+| Turnkey fitted workshop | $207,450 | A fully fitted 40ft container workshop, everything new |
+
+For a facility that already has a building, the real number sits below both, and we would want to
+walk the space before putting a figure on it.
+
+---
+
+## 5. The commercial shape
+
+This is the part we would want to be most explicit about, because it is where a partnership like
+this usually goes wrong.
+
+**Goods buys the output. It does not take it for free.**
+
+Goods already pays a manufacturer for exactly these components, at rates that are on invoices we can
+show you:
+
+| What Corrections would produce | What Goods pays for it today |
+|---|---|
+| Shredded HDPE | $40 per bed's worth (20kg at $2.00/kg) |
+| Finished, cut and edged leg kit | $344 per bed |
+| A bed assembled and ready to go | $400 per bed |
+
+So the proposition is simple: **we buy this every month and we would rather buy it from you.**
+
+Three reasons we think buying beats donating, from your side as much as ours:
+
+1. **An industries program with a paying customer survives a budget round.** One producing donations
+   is a cost centre, and cost centres get cut.
+2. **Trade revenue can pay participants properly**, rather than the program depending on a training
+   budget to do it.
+3. **It protects both organisations.** Product made for nothing and sold at full price is a story
+   neither of us wants written, and paying a fair rate removes the question entirely.
+
+**What Goods keeps:** sales, distribution, warranty and the customer relationship, which is the part
+Corrections cannot do. **What Corrections keeps:** the training outcomes, the industry capability and
+a revenue line for the unit.
+
+---
+
+## 6. What each side would provide
+
+| Goods on Country | NT Corrective Services |
+|---|---|
+| Product design and specification | Facility, power and space |
+| Equipment supply, installation and commissioning | Supervision and program staffing |
+| Operator training and written procedures | Participant selection and support |
+| Quality standards and inspection criteria | Day to day operation |
+| Maintenance pathway, spares and consumables | Compliance, WHS and site induction |
+| All sales, freight and distribution | Production to agreed specification |
+| Purchase of output at agreed rates | |
+
+---
+
+## 7. Safety and compliance
+
+The line involves a shredder, a heated press and a CNC router. In a correctional setting that carries
+a compliance load beyond a normal workshop, and we would expect to work through it with you rather
+than hand it over. The specific items:
+
+- Machine guarding, isolation, and lockout and tagout procedures on the shredder and the router
+- Fume extraction over the hot press, which runs at 180°C, and dust extraction on the router
+- Hearing protection zoning around the shredder
+- Tool control and accounting for the assembly station
+- Written safe work method statements per station, which we would supply and you would adapt to
+  your own requirements
+- Operator competency sign-off before unsupervised running
+
+---
+
+## 8. Where this goes
+
+Goods exists to move manufacturing onto Country and towards community ownership. We want to be
+straight that a correctional facility is not the destination of that pathway, it is a bridge to it,
+and we think that is what makes it worth doing rather than something to gloss over.
+
+The version of this we would be proud of has two halves. Production and training capacity at Darwin
+and Alice Springs, and a community facility waiting for people when they are released, so a skill
+learned inside has somewhere to go. We already have four community pathways under way in the NT and
+Queensland, and the thing they most lack is exactly the capability this would build.
+
+If there is any budget that can follow a person out of the gate, that is the conversation we would
+most like to have.
+
+---
+
+## 9. What we would need from you
+
+1. The direct purchase threshold before this has to go to open tender, which decides the timeline.
+2. What participants are paid for workshop labour, and whether that can be funded from trade revenue.
+3. Floor space, available power and existing extraction at Darwin and Alice Springs.
+4. Whether equipment installed in a facility can later be relocated, and who owns it.
+5. What "competitive on selling products" means from your side, and what you are comparing against.
+6. Whether any funding can follow a person into a community placement after release.
+
+---
+
+## 10. Sources
+
+Equipment costs and running costs come from the Goods capital module model
+(`cost-model-scenarios.json`, locked 2026-05-29), reconciled against supplier quotes and paid
+invoices. The rates Goods pays for components today are from Defy Manufacturing invoices INV-1602,
+INV-1731 and INV-1732. The bed price of $750 and the delivered examples are from the Goods
+asset register. The Maningrida delivery of 40 Stretch Beds is invoice INV-0303, 18 May 2026.
+
+Figures graded as estimates are marked. The equipment bands are planning figures and would be
+replaced with firm vendor quotes before anything is committed.
+
+*Generated from the Goods cost model. Regenerate with `npx tsx ../tools/build-corrections-pack.ts`.*

--- a/deliverables/NT-Corrections-production-pack.md
+++ b/deliverables/NT-Corrections-production-pack.md
@@ -2,7 +2,7 @@
 
 ## A production and training capability: products, equipment and process
 
-*Prepared for Bodie, NT Corrective Services. Generated from the Goods cost model, so every figure
+*INTERNAL BACKGROUND, not for sending. The external document is the one-pager. Generated from the Goods cost model, so every figure
 traces to a source named in the last section. A working document for discussion, not a quotation.*
 
 ---

--- a/tools/build-corrections-decision-note.ts
+++ b/tools/build-corrections-decision-note.ts
@@ -1,0 +1,237 @@
+/**
+ * The NT Corrections decision note: internal, for Ben, Nic and Defy.
+ *
+ * This is not the proposal. The proposal is the one-pager. This is the paper that
+ * decides whether to send it, and it exists because the narrow scope changed what
+ * the opportunity IS, and that change should be made deliberately rather than
+ * absorbed quietly.
+ *
+ * THE CHANGE: in the two-station scope, NT Corrections is a SUPPLIER, not a
+ * customer. The earlier framing had them answering the demand question, which is
+ * the largest hole in the whole business model. They no longer do. This is a cost
+ * and capability play and should be judged as one.
+ *
+ * THE PIVOT POINT: how many bed sets come out of one pressed panel. Every rate in
+ * the comparison is invoiced, so the only unknown is yield, and it moves the answer
+ * from a $23 saving to a $156 saving per bed. One question to Defy settles it, and
+ * nothing else should move until it does.
+ *
+ * Usage, from v2/:  npx tsx ../tools/build-corrections-decision-note.ts
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import scenarios from '../v2/src/lib/data/cost-model-scenarios.json';
+
+const defy = scenarios.defy_verified_rates;
+const capex = scenarios.capex_modules;
+const physics = scenarios.physics;
+
+const money = (n: number) => '$' + Math.round(n).toLocaleString('en-AU');
+const money2 = (n: number) => '$' + n.toFixed(2);
+
+const KIT_TODAY = defy.bed_kit_cut_finished.amount; // 344.05, INV-1602 + INV-1732
+const PANEL = defy.pre_pressed_panel_each.amount; // 200, INV-1731
+const CUT_ONLY = defy.cut_and_finish_only.amount; // 121.00, INV-1602
+const SHRED_KG = defy.hdpe_shred_per_kg.amount; // 2.00, INV-1731
+const SHRED_BED = physics.hdpe_kg_per_bed * SHRED_KG; // 40
+
+const shredKit = capex.modules.find((m) => m.key === 'shredding')!.capex_low ?? 0;
+const pressKit = capex.modules.find((m) => m.key === 'pressing_cnc')!.capex_low ?? 0;
+const stationSet = shredKit + pressKit;
+
+/** Landed leg cost if we buy panels and pay to cut and finish, at a given yield. */
+const landed = (bedsPerPanel: number) => PANEL / bedsPerPanel + CUT_ONLY;
+
+const VOLUME = 500; // modelled planning rate, beds/yr/site
+
+const doc = `# NT Corrections: decision note
+
+**For: Ben, Nic, Defy. Internal. Not the proposal.**
+*Prepared 2026-08-04, after the call with Bodie and the follow-up with Defy. Every rate is from a
+paid Defy invoice. The one unknown is named in section 3 and it decides the rest.*
+
+---
+
+## 1. What is being decided
+
+Whether to put a two-station production proposal to NT Correctional Industries, at what scope, on
+whose paper, and where it sits against everything else competing for August. Five specific
+decisions are listed in section 8.
+
+---
+
+## 2. What this opportunity actually is, now that the scope has narrowed
+
+The first version of this idea had Corrections running the line through to finished beds, and
+answering the demand question at the same time. The call with Defy narrowed it, correctly, to two
+stations producing **inputs**: washing and shredding, and utility panel pressing.
+
+**That change moves NT Corrections from the demand side to the supply side.**
+
+It is worth being blunt about what that means. Goods is not short of ways to make a bed. Goods is
+short of people who have agreed to buy one. This partnership does not touch that. It is a **cost and
+capability play**, and judging it as a revenue play will lead to the wrong decision.
+
+The separate question, whether NT Corrections might **buy** beds for its own facilities, is still
+open and is worth its own conversation. Note they already list bedding manufacture among their
+industries, which cuts both ways.
+
+---
+
+## 3. The number that decides everything: panel yield
+
+Goods buys a cut and finished leg kit for **${money2(KIT_TODAY)}** per bed today. The alternative is
+to buy a pressed panel from Corrections and pay to cut and finish it. Both halves of that are
+invoiced rates, so the only unknown is **how many bed sets come out of one panel**.
+
+| Bed sets per panel | Panel cost per bed | Plus cut and finish | Landed leg cost | Saving vs ${money2(KIT_TODAY)} | At ${VOLUME} beds/yr |
+|---|---|---|---|---|---|
+${[1, 2, 3]
+  .map(
+    (n) =>
+      `| ${n} | ${money2(PANEL / n)} | ${money2(CUT_ONLY)} | **${money2(landed(n))}** | ${money2(
+        KIT_TODAY - landed(n),
+      )} | ${money((KIT_TODAY - landed(n)) * VOLUME)} |`,
+  )
+  .join('\n')}
+
+**If one panel makes one bed set, this is not worth doing.** ${money2(
+  KIT_TODAY - landed(1),
+)} a bed does not justify a government procurement process, an advisory council, months of founder
+time and a reputational exposure. If a panel makes two or more, it is a serious saving and worth
+pursuing properly.
+
+**This is one question to Defy and it should be answered before anything else moves.** A panel is
+1200 × 1200 × 19mm, which is 1.44m². Two crossed X-trestles per bed is four planks. Whether that
+nests at two sets a panel or one is a cutting-diagram question Defy can answer from experience.
+
+*(The rough area estimate suggests two is plausible. That is an estimate from panel dimensions, not
+a nesting diagram, and it is not good enough to decide on.)*
+
+Shred, if that is all Corrections does, is worth **${money(SHRED_BED)} per bed's worth** at
+${money2(SHRED_KG)}/kg. Real, but small.
+
+---
+
+## 4. The costs
+
+**Equipment.** Shredder ${money(shredKit)}, pressing and CNC ${money(
+  pressKit,
+)}. About **${money(stationSet)} per station set**, and twice that if both Darwin and Alice. Goods
+has $0 of signed capital today, so this is funded by Corrections, by Defy, or it waits for the raise.
+
+**Founder time.** A proposal, an advisory council process, possibly an expression of interest,
+training, specification and quality management. Months of attention. Ben's unpaid time is already the
+$67,200 line that decides whether the business breaks even at two sites or three, so this is not free.
+
+**Ongoing.** Quality control against specification, the relationship, and freight of shred or panels
+to wherever the cutting happens.
+
+---
+
+## 5. The benefits
+
+**Freight, which is the strongest one.** INV-0303 records ${money(
+  5900,
+)} to move beds Brisbane to Darwin to Maningrida. Producing the plastic component in Darwin or Alice
+Springs largely removes that leg. Freight was the biggest unmodelled cost in the community model.
+
+**A second supply route.** Today a single supplier in Sydney makes the only structural component
+Goods cannot buy off a shelf. That is a single point of failure for the entire product.
+
+**The skills pipeline**, which is the actual point rather than a benefit. Someone who has run a
+primary recycling and remanufacturing line has exactly what a community production site needs.
+
+**Local inputs.** Steel and canvas are already bought in Alice Springs. This brings the third input
+home too.
+
+**Credibility with government**, which matters for procurement generally.
+
+---
+
+## 6. The risks, ranked by what would actually hurt
+
+**1. Reputational, and it is the one that could end the organisation.** The great majority of people
+in NT prisons are Aboriginal. A social enterprise whose supply chain runs through that, selling at
+$750, needs to be able to explain itself in one sentence to a journalist. Paying full cost helps, and
+is now aligned with published policy, but it does not remove the need for that sentence.
+
+**2. What community thinks, which nobody has asked.** Utopia, Oonchiumpa, Tennant Creek and Palm
+Island may have family inside in Darwin or Alice Springs. That could be the most powerful part of
+this, people making things for home, or it could be something communities want no part of. **Only
+they can say. This should be treated as a gate, not a consultation.** Designing a community
+ownership pathway and then routing production through a prison without asking would be a strange
+inversion of the whole model.
+
+**3. Scale and reach.** The beast risk. Reduced by the narrow scope, by choosing an input rather than
+a product, and by the exclusivity clause. Worth knowing that published correctional industry policy
+requires full cost recovery and forbids marginal costing, so the risk is capacity and reach rather
+than being undercut on price.
+
+**4. Supply dependency.** A lockdown, an incident or a policy change stops the line and stops Goods'
+supply with it. This must never become the only route.
+
+**5. Opportunity cost.** This is not on the QBE critical path. The raise turns on demand, the entity
+migration and the COGS reclassification. If this consumes August, that is a real cost with a
+deadline attached.
+
+**6. Entity.** Goods trades through a sole trader. Government contracting wants an ABN, insurances
+and WHS documentation. This is now a commercial blocker rather than an administrative one.
+
+---
+
+## 7. Watch-outs
+
+- **Do not accept free product.** Their own policy language on not exploiting cheap labour supports
+  paying properly. Free product is the version that looks generous and is actually dangerous.
+- **Do not let scope creep to finished goods.** The panel is safe precisely because nobody can put it
+  on a shelf.
+- **Do not sign anything until the entity question is resolved.**
+- **Do not promise the washing machine or anything beyond the bed.**
+- **Have a fallback if exclusivity cannot be granted.** Government may be unable to give it. The
+  fallback is a specification and quality bar only Goods and Defy can meet, plus a right of first
+  refusal rather than exclusivity.
+
+---
+
+## 8. The decisions
+
+| # | Decision | Options | Note |
+|---|---|---|---|
+| 1 | Counterparty | Goods, Defy, or joint | Defy prefers the panel comes through them as host of the scaled tech. That also puts the reputational exposure on their name, which cuts both ways. |
+| 2 | Who funds equipment | Corrections, Defy, Goods, or wait for the raise | Goods has $0 signed capital. |
+| 3 | Community consultation | Before sending, after sending, or not a gate | Recommendation: before, and treat it as a gate. |
+| 4 | Pilot scope | Shred only, or shred plus panel | Shred only is safer and worth ${money(
+  SHRED_BED,
+)}/bed. Panel is where the money is, if the yield supports it. |
+| 5 | Timing | Now, or after QBE closes 31 August | Depends on how much founder attention August can spare. |
+
+---
+
+## 9. Recommended sequence
+
+1. **Ask Defy the yield question.** One question. It decides whether the rest is worth doing, and it
+   costs nothing to ask.
+2. **Ask one community what they think.** Oonchiumpa is the natural first, given the relationship and
+   the Alice Springs proximity.
+3. **Then send the one-pager**, if both answers are good.
+
+**If the yield turns out to be one panel per bed set**, the recommendation flips: keep the
+relationship warm, park the supply idea, and pursue NT Corrections as a **buyer** of beds instead,
+which is where the actual gap in the business is.
+
+---
+
+*Rates: Defy invoices INV-1602, INV-1731, INV-1732. Freight: INV-0303. Equipment: Goods capital
+module model. Policy: NT.GOV.AU "Correctional industries and private business"; NSW Corrective
+Services Industries policy 6.1. Generated from the Goods cost model; regenerate with
+\`npx tsx ../tools/build-corrections-decision-note.ts\`.*
+`;
+
+const target = resolve(import.meta.dirname, '../deliverables/NT-Corrections-decision-note.md');
+mkdirSync(dirname(target), { recursive: true });
+writeFileSync(target, doc);
+console.log(`wrote ${target}`);
+console.log(`  pivot: panel yield. 1/panel saves ${money2(KIT_TODAY - landed(1))}/bed, 2/panel saves ${money2(KIT_TODAY - landed(2))}/bed`);
+console.log(`  station set ${money(stationSet)}; shred alone ${money(SHRED_BED)}/bed`);

--- a/tools/build-corrections-onepager.ts
+++ b/tools/build-corrections-onepager.ts
@@ -19,11 +19,30 @@
  * open market. That means it cannot easily be diverted into retail, which is the
  * failure mode being designed against (the Bunnings scenario).
  *
- * WHY EXCLUSIVITY IS ASKABLE. Government avoids commercial exclusivity because of
- * corruption policy. But NTCI's own position, per the Commissioner in 2016, is that
- * it stops work it believes competes with local business. So the clause is not a
- * favour being requested, it is a limit they already claim to observe, written down
- * so that a local Aboriginal enterprise is protected by it.
+ * WHY EXCLUSIVITY IS ASKABLE. Confirmed from primary sources 2026-08-04, after an
+ * earlier pass that had to rely on search summaries because every NT government
+ * domain 403s. The NT page was recovered from the Wayback Machine (snapshot
+ * 2025-04-07) and the NSW policy PDF was extracted with pdftotext.
+ *
+ * NT.GOV.AU, verbatim: "NT Correctional Industries is looking for opportunities to
+ * partner with local private businesses. This includes opportunities to grow local
+ * capacity and compete with interstate and overseas suppliers." And: "The
+ * Correctional Industries Advisory Council monitors the development and operation of
+ * Correctional Industries projects to ensure that they function prudently and
+ * sensitively in parallel with private sector businesses."
+ *
+ * So the non-competition principle is not something we are asking them to adopt. It
+ * is the Advisory Council's stated job, and the Council includes peak employer
+ * bodies, Unions NT, training organisations and the Chamber of Commerce.
+ *
+ * NSW CSI POLICY 6.1 gives the vocabulary and, unexpectedly, answers the undercutting
+ * fear directly: "Corrective Services Industries will avoid marginal costing" and
+ * "Corrective Services Industries is not exploiting 'cheap labour'... will only be
+ * accepted if CSI both recovers its full cost." A correctional industry that must
+ * recover full cost is not structurally able to undercut on price. It also names the
+ * five levels of private sector involvement, and requires an INDUSTRY IMPACT
+ * STATEMENT endorsed by its consultative council. This proposal is Level 3,
+ * subcontract work on a continuing basis, and offers the impact statement up front.
  *
  * Every rate here is from a paid invoice. Nothing is modelled.
  *
@@ -99,13 +118,46 @@ supplier, not a Territory one.
 
 The exclusivity clause is what keeps it that way. Without it, a government-backed facility operating
 at scale could displace the very community enterprises this program is meant to feed people into,
-including Aboriginal-owned operations in Alice Springs. NTCI's own stated position is that it steps
-back from work that competes with local business. This clause simply writes that commitment into
-the arrangement so both parties can rely on it.
+including Aboriginal-owned operations in Alice Springs.
+
+We understand this sits alongside an existing safeguard rather than replacing it. The Correctional
+Industries Advisory Council already exists, in NT.GOV.AU's words, to ensure Correctional Industries
+projects "function prudently and sensitively in parallel with private sector businesses". The clause
+we are proposing is that principle written into a single arrangement, so both parties can rely on it
+without returning to the Council every time the question arises.
 
 There is precedent in other jurisdictions for exactly this structure: NSW correctional industries
 fabricating for Street Furniture Australia, and Queensland producing for Street Swags. In both,
 exclusive supply back to a single partner funded the training and the facility.
+
+---
+
+## How we think this fits the framework
+
+We have looked at how correctional industries structure private sector work, and we would put this
+proposal in the most conventional category rather than asking for something unusual.
+
+**This is subcontract work on a continuing basis.** In the NSW policy that is a Level 3 arrangement,
+the middle of five levels, well short of a private operator managing a business unit. Goods and Defy
+supply the specification, the equipment and the offtake. The facility runs the work. We are not
+seeking to manage or staff anything, and we are not seeking access to public assets below commercial
+terms.
+
+**We expect to pay full cost, and we would rather you did not discount.** We understand correctional
+industries are required to recover full cost and to avoid marginal costing. That suits us: a rate
+that reflects the real cost of the work is what makes the arrangement durable, and it is what keeps
+the program from being read as cheap labour by anyone looking at it later. We would rather pay
+properly and have this survive scrutiny than pay less and have it questioned.
+
+**We will provide an industry impact statement.** We understand a proposal of this kind is expected
+to set out its likely effect on other Australian businesses. We would rather write that early and
+honestly than have it requested. Our short version: the component in question is currently made
+interstate, no Territory business currently supplies it, and the exclusivity clause is designed
+specifically to protect emerging Aboriginal-owned enterprises in Central Australia from being
+displaced.
+
+**Term.** We would suggest a pilot, then a two year term with a two year option, which we understand
+is the usual shape.
 
 ---
 
@@ -170,13 +222,16 @@ product, the steel and the canvas, are already bought there, and the communities
 
 ## What we need to know from you
 
-1. The direct-purchase threshold before this must go to open tender.
-2. Whether the Correctional Industries Advisory Council must approve a new venture of this kind, and
-   what that process involves.
+1. Whether an unsolicited proposal is the right pathway here, or whether this needs to go through an
+   expression of interest process.
+2. What the Correctional Industries Advisory Council requires from us, and whether an industry impact
+   statement should be prepared for it before anything else proceeds.
 3. What participants are paid, and whether that can be funded from trade revenue.
 4. Floor space, available power and existing extraction at Alice Springs and Darwin.
 5. Whether an exclusive supply arrangement can be written into a contract, and in what form.
-6. Whether any funding can follow a person into a community placement after release.
+6. NTCI already lists bedding manufacture among its industries. We would want to understand what that
+   covers before proposing anything adjacent to it.
+7. Whether any funding can follow a person into a community placement after release.
 
 That last question is the one we care most about. Skills learned inside are worth most when there is
 somewhere for them to go, and we have four community pathways under way in the NT and Queensland
@@ -185,7 +240,9 @@ that need exactly this capability.
 ---
 
 *Prepared by Goods on Country with Defy Manufacturing. Rates from Defy invoices INV-1602, INV-1731
-and INV-1732. Generated from the Goods cost model; regenerate with
+and INV-1732. Policy references: NT.GOV.AU, "Correctional industries and private business"; NSW
+Corrective Services Industries policy 6.1, "Private Sector Correctional Industry Programs".
+Generated from the Goods cost model; regenerate with
 \`npx tsx ../tools/build-corrections-onepager.ts\`.*
 `;
 

--- a/tools/build-corrections-onepager.ts
+++ b/tools/build-corrections-onepager.ts
@@ -1,0 +1,197 @@
+/**
+ * The NT Corrections one-pager: the narrow-scope proposal.
+ *
+ * WHY THIS REPLACED THE LONGER PACK
+ * ---------------------------------
+ * The first pack was built on the wrong constraint. It read "they cannot sell" as
+ * the binding fact and proposed Corrections run the whole line through to finished
+ * beds. The real risk runs the other way: NTCI has scale and government backing, and
+ * a broad scope creates a producer that competes with the community enterprises Goods
+ * exists to build. Defy's phrase for it was creating a beast that ends up eating us.
+ *
+ * So the scope here is deliberately narrow: TWO stations, washing and shredding, and
+ * utility panel pressing. Both produce inputs rather than products. Neither produces
+ * anything a community or a retailer buys. CNC is named as a possible downstream
+ * service, not as part of the ask.
+ *
+ * THE UTILITY PANEL IS THE SAFE UNIT. It is structurally consistent, clean and free
+ * of contaminants, with no aesthetic demand, and it is not a product available on the
+ * open market. That means it cannot easily be diverted into retail, which is the
+ * failure mode being designed against (the Bunnings scenario).
+ *
+ * WHY EXCLUSIVITY IS ASKABLE. Government avoids commercial exclusivity because of
+ * corruption policy. But NTCI's own position, per the Commissioner in 2016, is that
+ * it stops work it believes competes with local business. So the clause is not a
+ * favour being requested, it is a limit they already claim to observe, written down
+ * so that a local Aboriginal enterprise is protected by it.
+ *
+ * Every rate here is from a paid invoice. Nothing is modelled.
+ *
+ * Usage, from v2/:  npx tsx ../tools/build-corrections-onepager.ts
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import scenarios from '../v2/src/lib/data/cost-model-scenarios.json';
+
+const defy = scenarios.defy_verified_rates;
+const capex = scenarios.capex_modules;
+const physics = scenarios.physics;
+
+const money = (n: number) => '$' + Math.round(n).toLocaleString('en-AU');
+const shredPerKg = defy.hdpe_shred_per_kg.amount; // 2.00, INV-1731
+const panelEach = defy.pre_pressed_panel_each.amount; // 200, INV-1731
+const shredPerBed = physics.hdpe_kg_per_bed * shredPerKg; // 40
+
+const shredKit = capex.modules.find((m) => m.key === 'shredding')!;
+const pressKit = capex.modules.find((m) => m.key === 'pressing_cnc')!;
+
+const doc = `# A production partnership with NT Correctional Industries
+
+**Goods on Country · Defy Manufacturing · NT Correctional Industries**
+*Draft for discussion. Not a tender response. ${'Every rate below is from a paid invoice.'}*
+
+---
+
+## What we are proposing
+
+Two stations inside a correctional facility, producing **inputs to a manufacturing process**,
+sold exclusively back to Goods on Country and Defy Manufacturing.
+
+**Station 1 · Washing and shredding.** Post-consumer HDPE is sorted, washed to remove
+contaminants, and shredded to a consistent flake. Output: clean HDPE shred.
+
+**Station 2 · Utility panel pressing.** Shred is heat-pressed into a flat panel. A utility panel
+is structurally consistent, clean and free of contaminants, without the aesthetic demands of an
+architectural surface. Output: a pressed utility panel, ${'1200 × 1200 × 19mm'}.
+
+Optionally, and later, **CNC cutting** as a downstream service.
+
+That is the whole scope. We are deliberately not proposing that the facility assemble or produce
+finished goods, for reasons set out below.
+
+---
+
+## What it is worth
+
+Goods and Defy buy both of these today. The rates are not estimates:
+
+| Output | Current rate | Source |
+|---|---|---|
+| Clean HDPE shred | **$${shredPerKg.toFixed(2)} per kg** (${money(shredPerBed)} per bed's worth at ${physics.hdpe_kg_per_bed}kg) | Defy invoice INV-1731 |
+| Pressed utility panel | **${money(panelEach)} each** | Defy invoice INV-1731, 20 panels bulk |
+
+There is an existing, continuing demand for both. This is not a program hoping to find a customer.
+
+---
+
+## The commercial condition
+
+**Panels and shred produced by the facility are sold exclusively to Goods on Country and Defy
+Manufacturing, and are not sold to any other retailer or manufacturer.**
+
+We ask for this openly and we think it serves NTCI as much as us.
+
+NT Correctional Industries states that its partnerships exist to grow local capacity and compete
+with **interstate and overseas** suppliers. That is precisely this case: the panel component of our
+product is currently made in **Sydney**, 3,000km away. This partnership replaces an interstate
+supplier, not a Territory one.
+
+The exclusivity clause is what keeps it that way. Without it, a government-backed facility operating
+at scale could displace the very community enterprises this program is meant to feed people into,
+including Aboriginal-owned operations in Alice Springs. NTCI's own stated position is that it steps
+back from work that competes with local business. This clause simply writes that commitment into
+the arrangement so both parties can rely on it.
+
+There is precedent in other jurisdictions for exactly this structure: NSW correctional industries
+fabricating for Street Furniture Australia, and Queensland producing for Street Swags. In both,
+exclusive supply back to a single partner funded the training and the facility.
+
+---
+
+## Why this scope, and not a wider one
+
+The utility panel is chosen because it is **an input, not a product**. It is not sold in retail, it
+has no consumer market, and it is not a thing anyone can put on a shelf. That makes the scope
+self-limiting in a way a finished-goods scope would not be.
+
+Goods exists to move manufacturing onto Country and into community ownership. If a correctional
+facility became a major independent producer and seller, it would reverse that purpose rather than
+serve it. We would rather say that plainly at the start than discover it later.
+
+Assembly work is possible in principle, but only on a subcontract basis where the facility works to
+the order of Goods or Defy rather than producing on its own account.
+
+---
+
+## What the facility gains
+
+**Certified, transferable skills**, which is the point rather than a by-product:
+
+- **Washing and shredding:** industrial machine operation, guarding and isolation, lockout and
+  tagout, contamination control, routine maintenance, output quality checks.
+- **Panel pressing:** heat press operation and temperature control, measurement and tolerance,
+  material handling, finishing and inspection.
+
+These map onto real jobs in recycling and resource recovery, plastics fabrication, machine
+operation and plant maintenance. Major recyclers recognise this pathway, and someone leaving the
+facility can say they have run a primary recycling and remanufacturing line.
+
+**Environmental outcome:** ${physics.hdpe_kg_per_bed}kg of HDPE diverted from landfill for every
+bed's worth of material processed, with the finished product going to remote communities.
+
+---
+
+## What Goods and Defy provide
+
+Equipment specification, supply and commissioning. Operator training and written procedures.
+Quality standards and inspection criteria. Maintenance pathway, spares and consumables. A standing
+purchase arrangement for the output. All sales, freight and distribution.
+
+Indicative equipment cost, subject to walking the space and to firm vendor quotes:
+
+| Station | Equipment |
+|---|---|
+| Washing and shredding | ${money(shredKit.capex_low ?? 0)} |
+| Pressing | within ${money(pressKit.capex_low ?? 0)} for press, CNC and finishing together |
+
+A facility with an existing workshop, three-phase power and extraction needs materially less than a
+greenfield site. We would want to see the space before putting a number on it.
+
+---
+
+## What we suggest first
+
+**A pilot at Alice Springs.** Tight scope, one station or two, a fixed quantity, and a review before
+anything expands. Alice is the natural place to start: two of the three material inputs for our
+product, the steel and the canvas, are already bought there, and the communities we serve are close.
+
+---
+
+## What we need to know from you
+
+1. The direct-purchase threshold before this must go to open tender.
+2. Whether the Correctional Industries Advisory Council must approve a new venture of this kind, and
+   what that process involves.
+3. What participants are paid, and whether that can be funded from trade revenue.
+4. Floor space, available power and existing extraction at Alice Springs and Darwin.
+5. Whether an exclusive supply arrangement can be written into a contract, and in what form.
+6. Whether any funding can follow a person into a community placement after release.
+
+That last question is the one we care most about. Skills learned inside are worth most when there is
+somewhere for them to go, and we have four community pathways under way in the NT and Queensland
+that need exactly this capability.
+
+---
+
+*Prepared by Goods on Country with Defy Manufacturing. Rates from Defy invoices INV-1602, INV-1731
+and INV-1732. Generated from the Goods cost model; regenerate with
+\`npx tsx ../tools/build-corrections-onepager.ts\`.*
+`;
+
+const target = resolve(import.meta.dirname, '../deliverables/NT-Corrections-one-pager.md');
+mkdirSync(dirname(target), { recursive: true });
+writeFileSync(target, doc);
+console.log(`wrote ${target}`);
+console.log(`  scope: 2 stations (wash+shred, panel press). Assembly and finished goods excluded on purpose.`);
+console.log(`  rates: shred ${money(shredPerKg)}/kg, panel ${money(panelEach)} each, both INV-1731`);

--- a/tools/build-corrections-pack.ts
+++ b/tools/build-corrections-pack.ts
@@ -1,0 +1,346 @@
+/**
+ * Build the NT Corrective Services production pack.
+ *
+ * WHAT THIS IS FOR
+ * ----------------
+ * Bodie asked to see three things: the products they could make, the equipment
+ * needed, and the process. This generates that document from the same cost model
+ * the rest of the business runs on, so nothing in a partner's hands is a figure
+ * somebody typed once and forgot.
+ *
+ * THE FRAMING, WHICH IS DELIBERATE
+ * --------------------------------
+ * NT Corrections is buying a TRAINING CAPABILITY that happens to produce something
+ * with a real customer, not a factory. Their unit is industry and training. So each
+ * station is described by what it teaches and what it produces, and the commercial
+ * section leads with the fact that Goods BUYS the output at the price it already
+ * pays a manufacturer today.
+ *
+ * The pack never proposes taking product for free. A social enterprise selling beds
+ * that were made for nothing by incarcerated people is not a partnership, and in the
+ * Territory it is the story that would end the organisation. Paying a fair price
+ * makes the industries program self-funding, which is what an industries unit needs.
+ *
+ * Usage, from v2/:  npx tsx ../tools/build-corrections-pack.ts
+ */
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+import scenarios from '../v2/src/lib/data/cost-model-scenarios.json';
+import { VALUE_LADDER, SALES_SPREAD_PER_BED } from '../v2/src/lib/cost-model/community-model';
+
+const capex = scenarios.capex_modules;
+const alloc = capex.operating_allocation;
+const defy = scenarios.defy_verified_rates;
+
+const money = (n: number) => '$' + Math.round(n).toLocaleString('en-AU');
+const band = (lo: number | null, hi: number | null) =>
+  lo === null || hi === null ? 'quote required' : lo === hi ? money(lo) : `${money(lo)} to ${money(hi)}`;
+
+/** What each station teaches. Their unit buys competencies, not machines. */
+const COMPETENCIES: Record<string, { teaches: string; roles: string }> = {
+  collection_baling: {
+    teaches: 'Material identification and sorting, contamination control, safe manual handling, stock records',
+    roles: 'Recycling and waste operations, warehousing, logistics',
+  },
+  shredding: {
+    teaches: 'Industrial machine operation, guarding and isolation, lockout and tagout, routine maintenance, output quality checks',
+    roles: 'Machine operation, plant maintenance, recycling and resource recovery',
+  },
+  pressing_cnc: {
+    teaches: 'Heat press operation and temperature control, CNC setup and toolpath basics, measurement and tolerance, finishing',
+    roles: 'CNC machine operation, manufacturing, cabinetmaking and joinery, plastics fabrication',
+  },
+  assembly: {
+    teaches: 'Reading assembly instructions, fastening and torque, quality inspection, packing for freight',
+    roles: 'Production assembly, quality control, warehousing',
+  },
+  sales_delivery: {
+    teaches: 'Not run inside. Kept with community and Goods.',
+    roles: '-',
+  },
+};
+
+/** Site requirements per station, asked in the language a facilities manager uses. */
+const SITE_NEEDS: Record<string, string> = {
+  collection_baling: 'Covered, ventilated storage. Cages rather than bales for rigid HDPE. Forklift or pallet access.',
+  shredding: 'Three-phase power. Noise separation or hearing protection zone. Dust extraction. Guarded machine footprint.',
+  pressing_cnc: 'Three-phase power. Fume extraction over the hot press. Dust extraction on the router. Fire separation and a heat-safe work zone.',
+  assembly: 'Bench space, hand tools, packing area. No special services.',
+  sales_delivery: 'Not applicable inside the facility.',
+};
+
+const rung = (key: string) => VALUE_LADDER.find((r) => r.module === key)!;
+const mod = (key: string) => capex.modules.find((m) => m.key === key)!;
+const op = (key: string) => alloc.per_module.find((m) => m.key === key)?.total ?? 0;
+
+const INSIDE = ['collection_baling', 'shredding', 'pressing_cnc', 'assembly'] as const;
+
+const doc = `# Goods on Country and NT Corrective Services
+
+## A production and training capability: products, equipment and process
+
+*Prepared for Bodie, NT Corrective Services. Generated from the Goods cost model, so every figure
+traces to a source named in the last section. A working document for discussion, not a quotation.*
+
+---
+
+## 1. In one page
+
+NT Corrective Services is building industry and training capacity at Darwin and Alice Springs, and
+cannot sell what it produces. Goods designs and sells a product that is in demand across remote
+Australia and is currently manufactured in Sydney.
+
+The fit is straightforward. **Corrections runs the industrial middle of the process. Goods buys the
+output at the price it already pays a manufacturer today, and takes it to market.** Neither
+organisation can do the other's half, so this is a supply relationship rather than a competition.
+
+Three things make it worth doing beyond the training value:
+
+- **The customer already exists.** Goods buys these components every month. This is not a program
+  hoping to find a market.
+- **The materials are already local.** The steel and the canvas are both bought in Alice Springs
+  today. Only the plastic component is made interstate, and that is the part this partnership moves.
+- **The freight economics improve sharply.** Getting beds from Brisbane to a remote community
+  currently costs about $5,900 a load. From Darwin or Alice Springs it is a fraction of that.
+
+**What we would ask Corrections to do:** run collection, shredding, pressing and assembly.
+**What Goods does:** design, materials specification, equipment supply and commissioning, training,
+maintenance pathway, quality standards, and all sales and distribution.
+
+---
+
+## 2. The product
+
+**The Stretch Bed.** A flat-packable, washable bed built for remote Australia. It is in market now,
+it has been delivered to communities across the NT, Queensland and WA, and it sells for ${money(750)}.
+
+| | |
+|---|---|
+| Weight | 26kg |
+| Load capacity | 200kg |
+| Dimensions | 188 × 92 × 25cm |
+| Assembly | About 5 minutes, no tools |
+| Design life | 10+ years (intent, not yet field-proven) |
+| Plastic diverted | 20kg of HDPE per bed |
+
+**How it is built.** Two galvanised steel poles thread through sleeves along the long edges of a
+canvas sheet, and through the top holes of two crossed recycled-plastic X-trestle legs. Tensioning
+pulls the poles into the leg holes. The canvas is structural: the bed does not stand without it.
+There are no fixed joints and no tools.
+
+**The three inputs, and who supplies them today:**
+
+| Component | Detail | Currently from |
+|---|---|---|
+| Galvanised steel pipe | 26.9mm OD × 2.6mm wall, 1950mm | DNA Steel Direct, **Alice Springs** |
+| Heavy-duty canvas | Australian, fully washable, quick-drying | Centre Canvas, **Alice Springs** |
+| Recycled HDPE X-trestle legs | Pressed from collected plastic waste | Defy Design, **Sydney** |
+
+The third row is the opportunity. Two of the three inputs are already sourced within the Territory.
+The plastic component is the one made 3,000km away, and it is the one this partnership brings home.
+
+**A note on the rest of the range, so nothing is over-promised.** Goods also has a washing machine
+built for remote communities. It is at prototype stage, deployed in several communities, and is not
+a production line we would propose starting with. Other products are ideas, not designs. The bed is
+the one that is proven, sells, and has a customer waiting.
+
+---
+
+## 3. The process
+
+Plastic waste goes in one end and a finished bed comes out the other, through four stations that
+must run in order. Each one feeds the next.
+
+**Collection and sorting → Shredding → Pressing, CNC and finishing → Assembly**
+
+A fifth stage, sales and delivery, sits outside the facility and stays with Goods and community
+partners.
+
+Each station can be run on its own or added over time. A facility does not have to start with the
+whole line, and there is a case for starting with pressing and CNC, because that is the step that
+turns low-value material into the component Goods currently buys interstate.
+
+${INSIDE.map((key, i) => {
+  const m = mod(key);
+  const r = rung(key);
+  const c = COMPETENCIES[key];
+  return `### Station ${i + 1}. ${m.label}
+
+**Produces:** ${r.output}
+**What it teaches:** ${c.teaches}
+**Pathways it points at:** ${c.roles}
+**Equipment cost:** ${band(m.capex_low, m.capex_high)}${m.grade === 'estimate' ? ' (estimate, firm quote required)' : ''}
+**Running cost per year:** about ${money(op(key))}, excluding labour and the site itself
+**Site requirements:** ${SITE_NEEDS[key]}
+`;
+}).join('\n')}
+
+**Throughput.** One line running a single shift is planned at about 500 beds a year, which is
+roughly 10 a week. Short bursts run considerably faster: our own facility has produced at about 30
+beds a week over a two month deployment. We would model 500 for planning and treat anything above
+it as upside, because a planning rate has to survive a bad week.
+
+**A caution we would rather state than have you discover.** Our per-bed cost figure of $425.74 is
+calculated, not measured. The process is proven, and 40 beds were pressed, cut and assembled in
+house for a delivery to Maningrida in May 2026. What that run did not capture was operator hours,
+diesel and yield. A measured week of production would settle it, and we would be glad to do that
+jointly.
+
+---
+
+## 4. The equipment, and what a facility costs to stand up
+
+Costs are shown as bands because they depend on what a site already has. Where Corrections supplies
+the building, the power or the extraction, those lines come out.
+
+### The site base, needed before any station runs
+
+| Item | Cost |
+|---|---|
+${capex.site_base.lines.map((l: { item: string; low: number; high: number }) => `| ${l.item} | ${band(l.low, l.high)} |`).join('\n')}
+| **Site base total** | **${band(capex.site_base.capex_low, capex.site_base.capex_high)}** |
+
+Much of this is aimed at putting a line somewhere with no building and no power. An existing
+workshop inside a correctional facility already has the shell, the slab and the electrical
+infrastructure, so a realistic site base for Darwin or Alice Springs is materially lower than the
+figures above. The lines that stay are extraction, the electrical connection to the machines, and
+startup consumables.
+
+### The production stations
+
+| Station | Equipment cost | Running cost per year |
+|---|---|---|
+${INSIDE.map((k) => `| ${mod(k).label} | ${band(mod(k).capex_low, mod(k).capex_high)} | ${money(op(k))} |`).join('\n')}
+| **All four stations** | **${band(
+  INSIDE.reduce((t, k) => t + (mod(k).capex_low ?? 0), 0),
+  INSIDE.reduce((t, k) => t + (mod(k).capex_high ?? 0), 0),
+)}** | **${money(INSIDE.reduce((t, k) => t + op(k), 0))}** |
+
+There is also a site floor of about ${money(alloc.site_floor.total)} a year that is incurred as soon
+as anyone works on a site at all, covering administration, insurance and the yard. Inside an
+existing correctional facility most of that is already carried, and it should be struck out rather
+than passed on.
+
+### Two ways to scope it
+
+| Scope | Cost | What it is |
+|---|---|---|
+| Minimum viable line | about ${money(105000)} | A working line using the equipment set Goods already runs, second hand where sensible |
+| Turnkey fitted workshop | ${money(207450)} | A fully fitted 40ft container workshop, everything new |
+
+For a facility that already has a building, the real number sits below both, and we would want to
+walk the space before putting a figure on it.
+
+---
+
+## 5. The commercial shape
+
+This is the part we would want to be most explicit about, because it is where a partnership like
+this usually goes wrong.
+
+**Goods buys the output. It does not take it for free.**
+
+Goods already pays a manufacturer for exactly these components, at rates that are on invoices we can
+show you:
+
+| What Corrections would produce | What Goods pays for it today |
+|---|---|
+| Shredded HDPE | ${money(rung('shredding').perBedEquivalent ?? 0)} per bed's worth (20kg at $${defy.hdpe_shred_per_kg.amount.toFixed(2)}/kg) |
+| Finished, cut and edged leg kit | ${money(rung('pressing_cnc').perBedEquivalent ?? 0)} per bed |
+| A bed assembled and ready to go | ${money(rung('assembly').perBedEquivalent ?? 0)} per bed |
+
+So the proposition is simple: **we buy this every month and we would rather buy it from you.**
+
+Three reasons we think buying beats donating, from your side as much as ours:
+
+1. **An industries program with a paying customer survives a budget round.** One producing donations
+   is a cost centre, and cost centres get cut.
+2. **Trade revenue can pay participants properly**, rather than the program depending on a training
+   budget to do it.
+3. **It protects both organisations.** Product made for nothing and sold at full price is a story
+   neither of us wants written, and paying a fair rate removes the question entirely.
+
+**What Goods keeps:** sales, distribution, warranty and the customer relationship, which is the part
+Corrections cannot do. **What Corrections keeps:** the training outcomes, the industry capability and
+a revenue line for the unit.
+
+---
+
+## 6. What each side would provide
+
+| Goods on Country | NT Corrective Services |
+|---|---|
+| Product design and specification | Facility, power and space |
+| Equipment supply, installation and commissioning | Supervision and program staffing |
+| Operator training and written procedures | Participant selection and support |
+| Quality standards and inspection criteria | Day to day operation |
+| Maintenance pathway, spares and consumables | Compliance, WHS and site induction |
+| All sales, freight and distribution | Production to agreed specification |
+| Purchase of output at agreed rates | |
+
+---
+
+## 7. Safety and compliance
+
+The line involves a shredder, a heated press and a CNC router. In a correctional setting that carries
+a compliance load beyond a normal workshop, and we would expect to work through it with you rather
+than hand it over. The specific items:
+
+- Machine guarding, isolation, and lockout and tagout procedures on the shredder and the router
+- Fume extraction over the hot press, which runs at 180°C, and dust extraction on the router
+- Hearing protection zoning around the shredder
+- Tool control and accounting for the assembly station
+- Written safe work method statements per station, which we would supply and you would adapt to
+  your own requirements
+- Operator competency sign-off before unsupervised running
+
+---
+
+## 8. Where this goes
+
+Goods exists to move manufacturing onto Country and towards community ownership. We want to be
+straight that a correctional facility is not the destination of that pathway, it is a bridge to it,
+and we think that is what makes it worth doing rather than something to gloss over.
+
+The version of this we would be proud of has two halves. Production and training capacity at Darwin
+and Alice Springs, and a community facility waiting for people when they are released, so a skill
+learned inside has somewhere to go. We already have four community pathways under way in the NT and
+Queensland, and the thing they most lack is exactly the capability this would build.
+
+If there is any budget that can follow a person out of the gate, that is the conversation we would
+most like to have.
+
+---
+
+## 9. What we would need from you
+
+1. The direct purchase threshold before this has to go to open tender, which decides the timeline.
+2. What participants are paid for workshop labour, and whether that can be funded from trade revenue.
+3. Floor space, available power and existing extraction at Darwin and Alice Springs.
+4. Whether equipment installed in a facility can later be relocated, and who owns it.
+5. What "competitive on selling products" means from your side, and what you are comparing against.
+6. Whether any funding can follow a person into a community placement after release.
+
+---
+
+## 10. Sources
+
+Equipment costs and running costs come from the Goods capital module model
+(\`cost-model-scenarios.json\`, locked 2026-05-29), reconciled against supplier quotes and paid
+invoices. The rates Goods pays for components today are from Defy Manufacturing invoices INV-1602,
+INV-1731 and INV-1732. The bed price of ${money(750)} and the delivered examples are from the Goods
+asset register. The Maningrida delivery of 40 Stretch Beds is invoice INV-0303, 18 May 2026.
+
+Figures graded as estimates are marked. The equipment bands are planning figures and would be
+replaced with firm vendor quotes before anything is committed.
+
+*Generated from the Goods cost model. Regenerate with \`npx tsx ../tools/build-corrections-pack.ts\`.*
+`;
+
+const target = resolve(import.meta.dirname, '../deliverables/NT-Corrections-production-pack.md');
+mkdirSync(dirname(target), { recursive: true });
+writeFileSync(target, doc);
+console.log(`wrote ${target}`);
+console.log(`  ${doc.split('\n').length} lines, ${INSIDE.length} stations`);
+console.log(`  sales spread held out of the pack on purpose: $${SALES_SPREAD_PER_BED}/bed stays with Goods and community`);

--- a/tools/build-corrections-pack.ts
+++ b/tools/build-corrections-pack.ts
@@ -1,6 +1,15 @@
 /**
  * Build the NT Corrective Services production pack.
  *
+ * ⚠ SUPERSEDED AS THE THING WE SEND. 2026-08-04, after the call with Defy.
+ * The EXTERNAL document is now tools/build-corrections-onepager.ts, which is
+ * deliberately narrow: washing and shredding, and utility panel pressing, with an
+ * exclusive sell-back clause. This pack proposes a scope that goes through to
+ * assembled beds, which would make a government-backed facility a producer of the
+ * finished product and compete with the community enterprises Goods exists to build.
+ * Keep this as INTERNAL background for the equipment, process and safety detail.
+ * Do not send it.
+ *
  * WHAT THIS IS FOR
  * ----------------
  * Bodie asked to see three things: the products they could make, the equipment
@@ -80,7 +89,7 @@ const doc = `# Goods on Country and NT Corrective Services
 
 ## A production and training capability: products, equipment and process
 
-*Prepared for Bodie, NT Corrective Services. Generated from the Goods cost model, so every figure
+*INTERNAL BACKGROUND, not for sending. The external document is the one-pager. Generated from the Goods cost model, so every figure
 traces to a source named in the last section. A working document for discussion, not a quotation.*
 
 ---


### PR DESCRIPTION
Three documents from the Bodie call and the Defy follow-up, all generated from the cost model so figures cannot drift.

| Document | For | Status |
|---|---|---|
| `NT-Corrections-one-pager.md` | Bodie | The proposal |
| `NT-Corrections-decision-note.md` | Ben, Nic, Defy | Decides whether to send it |
| `NT-Corrections-production-pack.md` | Internal | Background, marked do-not-send |

## The scope narrowed, and it matters

The first pack read "they cannot sell" as the binding constraint and proposed Corrections run the line through to finished beds. The real risk runs the other way: NTCI has scale and government backing, and a broad scope creates a producer that competes with the community enterprises Goods exists to build.

Now **two stations**: washing and shredding, and utility panel pressing. Both produce **inputs**, not products. The utility panel is the safe unit precisely because nobody can put it on a shelf.

**That also moves NT Corrections from the demand side to the supply side.** Goods is not short of ways to make a bed, it is short of people who have agreed to buy one. The decision note says so plainly.

## The number that decides it

| Bed sets per panel | Landed leg cost | Saving vs $344.05 | At 500 beds/yr |
|---|---|---|---|
| 1 | $321.00 | $23.05 | $11,525 |
| 2 | $221.00 | $123.05 | $61,525 |
| 3 | $187.67 | $156.38 | $78,192 |

One question to Defy. At one set per panel the note says outright it is not worth a procurement process.

## Primary sources, not summaries

NT government domains all 403, so the NTCI page was recovered from the Wayback Machine and the NSW policy PDF extracted with pdftotext.

- NT.GOV.AU: NTCI partners with local business to "grow local capacity and **compete with interstate and overseas suppliers**". Our panels come from Sydney.
- NT.GOV.AU: the Correctional Industries Advisory Council exists to ensure projects "function prudently and sensitively **in parallel with private sector businesses**".
- NSW CSI policy 6.1: "will avoid marginal costing" and "is not exploiting 'cheap labour'... only be accepted if CSI both recovers its full cost". **A correctional industry required to recover full cost cannot undercut on price.**

The one-pager positions this as **Level 3, subcontract work on a continuing basis**, offers an industry impact statement up front, and says Goods expects to pay full cost and would rather they did not discount.

## Risks ranked by what would actually hurt

Reputational first. Then the one nobody had raised: **what community thinks.** Utopia, Oonchiumpa, Tennant Creek and Palm Island may have family inside. The note treats that as a **gate**, not a consultation.

Documents only. No site or model changes.