### PR TITLE
Make the pitch deck readable: contents, slide mode, print, and audience cuts

### DIFF
--- a/design/brand/claude-design/invest-deck-full.html
+++ b/design/brand/claude-design/invest-deck-full.html
@@ -417,7 +417,7 @@
     <div class="stat sage"><div class="num">CANON:num:washers-in-community</div><div class="lbl">washing machines in community</div></div>
     <div class="stat sage"><div class="num">CANON:num:plastic-kg</div><div class="lbl">recycled HDPE diverted</div></div>
     <div class="stat"><div class="num">CANON:num:revenue-received</div><div class="lbl">funding received to date, Goods-scoped</div></div>
-    <div class="stat"><div class="num">CANON:num:revenue-carveout</div><div class="lbl">accountant-signed Goods-only revenue carve-out</div></div>
+    <div class="stat"><div class="num">CANON:num:revenue-carveout</div><div class="lbl">Goods-only revenue carve-out (workpaper basis)</div></div>
   </div>
   <p class="footnote">Bed counts are QR-tracked in the asset register and drift-guarded. Revenue is Goods-scoped cash received, restated 3 Jun 2026; CANON:num:accounts-receivable in authorised receivables sits on top. No surplus is claimed: the connected entity runs an FY26 net loss, investing ahead of revenue. Figures in AUD.</p>
 </div>

--- a/design/canon-numbers.json
+++ b/design/canon-numbers.json
@@ -2,36 +2,36 @@
   "_comment": "GENERATED from v2/src/lib/data/canon.ts by v2/scripts/canon-numbers.mjs — do not hand-edit. Artifacts reference these as CANON:num:<id>; canon-render.mjs bakes the formatted value. Verify with: node v2/scripts/canon-numbers.mjs --check",
   "numbers": {
     "beds-deployed": {
-      "value": "536",
-      "raw": 536,
+      "value": "540",
+      "raw": 540,
       "unit": "units",
       "label": "Beds deployed",
       "asAt": "2026-07-18"
     },
     "stretch-beds-deployed": {
-      "value": "173",
-      "raw": 173,
+      "value": "177",
+      "raw": 177,
       "unit": "units",
       "label": "Stretch Beds deployed",
       "asAt": "2026-05-30"
     },
     "washers-in-community": {
-      "value": "18",
-      "raw": 18,
+      "value": "22",
+      "raw": 22,
       "unit": "units",
       "label": "Washing machines in community",
-      "asAt": "2026-07-18"
+      "asAt": "2026-07-21"
     },
     "communities-served": {
-      "value": "9",
-      "raw": 9,
+      "value": "11",
+      "raw": 11,
       "unit": "communities",
       "label": "Communities served",
       "asAt": "2026-05-30"
     },
     "plastic-kg": {
-      "value": "3,460kg",
-      "raw": 3460,
+      "value": "3,540kg",
+      "raw": 3540,
       "unit": "kg",
       "label": "Recycled HDPE diverted",
       "asAt": "2026-05-30"
@@ -69,7 +69,7 @@
       "raw": 750,
       "unit": "AUD",
       "label": "Stretch Bed price",
-      "asAt": "2026-05-29"
+      "asAt": "2026-07-25"
     },
     "marginal-buykit": {
       "value": "$685",
@@ -83,28 +83,28 @@
       "raw": 426,
       "unit": "AUD",
       "label": "Marginal cost / bed (Factory)",
-      "asAt": "2026-05-29"
+      "asAt": "2026-07-31"
     },
     "marginal-community": {
       "value": "$421",
       "raw": 421,
       "unit": "AUD",
       "label": "Marginal cost / bed (Community)",
-      "asAt": "2026-05-29"
+      "asAt": "2026-07-25"
     },
     "save-per-bed": {
       "value": "$194",
       "raw": 194,
       "unit": "AUD",
       "label": "Saving from pressing in-house",
-      "asAt": "2026-05-29"
+      "asAt": "2026-07-31"
     },
     "cleared-voices": {
-      "value": "32",
-      "raw": 32,
+      "value": "35",
+      "raw": 35,
       "unit": "voices",
       "label": "Consent-cleared voices (external use)",
-      "asAt": "2026-06-17"
+      "asAt": "2026-08-01"
     },
     "display-storyteller-pool": {
       "value": "32",
@@ -114,11 +114,11 @@
       "asAt": "2026-06-16"
     },
     "el-published-stories": {
-      "value": "0",
-      "raw": 0,
+      "value": "2",
+      "raw": 2,
       "unit": "stories",
-      "label": "Empathy Ledger published stories",
-      "asAt": "2026-06-03"
+      "label": "Empathy Ledger published stories (public)",
+      "asAt": "2026-07-25"
     },
     "signed-lois": {
       "value": "0",

--- a/thoughts/shared/handoffs/pitch-decks/current.md
+++ b/thoughts/shared/handoffs/pitch-decks/current.md
@@ -1,0 +1,183 @@
+# Pitch decks, the reading apparatus, and the Claude Design bridge
+
+## Ledger
+<!-- This section is extracted by SessionStart hook for quick resume -->
+**Updated:** 2026-08-05T06:30:00Z
+**Goal:** Make the pitch deck easier to read and understand, and clean the funder-facing
+design-system cards. Code work is DONE and green. **PR #206 is OPEN and NOT MERGED.**
+**Branch:** `feat/pitch-readability` = `0b624b2`, one commit ahead of `origin/main` = `68433c1`.
+**Test:** `cd v2 && npm test && npm run check:audience && npm run check:voice && npm run check:retired-figures && npm run build`
+
+### Now
+[->] **NEXT TOPIC = DEEP RESEARCH: how to drive Claude Design fully from the Claude CLI.**
+     Read "The research question" below FIRST. The premise that this cannot be done is WRONG
+     and was my error, not a finding. Most of it already works.
+
+[->] **PR #206 needs a human call.** Green, MERGEABLE, CLEAN, preview verified. Ben opened the
+     preview but had not reported back before the session ended. Do NOT merge without him
+     saying he has looked: the 2026-07-27 six-front-doors revert happened exactly this way.
+     Preview: https://goods-on-country-git-feat-pitc-2d336d-benjamin-knights-projects.vercel.app/pitch/road
+
+[->] **Claude Design gallery is in a broken intermediate state until someone reindexes.**
+     See "The one manual step" below. This is the ONLY thing today that a human had to do.
+
+---
+
+## The research question for the next session
+
+**Do not start from "can we connect Claude Design to the CLI". We already have.**
+
+Verified working today via the `DesignSync` MCP tool, all from the CLI:
+`list_projects` · `get_project` · `list_files` · `get_file` · `create_project` ·
+`finalize_plan` · `write_files` (11 files) · `delete_files` (1 file).
+
+The write flow is: `finalize_plan` (locks exact paths + a `localDir`, requires BOTH `writes` and
+`deletes` keys even when one is empty) returns a `planId`, then `write_files` with
+`localPath` per file reads from disk and uploads without the content entering context.
+
+**The ONE thing that did not work: rebuilding the card index (`_ds_manifest.json`).**
+Files upload correctly and `list_files` confirms them, but the gallery does not show them until
+something app-side recompiles the manifest from the `<!-- @dsCard ... -->` marker on line 2 of
+each preview HTML. Observed behaviour, twice, five weeks apart:
+
+- A FIRST batch written to a FRESHLY CREATED project indexes automatically.
+- LATER batches to an EXISTING project do not, and no amount of waiting or hard-refreshing fixes
+  it. `preview/invest-next-phase.html` has been sitting unindexed since before today, which is
+  independent evidence this is not about how I uploaded.
+- `register_assets` / `unregister_assets` report success and change nothing. The tool description
+  now calls them **legacy** outright and says the index comes from `@dsCard` markers.
+
+**Leads I dismissed instead of chasing. Start here:**
+
+1. **The `/design-sync` skill is referenced in the DesignSync tool description and is NOT
+   installed on this machine.** Nothing in `~/.claude/skills/` matches. If it exists upstream it
+   very likely carries the correct end-to-end recipe, including whatever triggers the reindex.
+   Find it, install it, read it. **This is the single highest-value lead.**
+2. **`/design-login`** is also referenced (a dedicated design authorization for sessions without
+   a claude.ai login). Unexamined.
+3. **`report_validate` and the `counts` parameter** on DesignSync mention a `.render-check.json`
+   and an app-side "self-check" that COMPILES the manifest. That self-check is the thing we need
+   to trigger. Its trigger condition is unknown and is the crux of the whole problem.
+4. **`_ds_bundle.js` and `_adherence.oxlintrc.json`** exist at the project root and were never
+   opened. They may describe the build/validate contract.
+5. Whether writing a **deliberately modified `_ds_manifest.json`** directly via `write_files`
+   works, or whether it is regenerated and overwritten. Never tested. Cheap to test.
+
+**Test project:** "Goods on Country — Investor Materials" `b333c5aa-2dfa-4043-ab5f-ef7460692623`.
+Old project `a24f62c8-2be7-4811-887d-f5f8a24f3cf9` still exists and is a fine sacrificial target
+for destructive experiments. Do not experiment on `b333c5aa`, it is now the real one.
+
+**Also worth researching, separately:** whether the round trip can be closed. Today it is
+one-way-plus-manual: repo → Design (automatic), Design → repo (`get_file`, then a HAND PORT into
+React). Nothing binds an HTML card to `pitch-chrome.tsx`. Pencil round-trips both ways via MCP,
+which is why `design/goods-theory-of-change-v2.pen` was chosen as the canonical editable deck.
+Whether Design can reach parity is an open question nobody has actually asked.
+
+---
+
+## The one manual step (blocking the gallery)
+
+Open **claude.ai/design** → project "Goods on Country — Investor Materials" → in-app chat, paste:
+
+> Reindex the design system cards. `preview/invest-funder-pipeline.html` was deleted and its
+> manifest entry is dangling. Pick up the new `Deck chrome` group (4 cards),
+> `preview/invest-loi-ladder.html`, and `preview/invest-next-phase.html`, and refresh the card
+> names and subtitles from the `@dsCard` markers.
+
+**Until this runs the gallery is WORSE than before**, because the manifest still points at the
+deleted `invest-funder-pipeline.html` and will render "file not found" — the exact dangling-entry
+failure that caused the migration off project `a24f62c8` in July. File contents are all correct
+and live; only the index lags.
+
+---
+
+## What landed this session
+
+### PR #206 — the deck's reading apparatus (OPEN, not merged)
+
+`/pitch/road` is the canonical deck (ruling R) and its CONTENT was never the problem. It is a
+**deck rendered as a document**: 18 panels, each already authored one-per-viewport
+(`lg:h-[100svh]`), served as one scroll with no pagination, no map, no print path and no shorter
+cut for a non-funder. That is why five pitch artifacts existed instead of one.
+
+- **New module `v2/src/lib/data/pitch-chrome.ts`** holds the apparatus, not the content: panel
+  order (mirrored from `deckSlides`, guarded), packs, appendices, the opener. **19 guards** in
+  `pitch-chrome.guards.test.ts`.
+- **New client `v2/src/app/pitch/road/pitch-chrome.tsx`** works on the rendered DOM by panel id
+  rather than owning the markup, so the server-rendered deck keeps streaming and priority hints.
+  Reads state from `window.location` and writes back with `replaceState` (using
+  `useSearchParams` would force a Suspense boundary around the whole deck for a nav bar).
+- **`page.tsx`**: 13 `data-pitch-panel` tags added (renders as 18 panels at runtime).
+- **`globals.css`**: slide mode + a print block giving one panel per page.
+- Modes: contents bar with scrollspy · `?view=slides` (arrows, space, Escape) · print · `?for=`.
+
+**Two live defects fixed on the way:**
+1. The hero's "Open the slide deck" button linked to `/pitch/deck`, which `next.config` 302s
+   straight back to `/pitch/road`. **A redirect loop on the deck's own cover.** Now opens slide mode.
+2. `pitch-surface-notice.tsx` hardcoded `/pitch/funder-pathways` as "THE canonical funder
+   surface" while ruling R, `audience.ts` (`funder.frontDoor`) and seven `next.config` redirects
+   all said `/pitch/road`. **Every appendix was signposting funders away from the front door** —
+   the exact failure that component was written to prevent. Now derives from `audience.ts`, with
+   a guard asserting it never goes back to a hardcoded string.
+
+### Claude Design: 5 cards added, 6 corrected, 1 deleted
+
+New **Deck chrome** group (4): `deck-opener`, `deck-contents-bar`, `deck-pack-switcher`,
+`deck-slide-transport`. Plus `invest-loi-ladder`.
+
+**Three separate rulings had never been swept into the Investment cards:**
+- **Ruling V (2026-08-01).** Cards claimed the QBE grant was matched "at least 1:1" and drew a
+  "$150K floor" tick on a progress track. Neither exists. Catalytic and discretionary, typically
+  $150K–$400K, pool up to $1.1M across TEN enterprises. Raising $400K obliges QBE to nothing.
+- **Ben, 2026-08-02.** Centrecorp still in the capital stack as a $75K grant. They are a BUYER.
+  Inflated the grant column by $75,000. Stack is **$400K** (confirmed by Ben 2026-08-05), not $475K.
+- **Ruling G/H (2026-07-25).** Three cards read "signed FY revenue (Goods-only,
+  accountant-signed)". There is no accountant-signed document; it is a **workpaper**.
+  *Caught only by reading a file back AFTER writing it. I had not scanned for it.*
+- **Canon drift:** beds 496→**540**, communities 9→**11**, HDPE 2,660kg→**3,540kg**.
+
+**Deleted (Ben, explicit):** `preview/invest-funder-pipeline.html`. It named fifteen funders with
+an amount and a stage each, captioned "as at 3 Jul 2026". It could NOT be rebuilt from
+`loi-pipeline.ts`, because that file holds only the ladder config, three GHL pipeline ids and a
+23-stage map — **no names, no amounts**. Those come from GHL, read live by `/admin/loi-tracker`.
+It was also the same content class as the `/pitch/deck` presenter-script leak fixed 2026-08-02.
+Replaced by `invest-loi-ladder.html`, which mirrors STRUCTURE and points at the tracker for STATE.
+Local copy retained at `design/brand/claude-design/preview/invest-funder-pipeline.html`.
+
+---
+
+## Decisions
+
+- **Three packs on `/pitch/road`, not six.** `buyer.frontDoor` is `/shop` and
+  `buyer.mustNeverSee` forbids the impact story ahead of the spec, which is this page's entire
+  first half. `community.mustNeverSee` forbids arriving with a proposal instead of a yarn, and
+  this page is a proposal from panel one. A guard refuses to add either.
+- **The opener is the highest-risk prose in the system** and is guarded accordingly: no bed
+  threshold, no payback promise, **no site count and no break-even claim**, and it must say
+  plainly that nothing is signed.
+- **`/pitch/document`, `/pitch/funder-pathways`, `/pitch/community-narrative` are APPENDICES**,
+  linked from the deck's contents, not retired. `/pitch/document` carries prose the deck does not
+  (competition table, why-now, the pains); deleting it loses content rather than duplication.
+- **If a figure or a name is typed into HTML, it will be wrong within a month.** Every card
+  corrected today was accurate when written. Use `CANON:num:<id>` and `CANON:<slot>` tokens.
+
+## Gotchas found
+
+- `design/brand/claude-design/` is **gitignored**. The 11 card files exist ONLY there and in the
+  Design project. They are not in git and PR #206 does not contain them.
+- `design/brand/kit/render.sh` is **not executable**; run it as `bash design/brand/kit/render.sh
+  <file.html>`. Verified working: outputs `.pdf` + `-preview.png`, ~8 seconds.
+- `check:retired-figures` scans ALL of `src/`, including ban-list literals. Writing `'co-designed'`
+  inside an OPENER_BANNED array trips it. Do not restate global voice rules in local lists.
+- `finalize_plan` requires both `writes` and `deletes` keys, even when one is `[]`.
+
+## Open
+
+- **UNRESOLVED, blocks the investor number: what a site costs to run for a year.** Four live
+  answers ($15,000 / $48,333 / $64,333 / $79,333), moving break-even from 2.0 to 4.6 sites.
+  `deliverables/GOC-site-cost-decision.md` is ready to settle it: three questions, options priced,
+  blank decision lines. Half an hour with Nic. **Do NOT print a site count until then.**
+- Email to Matt drafted 2026-08-04, still NOT sent. Sheet still not shared with Matt/Mal.
+- `invest-funder-card.html` retains a "Match-eligible" chip. Judged acceptable: ruling V struck
+  the 1:1 and the floor, not the coverage test, and `ASK_MATCH_VEHICLE.rule` still uses coverage
+  language. Flagged in case a future reader disagrees.

--- a/thoughts/shared/handoffs/pitch-decks/current.md
+++ b/thoughts/shared/handoffs/pitch-decks/current.md
@@ -2,24 +2,38 @@
 
 ## Ledger
 <!-- This section is extracted by SessionStart hook for quick resume -->
-**Updated:** 2026-08-05T06:30:00Z
-**Goal:** Make the pitch deck easier to read and understand, and clean the funder-facing
-design-system cards. Code work is DONE and green. **PR #206 is OPEN and NOT MERGED.**
-**Branch:** `feat/pitch-readability` = `0b624b2`, one commit ahead of `origin/main` = `68433c1`.
-**Test:** `cd v2 && npm test && npm run check:audience && npm run check:voice && npm run check:retired-figures && npm run build`
+**Updated:** 2026-08-05T08:15:00Z
+**Goal:** DONE for this thread. The Claude Design CLI bridge is SOLVED (sentinel), the project
+is fully corrected + stocked with 138 photos, and `tools/design-push.mjs` makes it a render
+target of the spine. **PR #206 is OPEN and NOT MERGED** — awaiting Ben's eyes only.
+**Branch:** `feat/pitch-readability` = `d54880b` (5 commits), pushed through `32274d2`.
+**Test:** `cd v2 && npm test && npm run check:audience && npm run check:voice && npm run check:retired-figures && npm run build` · `node tools/design-push.mjs --check-only`
 
 ### Now
-[->] **NEXT TOPIC = DEEP RESEARCH: how to drive Claude Design fully from the Claude CLI.**
-     Read "The research question" below FIRST. The premise that this cannot be done is WRONG
-     and was my error, not a finding. Most of it already works.
+[->] **PR #206 needs a human call.** Green, MERGEABLE. Do NOT merge without Ben saying he has
+     looked (the 2026-07-27 revert). Preview:
+     https://goods-on-country-git-feat-pitc-2d336d-benjamin-knights-projects.vercel.app/pitch/road
+[->] **Ben must RELOAD the Design project** (claude.ai/design → Goods on Country — Investor
+     Materials) so the armed sentinel rebuilds the card index: Image library card, Deck chrome
+     group, LOI ladder appear; the dangling funder-pipeline entry disappears. If a real
+     close-and-reopen still shows the old list, the recompile machinery needs digging.
+[->] **The standing flow from here:** edit `canon.ts` or a card → `node tools/design-push.mjs`
+     → a Claude session executes `.push/push-plan.json` via DesignSync (≤10 files/call,
+     sentinel LAST). Deck prompt for the in-app design agent is in the 2026-08-05 transcript.
 
-[->] **PR #206 needs a human call.** Green, MERGEABLE, CLEAN, preview verified. Ben opened the
-     preview but had not reported back before the session ended. Do NOT merge without him
-     saying he has looked: the 2026-07-27 six-front-doors revert happened exactly this way.
-     Preview: https://goods-on-country-git-feat-pitc-2d336d-benjamin-knights-projects.vercel.app/pitch/road
-
-[->] **Claude Design gallery is in a broken intermediate state until someone reindexes.**
-     See "The one manual step" below. This is the ONLY thing today that a human had to do.
+### Landed this session (research + hardening, all in the Design project + repo)
+- **Reindex solved**: `_ds_needs_recompile` sentinel (see below). `/design-sync` is BUILT INTO
+  Claude Code — `Skill(skill:"design-sync")` loads it even though unlisted.
+- **README rewritten** with corrected figures + a Claim ceiling section (it is inlined into the
+  design agent's system prompt — it was carrying $475K/accountant-signed/496/9 until today).
+- **138 photos uploaded** to `images/` (resized 1600px from `design/starred-images/`, filenames
+  carry community/person metadata) + `preview/image-library.html` gallery card mapping usage.
+- **Stale funder briefs DELETED from `downloads/`** (sefa/snow/centrecorp, June exports, $475K +
+  Centrecorp-as-funder). Wiki originals untouched. `downloads/investor-deck-full.pdf` replaced
+  with a fresh render: deck HTML's "accountant-signed" label fixed (ruling G/H),
+  `canon-numbers.json` rebuilt (was stale: 496/9 → 540/11).
+- **`tools/design-push.mjs`**: stage → bake CANON tokens → negation-aware claim-ceiling gate →
+  push plan + sentinel. Proven end-to-end. `invest-funder-pipeline.html` on a hard never-push list.
 
 ---
 

--- a/thoughts/shared/handoffs/pitch-decks/current.md
+++ b/thoughts/shared/handoffs/pitch-decks/current.md
@@ -75,19 +75,21 @@ Whether Design can reach parity is an open question nobody has actually asked.
 
 ---
 
-## The one manual step (blocking the gallery)
+## ~~The one manual step~~ SOLVED 2026-08-05 (research session)
 
-Open **claude.ai/design** → project "Goods on Country — Investor Materials" → in-app chat, paste:
+**The reindex trigger is the sentinel file `_ds_needs_recompile`.** Write it (empty) via
+`finalize_plan` + `write_files`; the app rebuilds `_ds_manifest.json` from the `@dsCard` markers
+next time the project is opened, and dangling entries for deleted files drop automatically.
+The sentinel has been WRITTEN to `b333c5aa` — **the gallery fixes itself the next time Ben opens
+the project.** No chat paste needed. This also explains the old behaviour: fresh projects compile
+on first open; later batches never indexed because no sentinel was written.
 
-> Reindex the design system cards. `preview/invest-funder-pipeline.html` was deleted and its
-> manifest entry is dangling. Pick up the new `Deck chrome` group (4 cards),
-> `preview/invest-loi-ladder.html`, and `preview/invest-next-phase.html`, and refresh the card
-> names and subtitles from the `@dsCard` markers.
-
-**Until this runs the gallery is WORSE than before**, because the manifest still points at the
-deleted `invest-funder-pipeline.html` and will render "file not found" — the exact dangling-entry
-failure that caused the migration off project `a24f62c8` in July. File contents are all correct
-and live; only the index lags.
+Source: the `/design-sync` skill, which turned out to be **built into Claude Code** (binary
+2.1.220, `claude-cli-design-sync`) — unlisted but loadable with `Skill(skill:"design-sync")`;
+converter scripts at `/private/tmp/claude-501/bundled-skills/2.1.220/…/design-sync/`. Full recipe
+per the skill: sentinel before a big push, files, sentinel re-write after every push; pin
+projectId in `.design-sync/config.json`; `_ds_sync.json` anchor written last; never use
+`register_assets`.
 
 ---
 

--- a/tools/design-push.mjs
+++ b/tools/design-push.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * DESIGN PUSH — the one method, applied to the Claude Design project.
+ *
+ * The Design project (claude.ai/design, "Goods on Country — Investor Materials",
+ * b333c5aa-2dfa-4043-ab5f-ef7460692623) is a RENDER TARGET of the repo spine, never a
+ * source. This script makes that true mechanically: it stages the cards + README, bakes
+ * canon tokens from canon.ts, refuses to stage anything that breaks the claim ceiling,
+ * and emits a push plan the Claude session executes with the DesignSync tool.
+ *
+ * Pipeline:
+ *   1. Regenerate design/canon-numbers.json from canon.ts (drift dies here, not in a card).
+ *   2. Stage README.md + preview HTML into design/brand/claude-design/.push/, running
+ *      canon-render.mjs on each HTML (CANON:num:<id> and CANON:<slot> tokens bake) and a
+ *      plain token pass over the README.
+ *   3. CLAIM-CEILING GATE over every staged file: retired figures and banned phrases fail
+ *      the run with file:line. A figure hand-typed into a card dies here when it drifts.
+ *   4. Write .push/push-plan.json + the _ds_needs_recompile sentinel. The Claude session
+ *      then runs: DesignSync finalize_plan (localDir = .push, writes from the plan) →
+ *      write_files per chunk (≤10 files/call, images larger) → sentinel last.
+ *
+ * The sentinel is what makes the app rebuild _ds_manifest.json from @dsCard markers on
+ * next open (solved 2026-08-05). Never use register_assets — legacy, does nothing.
+ *
+ * Usage: node tools/design-push.mjs [--check-only]
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SRC = path.join(REPO, 'design/brand/claude-design');
+const STAGE = path.join(SRC, '.push');
+const PROJECT_ID = 'b333c5aa-2dfa-4043-ab5f-ef7460692623';
+const checkOnly = process.argv.includes('--check-only');
+
+// Files that exist locally but must NEVER be pushed. invest-funder-pipeline.html was
+// deleted from the project on 2026-08-05 (named funders with amounts — same leak class
+// as the /pitch/deck presenter script); the local copy is retained as a record only.
+const NEVER_PUSH = new Set(['invest-funder-pipeline.html']);
+
+// The claim ceiling, as greps. Sources: ruling V (2026-08-01), ruling G/H (2026-07-25),
+// Ben's Centrecorp call (2026-08-02), canon as of 2026-08-05. Case-insensitive.
+// A hit = the staged bundle is lying to a funder; the push refuses.
+const BANNED = [
+  [/accountant.signed/i, 'ruling G/H: the revenue figure is a workpaper'],
+  [/co.design/i, 'voice: designed in/with community, never co-designed'],
+  [/dollar.for.dollar/i, 'ruling V: QBE money is catalytic, not matched'],
+  [/1:1 match|matched at least/i, 'ruling V: no 1:1 match exists'],
+  [/\$?150k\s*floor/i, 'ruling V: no $150K floor exists'],
+  [/\$475/, 'stack is $400K — Centrecorp ($75K) is a buyer, not a funder'],
+  [/496\s*beds/i, 'canon: 540 beds'],
+  [/\b9 communities/i, 'canon: 11 communities'],
+  [/2,?660\s*kg/i, 'canon: 3,540kg HDPE'],
+  [/\$607[.,]?5/, 'retired figure: the $607.5K counted a bed buyer'],
+  [/centrecorp[^.]{0,60}(grant|funder|stack|pledge)/i, 'Centrecorp is a BUYER (Ben 2026-08-02)'],
+];
+
+// Negation awareness (same problem check-retired-figures.mjs solves): the corrected
+// cards and the README's claim-ceiling section QUOTE the banned claims to refute them.
+// A line that is denying the claim is not making it.
+const NEGATED = /\b(never|not|no longer|no floor|there is no|isn'?t|is not|was not|wrong|error|retired|struck|superseded|reclassified|correction|instead of|rather than|does not exist|creates no|obliges .{0,20}nothing)\b/i;
+
+const run = (cmd, args) => execFileSync(cmd, args, { cwd: REPO, stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+
+// 1. Canon numbers regenerate from the spine.
+run('node', ['v2/scripts/canon-numbers.mjs']);
+const canon = JSON.parse(fs.readFileSync(path.join(REPO, 'design/canon-numbers.json'), 'utf8')).numbers;
+
+// 2. Stage.
+fs.rmSync(STAGE, { recursive: true, force: true });
+fs.mkdirSync(path.join(STAGE, 'preview'), { recursive: true });
+
+const staged = [];
+for (const f of fs.readdirSync(path.join(SRC, 'preview'))) {
+  if (NEVER_PUSH.has(f)) continue;
+  if (!f.endsWith('.html') && f !== '_base.css') continue;
+  const src = path.join(SRC, 'preview', f);
+  const out = path.join(STAGE, 'preview', f);
+  if (f.endsWith('.html')) {
+    run('node', ['v2/scripts/canon-render.mjs', src, '-o', out]);
+  } else {
+    fs.copyFileSync(src, out);
+  }
+  staged.push(`preview/${f}`);
+}
+
+// README: plain CANON:num token pass (canon-render is HTML-shaped; the README is md).
+let readme = fs.readFileSync(path.join(SRC, 'README.md'), 'utf8');
+readme = readme.replace(/CANON:num:([a-z0-9-]+)/g, (m, id) => canon[id]?.value ?? m);
+const unresolved = readme.match(/CANON:num:[a-z0-9-]+/g);
+if (unresolved) fail(`README has unresolved canon tokens: ${unresolved.join(', ')}`);
+fs.writeFileSync(path.join(STAGE, 'README.md'), readme);
+staged.push('README.md');
+
+// 3. Claim-ceiling gate over the staged output (the thing that actually ships).
+const hits = [];
+for (const rel of staged) {
+  if (!rel.endsWith('.html') && !rel.endsWith('.md')) continue;
+  const lines = fs.readFileSync(path.join(STAGE, rel), 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    if (NEGATED.test(line) || NEGATED.test(lines[i - 1] ?? '')) return;
+    for (const [re, why] of BANNED) {
+      if (re.test(line)) hits.push(`  ${rel}:${i + 1}  [${re}]  ${why}`);
+    }
+  });
+}
+if (hits.length) fail(`claim-ceiling violations in staged bundle:\n${hits.join('\n')}`);
+
+// README figure tie-out: hand-typed figures must match canon or the push refuses.
+const tieOut = [
+  ['beds-deployed', /\b(\d{3}) beds/],
+  ['communities-served', /\b(\d{1,2}) communities/],
+  ['plastic-kg', /([\d,]+)\s?kg/i],
+];
+for (const [id, re] of tieOut) {
+  const m = readme.match(re);
+  if (m && m[1].replace(/,/g, '') !== String(canon[id].raw)) {
+    fail(`README says "${m[0]}" but canon ${id} = ${canon[id].value} — fix the README or canon.ts`);
+  }
+}
+
+// 4. Sentinel + plan.
+fs.writeFileSync(path.join(STAGE, '_ds_needs_recompile'), '');
+staged.push('_ds_needs_recompile');
+const plan = {
+  projectId: PROJECT_ID,
+  localDir: STAGE,
+  writes: ['preview/**', 'README.md', '_ds_needs_recompile'],
+  files: staged.map((p) => ({ path: p, localPath: p })),
+  note: 'DesignSync: finalize_plan with these writes, write_files in ≤10-file chunks, sentinel LAST.',
+  generatedAt: new Date().toISOString(),
+};
+fs.writeFileSync(path.join(STAGE, 'push-plan.json'), JSON.stringify(plan, null, 2));
+
+console.log(`design-push: ${staged.length} files staged clean -> ${path.relative(REPO, STAGE)}/`);
+console.log(checkOnly ? 'check-only: no plan consumed.' : `plan: ${path.relative(REPO, STAGE)}/push-plan.json — hand to the Claude session to execute via DesignSync.`);
+
+function fail(msg) {
+  console.error(`design-push: REFUSED — ${msg}`);
+  process.exit(1);
+}

--- a/v2/src/app/globals.css
+++ b/v2/src/app/globals.css
@@ -177,6 +177,68 @@
   }
 }
 
+/* ---------------------------------------------------------------------------
+   The pitch deck, presented and printed.
+
+   `/pitch/road` is authored as one panel per viewport and then served as a
+   scroll. These two blocks are the other two ways to read it, and neither
+   duplicates the content: slide mode is the same DOM with one panel shown, and
+   the print path is the same DOM again with a page break between panels.
+
+   This is what retires the drifting PowerPoint in `deliverables/`. A deck that
+   can be presented and printed from the page it is written on cannot fall out
+   of step with the page it is written on.
+   --------------------------------------------------------------------------- */
+
+/* Slide mode. The chrome bar is fixed to the bottom, so the panel needs room
+   under it, and panels authored with `min-h-screen` must not exceed the screen
+   or the transport scrolls away. */
+body[data-pitch-mode='slides'] [data-pitch-panel] {
+  min-height: calc(100svh - 3.25rem) !important;
+  height: auto;
+}
+
+body[data-pitch-mode='slides'] .road-pitch-scroll {
+  padding-bottom: 3.25rem;
+}
+
+@media print {
+  /* The apparatus is not part of the artifact. */
+  [data-pitch-bar],
+  .road-pitch-editor,
+  /* The in-hero anchor cluster only. The <nav> itself stays, because it carries
+     the wordmark and the cover needs its branding on paper. */
+  header nav a[href^='#'] {
+    display: none !important;
+  }
+
+  /* One panel per page. `break-inside: avoid` keeps a stop from splitting
+     across a page boundary, which is what made the old PDF unreadable. */
+  [data-pitch-panel] {
+    break-after: page;
+    break-inside: avoid;
+    min-height: 0 !important;
+    height: auto !important;
+    overflow: visible !important;
+  }
+
+  [data-pitch-panel]:last-of-type {
+    break-after: auto;
+  }
+
+  /* The deck is dark-on-light in places and light-on-dark in others. Without
+     this, the dark panels print as white text on white paper. */
+  * {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  html,
+  body {
+    background: #fbf8f1;
+  }
+}
+
 /* Custom animations */
 @keyframes shake {
   0%, 100% { transform: translateX(0); }

--- a/v2/src/app/pitch/road/page.tsx
+++ b/v2/src/app/pitch/road/page.tsx
@@ -9,6 +9,7 @@ import { deckSlides, deckUpdated, type DeckSlide } from '@/lib/data/deck';
 import { getStoryteller } from '@/lib/data/storyteller-registry';
 import { RoadPitchMap } from './road-map';
 import { RoadPitchEditor } from './road-pitch-editor';
+import { PitchChrome } from './pitch-chrome';
 import { ZoomableBedImage } from './zoomable-bed-image';
 import { ProductionFacilityExperience } from './production-facility-experience';
 import { MykelStoryMedia } from './mykel-story-media';
@@ -228,7 +229,7 @@ export default function RoadPitchPage() {
 
   return (
     <article className="road-pitch-scroll overflow-x-hidden bg-[#fbf8f1] text-[#2b2a26]">
-      <header className="relative min-h-screen overflow-hidden bg-[#171714] text-[#fbf8f1]">
+      <header id="cover" data-pitch-panel="cover" className="relative min-h-screen overflow-hidden bg-[#171714] text-[#fbf8f1]">
         <div data-road-media="cover.photo" className="absolute inset-y-0 right-0 w-full lg:w-[56%]">
           <Image
             src="/images/media-pack/lying-on-stretch-bed.jpg"
@@ -277,12 +278,12 @@ export default function RoadPitchPage() {
                 >
                   Walk the road
                 </a>
-                <Link
-                  href="/pitch/deck"
+                <a
+                  href="?view=slides"
                   className="border border-white/35 px-6 py-3 text-sm font-semibold text-white hover:border-white"
                 >
-                  Open the slide deck
-                </Link>
+                  Present as slides
+                </a>
               </div>
               <p className="mt-8 border-t border-white/20 pt-5 font-mono text-[10px] uppercase leading-6 tracking-[0.13em] text-white/55">
                 <span className="text-white">{CANONICAL_ASSETS.bedsDeployed}</span> beds
@@ -298,7 +299,9 @@ export default function RoadPitchPage() {
         </div>
       </header>
 
-      <section id="road" className="border-b border-[#e6dfd1] lg:h-[100svh] lg:min-h-[760px] lg:overflow-hidden">
+      <PitchChrome />
+
+      <section id="road" data-pitch-panel="road" className="border-b border-[#e6dfd1] lg:h-[100svh] lg:min-h-[760px] lg:overflow-hidden">
         <div className="mx-auto flex h-full max-w-[1600px] flex-col px-6 py-10 md:px-10 lg:px-14 lg:py-8">
           <div className="grid gap-8 lg:grid-cols-2 lg:items-end">
             <div>
@@ -371,6 +374,7 @@ export default function RoadPitchPage() {
             <section
               key={stop.id}
               id={stop.id}
+              data-pitch-panel={stop.id}
               className="border-b border-[#d9d1c3] bg-[#fbf8f1] px-5 py-7 md:px-8 md:py-9 lg:h-[100svh] lg:min-h-[720px] lg:overflow-hidden lg:px-10"
             >
               <div className="mx-auto grid h-full max-w-[1700px] gap-5 lg:grid-rows-[auto_minmax(0,1fr)]">
@@ -456,6 +460,7 @@ export default function RoadPitchPage() {
           <Fragment key={stop.id}>
           <section
             id={stop.id}
+            data-pitch-panel={stop.id}
             className={`border-b border-[#e6dfd1] lg:h-[100svh] lg:min-h-[680px] lg:overflow-hidden ${
               index === 4 || index === 6 ? 'bg-[#22211e] text-[#fbf8f1]' : 'bg-[#fbf8f1]'
             }`}
@@ -586,6 +591,7 @@ export default function RoadPitchPage() {
           {index === 3 && resolvedProductSlide && (
             <section
               id={resolvedProductSlide.id}
+              data-pitch-panel={resolvedProductSlide.id}
               className="border-b border-[#d9d1c3] bg-[#fbf8f1] px-6 py-8 md:min-h-screen md:px-10 md:py-10 lg:px-14"
             >
               <div className="mx-auto flex max-w-[1600px] flex-col justify-center md:min-h-[calc(100vh-5rem)]">
@@ -712,7 +718,7 @@ export default function RoadPitchPage() {
         );
       })}
 
-      <section id="map" className="min-h-screen bg-[#171714] px-6 py-10 text-[#fbf8f1] md:px-10 md:py-12 lg:px-14">
+      <section id="map" data-pitch-panel="map" className="min-h-screen bg-[#171714] px-6 py-10 text-[#fbf8f1] md:px-10 md:py-12 lg:px-14">
         <div className="mx-auto max-w-[1500px]">
           <div className="mb-8 grid gap-5 sm:grid-cols-[0.9fr_1.1fr] sm:items-end">
             <div>
@@ -733,7 +739,7 @@ export default function RoadPitchPage() {
         </div>
       </section>
 
-      <section id="model" className="border-b border-[#d9d1c3] bg-[#f1ece4] px-6 py-12 md:px-10 lg:min-h-screen lg:px-14">
+      <section id="model" data-pitch-panel="model" className="border-b border-[#d9d1c3] bg-[#f1ece4] px-6 py-12 md:px-10 lg:min-h-screen lg:px-14">
         <div className="mx-auto flex max-w-[1500px] flex-col justify-center lg:min-h-[calc(100vh-6rem)]">
           <div className="grid gap-10 lg:grid-cols-[0.72fr_1.28fr] lg:items-center">
             <div className="max-w-3xl">
@@ -772,7 +778,7 @@ export default function RoadPitchPage() {
         </div>
       </section>
 
-      <section id="one-bed" className="border-b border-[#d9d1c3] bg-[#fbf8f1] px-6 py-14 md:px-10 lg:px-14 lg:py-20">
+      <section id="one-bed" data-pitch-panel="one-bed" className="border-b border-[#d9d1c3] bg-[#fbf8f1] px-6 py-14 md:px-10 lg:px-14 lg:py-20">
         <div className="mx-auto max-w-[1600px]">
           <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#c45c3e]">
             One bed, plainly
@@ -833,7 +839,7 @@ export default function RoadPitchPage() {
         </div>
       </section>
 
-      <section id="the-stopwatch" className="bg-[#171714] text-[#fbf8f1]">
+      <section id="the-stopwatch" data-pitch-panel="the-stopwatch" className="bg-[#171714] text-[#fbf8f1]">
         <div className="mx-auto grid max-w-[1800px] lg:grid-cols-[0.85fr_1.15fr]">
           <div className="relative min-h-[45vh] lg:min-h-screen">
             <Image
@@ -906,7 +912,7 @@ export default function RoadPitchPage() {
         </div>
       </section>
 
-      <section id="the-chain" className="border-b border-[#d9d1c3] bg-[#fbf8f1] px-6 py-14 md:px-10 lg:px-14 lg:py-20">
+      <section id="the-chain" data-pitch-panel="the-chain" className="border-b border-[#d9d1c3] bg-[#fbf8f1] px-6 py-14 md:px-10 lg:px-14 lg:py-20">
         <div className="mx-auto max-w-[1600px]">
           <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#c45c3e]">
             {CHAIN_INTRO.eyebrow}
@@ -1030,7 +1036,7 @@ export default function RoadPitchPage() {
           </p>
         </div>
       </section>
-      <section id="four-asks" className="border-b border-[#d9d1c3] bg-[#f1ece4]">
+      <section id="four-asks" data-pitch-panel="four-asks" className="border-b border-[#d9d1c3] bg-[#f1ece4]">
         <div className="mx-auto max-w-[1600px] px-6 py-14 md:px-10 lg:px-14 lg:py-20">
           <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#c45c3e]">
             Where they are, in what they asked for
@@ -1124,7 +1130,7 @@ export default function RoadPitchPage() {
         </div>
       </section>
 
-      <section id="the-letter" className="bg-[#171714] px-6 py-16 text-[#fbf8f1] md:px-10 lg:px-14 lg:py-20">
+      <section id="the-letter" data-pitch-panel="the-letter" className="bg-[#171714] px-6 py-16 text-[#fbf8f1] md:px-10 lg:px-14 lg:py-20">
         <div className="mx-auto max-w-[1600px]">
           <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#e88461]">
             The ask
@@ -1218,7 +1224,7 @@ export default function RoadPitchPage() {
         </div>
       </section>
 
-      <footer data-road-media="closing.photo" className="relative min-h-screen overflow-hidden bg-[#171714] text-white">
+      <footer id="closing" data-pitch-panel="closing" data-road-media="closing.photo" className="relative min-h-screen overflow-hidden bg-[#171714] text-white">
         <Image
           src={closingSlide?.photo ?? '/images/media-pack/lying-on-stretch-bed.jpg'}
           alt={closingSlide?.photoAlt ?? ''}

--- a/v2/src/app/pitch/road/pitch-chrome.tsx
+++ b/v2/src/app/pitch/road/pitch-chrome.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+/**
+ * The reading apparatus for `/pitch/road`. Content lives in `page.tsx` and `deck.ts`; this file
+ * only decides what is shown, in what order, and how you move through it.
+ *
+ * It works on the rendered DOM by panel id rather than owning the markup, for one reason: the deck
+ * is 1,253 lines of server-rendered sections with images, maps and video in them, and pulling that
+ * through a client component would cost the streaming and the priority hints for no gain. Every
+ * panel already carries the id this needs.
+ *
+ * Three modes, all driven from the query string so a link can carry them:
+ *
+ *   ?for=funder|supporter|press   which panels exist at all
+ *   ?view=slides                  one panel per screen, arrow keys, counter
+ *   (print)                       the browser's own print path, styled to one panel per page
+ *
+ * State is read from `window.location` in an effect and written back with `replaceState` rather
+ * than through `useSearchParams`, which would force a Suspense boundary around the whole deck for
+ * a nav bar.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  DEFAULT_PACK,
+  OPENER_HEADING,
+  OPENER_LINES,
+  PITCH_APPENDICES,
+  PITCH_CHAPTERS,
+  PITCH_PACKS,
+  panelsForPack,
+  pitchPack,
+  resolvePack,
+  type PitchPackId,
+} from '@/lib/data/pitch-chrome';
+
+type Mode = 'scroll' | 'slides';
+
+export function PitchChrome() {
+  const [pack, setPack] = useState<PitchPackId>(DEFAULT_PACK);
+  const [mode, setMode] = useState<Mode>('scroll');
+  const [index, setIndex] = useState(0);
+  const [ready, setReady] = useState(false);
+  const [navOpen, setNavOpen] = useState(false);
+
+  const panels = useMemo(() => panelsForPack(pack), [pack]);
+
+  // Read the query string once on mount. Before this runs the page is the funder deck in scroll
+  // mode, which is the correct no-JS result too.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setPack(resolvePack(params.get('for') ?? undefined));
+    setMode(params.get('view') === 'slides' ? 'slides' : 'scroll');
+    setReady(true);
+  }, []);
+
+  // Keep the URL honest, so any state a presenter reaches is a link they can send.
+  useEffect(() => {
+    if (!ready) return;
+    const params = new URLSearchParams(window.location.search);
+    if (pack === DEFAULT_PACK) params.delete('for');
+    else params.set('for', pack);
+    if (mode === 'slides') params.set('view', 'slides');
+    else params.delete('view');
+    const query = params.toString();
+    window.history.replaceState(null, '', query ? `?${query}` : window.location.pathname);
+  }, [pack, mode, ready]);
+
+  /** Apply pack and mode to the rendered panels. The only place display is touched. */
+  useEffect(() => {
+    if (!ready) return;
+    const visible = new Set(panels.map((panel) => panel.id));
+    const all = document.querySelectorAll<HTMLElement>('[data-pitch-panel]');
+
+    all.forEach((el) => {
+      const id = el.dataset.pitchPanel ?? '';
+      const inPack = visible.has(id);
+      const isCurrent = mode === 'scroll' || panels[index]?.id === id;
+      el.style.display = inPack && isCurrent ? '' : 'none';
+    });
+
+    document.body.dataset.pitchMode = mode;
+    return () => {
+      all.forEach((el) => {
+        el.style.display = '';
+      });
+      delete document.body.dataset.pitchMode;
+    };
+  }, [panels, mode, index, ready]);
+
+  // A pack change can leave the cursor past the end of a shorter cut.
+  useEffect(() => {
+    setIndex((current) => Math.min(current, Math.max(panels.length - 1, 0)));
+  }, [panels.length]);
+
+  const go = useCallback(
+    (delta: number) => {
+      setIndex((current) => Math.min(Math.max(current + delta, 0), panels.length - 1));
+      window.scrollTo({ top: 0, behavior: 'auto' });
+    },
+    [panels.length],
+  );
+
+  // Arrow keys in slide mode, and Escape back to the scroll. Ignored while typing, because the
+  // deck carries an inline editor.
+  useEffect(() => {
+    if (mode !== 'slides') return;
+    const onKey = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target?.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target?.tagName ?? '')) return;
+      if (event.key === 'ArrowRight' || event.key === 'PageDown' || event.key === ' ') {
+        event.preventDefault();
+        go(1);
+      } else if (event.key === 'ArrowLeft' || event.key === 'PageUp') {
+        event.preventDefault();
+        go(-1);
+      } else if (event.key === 'Escape') {
+        setMode('scroll');
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [mode, go]);
+
+  // Scrollspy, so the nav names where you are rather than only where you can go.
+  useEffect(() => {
+    if (!ready || mode !== 'scroll') return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const hit = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+        if (!hit) return;
+        const id = (hit.target as HTMLElement).dataset.pitchPanel;
+        const next = panels.findIndex((panel) => panel.id === id);
+        if (next >= 0) setIndex(next);
+      },
+      { rootMargin: '-45% 0px -45% 0px', threshold: [0, 0.25, 0.5] },
+    );
+    document.querySelectorAll<HTMLElement>('[data-pitch-panel]').forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
+  }, [panels, mode, ready]);
+
+  const current = panels[index];
+  const chapters = PITCH_CHAPTERS.filter((chapter) =>
+    panels.some((panel) => panel.chapter === chapter.id),
+  );
+
+  return (
+    <>
+      {/* The "if you read nothing else" block. First panel only, and never in slide mode, where
+          the cover carries the same job with a photograph. */}
+      {mode === 'scroll' && (
+        <aside
+          data-pitch-opener
+          className="border-b border-[#d9d1c3] bg-[#f1ece4] px-6 py-10 md:px-10 lg:px-14"
+        >
+          <div className="mx-auto max-w-[1100px]">
+            <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#c45c3e]">
+              {OPENER_HEADING}
+            </p>
+            <ol className="mt-6 space-y-4">
+              {OPENER_LINES.map((line, i) => (
+                <li key={line} className="flex gap-4 text-lg leading-8 text-[#2b2a26] md:text-xl md:leading-9">
+                  <span className="font-mono text-[11px] leading-9 text-[#c45c3e]">{i + 1}</span>
+                  <span>{line}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </aside>
+      )}
+
+      {/* The bar. Sticky in scroll mode so wayfinding survives past the hero; fixed to the bottom
+          in slide mode where it is the transport. */}
+      <div
+        data-pitch-bar
+        className={`z-40 border-t border-white/15 bg-[#171714]/95 text-white backdrop-blur ${
+          mode === 'slides' ? 'fixed inset-x-0 bottom-0' : 'sticky top-0 border-b border-t-0'
+        }`}
+      >
+        <div className="mx-auto flex max-w-[1600px] flex-wrap items-center gap-x-5 gap-y-2 px-6 py-2.5 md:px-10 lg:px-14">
+          <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-white/45">
+            {index + 1}/{panels.length}
+          </span>
+          <span className="max-w-[42vw] truncate text-sm font-semibold">{current?.label}</span>
+
+          {mode === 'slides' ? (
+            <span className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => go(-1)}
+                disabled={index === 0}
+                className="border border-white/25 px-3 py-1 text-xs disabled:opacity-30"
+              >
+                Prev
+              </button>
+              <button
+                type="button"
+                onClick={() => go(1)}
+                disabled={index === panels.length - 1}
+                className="border border-white/25 px-3 py-1 text-xs disabled:opacity-30"
+              >
+                Next
+              </button>
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setNavOpen((open) => !open)}
+              className="border border-white/25 px-3 py-1 text-xs"
+              aria-expanded={navOpen}
+            >
+              {navOpen ? 'Hide contents' : 'Contents'}
+            </button>
+          )}
+
+          <span className="ml-auto flex items-center gap-2">
+            <label className="sr-only" htmlFor="pitch-pack">Reader</label>
+            <select
+              id="pitch-pack"
+              value={pack}
+              onChange={(event) => {
+                setPack(event.target.value as PitchPackId);
+                setIndex(0);
+              }}
+              className="border border-white/25 bg-transparent px-2 py-1 text-xs text-white [&>option]:text-black"
+              title={pitchPack(pack).blurb}
+            >
+              {PITCH_PACKS.map((entry) => (
+                <option key={entry.id} value={entry.id}>
+                  {entry.label}
+                </option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={() => {
+                setMode(mode === 'slides' ? 'scroll' : 'slides');
+                setIndex(0);
+                window.scrollTo({ top: 0 });
+              }}
+              className="border border-white/25 px-3 py-1 text-xs"
+            >
+              {mode === 'slides' ? 'Read as page' : 'Present'}
+            </button>
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="border border-white/25 px-3 py-1 text-xs"
+            >
+              PDF
+            </button>
+          </span>
+        </div>
+
+        {/* Contents, grouped by chapter so eighteen panels read as five parts. */}
+        {navOpen && mode === 'scroll' && (
+          <div className="border-t border-white/15 px-6 pb-5 pt-4 md:px-10 lg:px-14">
+            <div className="mx-auto grid max-w-[1600px] gap-5 sm:grid-cols-2 lg:grid-cols-5">
+              {chapters.map((chapter) => (
+                <div key={chapter.id}>
+                  <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#d97a59]">
+                    {chapter.label}
+                  </p>
+                  <ul className="mt-2 space-y-1">
+                    {panels
+                      .filter((panel) => panel.chapter === chapter.id)
+                      .map((panel) => (
+                        <li key={panel.id}>
+                          <a
+                            href={`#${panel.id}`}
+                            onClick={() => setNavOpen(false)}
+                            className={`block truncate py-0.5 text-sm hover:text-white ${
+                              panel.id === current?.id ? 'text-white' : 'text-white/55'
+                            }`}
+                          >
+                            {panel.label}
+                          </a>
+                        </li>
+                      ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+
+            {/* Appendices. Named here so the supporting surfaces stay reachable FROM the deck
+                rather than competing with it as separate front doors. */}
+            <div className="mx-auto mt-5 max-w-[1600px] border-t border-white/15 pt-4">
+              <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-[#d97a59]">
+                Appendices
+              </p>
+              <ul className="mt-2 flex flex-wrap gap-x-6 gap-y-1">
+                {PITCH_APPENDICES.map((appendix) => (
+                  <li key={appendix.href}>
+                    <a
+                      href={appendix.href}
+                      title={appendix.answers}
+                      className="text-sm text-white/55 underline-offset-4 hover:text-white hover:underline"
+                    >
+                      {appendix.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/v2/src/app/pitch/road/road-pitch-editor.tsx
+++ b/v2/src/app/pitch/road/road-pitch-editor.tsx
@@ -169,7 +169,7 @@ export function RoadPitchEditor() {
 
   return (
     <>
-      <div className="fixed bottom-5 right-5 z-[100] flex items-center gap-2 rounded-full border border-white/15 bg-[#171714] p-2 text-white shadow-2xl">
+      <div className="road-pitch-editor fixed bottom-5 right-5 z-[100] flex items-center gap-2 rounded-full border border-white/15 bg-[#171714] p-2 text-white shadow-2xl">
         <button
           type="button"
           onClick={() => setEditing((value) => !value)}

--- a/v2/src/components/pitch/pitch-surface-notice.tsx
+++ b/v2/src/components/pitch/pitch-surface-notice.tsx
@@ -1,29 +1,37 @@
 /**
  * Signposting for the pitch surfaces.
  *
- * The problem this solves (2026-07-25): there are eleven /pitch/* routes plus /deck, and none of
+ * The problem this solved (2026-07-25): there were eleven /pitch/* routes plus /deck, and none of
  * them said which one to send to a funder. Every route reads from canon.ts so none of them are
  * WRONG, which is exactly why the sprawl was hard to notice. The fix is a pointer, not a warning.
  *
- * THE canonical funder surface is /pitch/funder-pathways.
- * THE canonical deck is /pitch/road (ruling R, 2026-07-26), built on the road spine from canon.
- * /pitch/simple was retired 2026-08-02 (ruling W) and now redirects here. Its PDF pipeline was
- * broken: the renderer it named did not exist, so nothing had regenerated since 25 July.
+ * ---------------------------------------------------------------------------
+ * THE CORRECTION, 2026-08-04
+ * ---------------------------------------------------------------------------
+ * This file used to hardcode `/pitch/funder-pathways` as the canonical funder surface. By then
+ * three other places said otherwise and agreed with each other: ruling R named `/pitch/road` THE
+ * deck, `audience.ts` set `funder.frontDoor` to `/pitch/road`, and `next.config` redirected seven
+ * pitch routes there. So the supporting surfaces were signposting funders AWAY from the front
+ * door, which is the exact failure the component was written to prevent.
+ *
+ * It now reads the front door out of `audience.ts` instead of restating it. A hardcoded constant
+ * is what drifted; a lookup cannot. If the funder front door ever moves, it moves in one place and
+ * every notice follows.
+ *
+ * The three surviving supporting surfaces are APPENDICES to the deck, not alternatives to it:
+ *   /pitch/funder-pathways   how a request becomes a priced pathway
+ *   /pitch/community-narrative  the storyteller cut
+ *   /pitch/document          the long-form written version
+ * Each answers a question the deck raises. None of them is a front door.
  */
 
-const CANONICAL_HREF = '/pitch/funder-pathways';
+import { audience } from '@/lib/data/audience';
+
+/** Never restated here. `audience.ts` is where a front door is decided. */
+const FUNDER_FRONT_DOOR = audience('funder').frontDoor ?? '/pitch/road';
 
 export function CanonicalPitchNotice() {
-  return (
-    <div className="border-b border-[#c9b89a] bg-[#f0e5cf] px-5 py-2.5 text-center">
-      <p className="text-xs tracking-[0.12em] text-[#6b5836] uppercase">
-        Canonical funder surface · deck at{' '}
-        <a href="/pitch/road" className="underline decoration-[#b9852f] underline-offset-2">
-          /pitch/road
-        </a>
-      </p>
-    </div>
-  );
+  return <OtherPitchSurfaceNotice note="This is the funder pathways appendix." />;
 }
 
 export function OtherPitchSurfaceNotice({ note }: { note?: string }) {
@@ -31,12 +39,12 @@ export function OtherPitchSurfaceNotice({ note }: { note?: string }) {
     <div className="border-b border-[#d8cdbd] bg-[#efe8dc] px-5 py-2.5 text-center">
       <p className="text-xs leading-5 text-[#6b5f4c]">
         {note ? `${note} ` : 'This is a supporting pitch surface. '}
-        The one to send a funder is{' '}
+        It is an appendix to the deck. The one to send a funder is{' '}
         <a
-          href={CANONICAL_HREF}
+          href={FUNDER_FRONT_DOOR}
           className="font-semibold underline decoration-[#b65738] underline-offset-2"
         >
-          /pitch/funder-pathways
+          {FUNDER_FRONT_DOOR}
         </a>
         .
       </p>

--- a/v2/src/lib/data/pitch-chrome.guards.test.ts
+++ b/v2/src/lib/data/pitch-chrome.guards.test.ts
@@ -1,0 +1,168 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { deckSlides } from './deck';
+import { AUDIENCES } from './audience';
+import {
+  DEFAULT_PACK,
+  OPENER_BANNED,
+  OPENER_LINES,
+  PITCH_APPENDICES,
+  PITCH_CHAPTERS,
+  PITCH_PACKS,
+  PITCH_PANELS,
+  audienceForPack,
+  panelsForPack,
+  resolvePack,
+} from './pitch-chrome';
+
+describe('pitch panels mirror the deck rather than duplicating it', () => {
+  it('has no duplicate panel ids', () => {
+    const ids = PITCH_PANELS.map((panel) => panel.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every panel sits in a declared chapter', () => {
+    const chapters = new Set(PITCH_CHAPTERS.map((chapter) => chapter.id));
+    for (const panel of PITCH_PANELS) {
+      expect(chapters.has(panel.chapter), `${panel.id} has an undeclared chapter`).toBe(true);
+    }
+  });
+
+  /**
+   * The one that matters. `page.tsx` renders a section per road stop straight from `deckSlides`,
+   * plus the product slide after Palm Island. If a stop is added, removed or reordered in the deck
+   * and this list is not updated, the nav would quietly omit it and slide mode would skip it. This
+   * fails first instead.
+   */
+  it('the places chapter matches the deck source, in deck order', () => {
+    const fromDeck = deckSlides
+      .filter((slide) => slide.kind === 'stop' || slide.id === 'the-stretch-bed')
+      .map((slide) => slide.id);
+    const fromPanels = PITCH_PANELS.filter((panel) => panel.chapter === 'the-places').map(
+      (panel) => panel.id,
+    );
+    expect(fromPanels).toEqual(fromDeck);
+  });
+});
+
+describe('packs cut the deck without breaking the audience model', () => {
+  it('the funder pack is the deck as written, every panel', () => {
+    expect(panelsForPack('funder')).toEqual(PITCH_PANELS);
+  });
+
+  it('every cut is shorter than the funder deck and keeps reading order', () => {
+    for (const pack of PITCH_PACKS.filter((entry) => entry.id !== 'funder')) {
+      const panels = panelsForPack(pack.id);
+      expect(panels.length).toBeGreaterThan(0);
+      expect(panels.length).toBeLessThan(PITCH_PANELS.length);
+      const order = panels.map((panel) => PITCH_PANELS.indexOf(panel));
+      expect(order).toEqual([...order].sort((a, b) => a - b));
+    }
+  });
+
+  it('every pack names a real audience record', () => {
+    for (const pack of PITCH_PACKS) {
+      expect(audienceForPack(pack.id).id).toBe(pack.audience);
+    }
+  });
+
+  /**
+   * Not a preference. `buyer.mustNeverSee` forbids the impact story ahead of the specification and
+   * `community.mustNeverSee` forbids arriving with a proposal instead of a yarn. This page opens
+   * with the story and is a proposal throughout, so a pack for either audience would ship a known
+   * relationship-ending failure. Their front doors are `/shop` and a conversation.
+   */
+  it('refuses to cut this page for buyers or communities', () => {
+    const served = PITCH_PACKS.map((pack) => pack.audience);
+    expect(served).not.toContain('buyer');
+    expect(served).not.toContain('community');
+  });
+
+  it('the non-funder cuts carry no funding ask', () => {
+    for (const packId of ['supporter', 'press'] as const) {
+      const ids = panelsForPack(packId).map((panel) => panel.id);
+      expect(ids, `${packId} must not carry the ask`).not.toContain('four-asks');
+    }
+  });
+
+  it('an unknown or missing ?for= falls back to the deck as written', () => {
+    expect(resolvePack(undefined)).toBe(DEFAULT_PACK);
+    expect(resolvePack('investor')).toBe(DEFAULT_PACK);
+    expect(resolvePack('')).toBe(DEFAULT_PACK);
+    expect(resolvePack(['press', 'funder'])).toBe('press');
+    expect(DEFAULT_PACK).toBe('funder');
+  });
+
+  it('the audiences the packs name actually exist in the audience model', () => {
+    const known = new Set(AUDIENCES.map((entry) => entry.id));
+    for (const pack of PITCH_PACKS) expect(known.has(pack.audience)).toBe(true);
+  });
+});
+
+describe('the supporting surfaces are appendices, not front doors', () => {
+  it('every appendix names the question it answers', () => {
+    for (const appendix of PITCH_APPENDICES) {
+      expect(appendix.href.startsWith('/pitch/')).toBe(true);
+      expect(appendix.answers.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('the deck itself is never listed as its own appendix', () => {
+    expect(PITCH_APPENDICES.map((entry) => entry.href)).not.toContain('/pitch/road');
+  });
+
+  /**
+   * The exact drift that happened. `pitch-surface-notice.tsx` hardcoded `/pitch/funder-pathways`
+   * as the canonical funder surface while ruling R, `audience.ts` and `next.config` all said
+   * `/pitch/road`, so every supporting page signposted funders away from the front door. It now
+   * reads `audience('funder').frontDoor`. This asserts it still does.
+   */
+  it('the surface notice derives the front door instead of hardcoding one', () => {
+    const source = readFileSync(
+      new URL('../../components/pitch/pitch-surface-notice.tsx', import.meta.url),
+      'utf8',
+    );
+    const code = source.replace(/\/\*\*[\s\S]*?\*\//g, '');
+    expect(code).toContain("audience('funder').frontDoor");
+    expect(code.match(/'\/pitch\/funder-pathways'/)).toBeNull();
+  });
+
+  it('the funder front door is the deck', () => {
+    const funder = AUDIENCES.find((entry) => entry.id === 'funder');
+    expect(funder?.frontDoor).toBe('/pitch/road');
+  });
+});
+
+describe('the opener is the highest-risk prose in the system', () => {
+  it('is five lines', () => {
+    expect(OPENER_LINES).toHaveLength(5);
+  });
+
+  it('contains none of the banned phrases', () => {
+    const text = OPENER_LINES.join(' ').toLowerCase();
+    for (const phrase of OPENER_BANNED) {
+      expect(text, `opener must not contain "${phrase}"`).not.toContain(phrase);
+    }
+  });
+
+  /**
+   * The per-site annual running cost has four live answers and break-even moves from two sites to
+   * five across them. No site count may appear as settled until that is resolved.
+   * See `deliverables/GOC-site-cost-decision.md`.
+   */
+  it('states no site count as settled', () => {
+    const text = OPENER_LINES.join(' ').toLowerCase();
+    for (const claim of ['two sites', 'three sites', 'four sites', 'five sites']) {
+      expect(text).not.toContain(claim);
+    }
+  });
+
+  it('says nothing is signed, because that comes plainly and first', () => {
+    const text = OPENER_LINES.join(' ').toLowerCase();
+    expect(text).toContain('signed');
+  });
+
+  it('uses no em-dashes', () => {
+    for (const line of OPENER_LINES) expect(line).not.toContain('—');
+  });
+});

--- a/v2/src/lib/data/pitch-chrome.ts
+++ b/v2/src/lib/data/pitch-chrome.ts
@@ -1,0 +1,256 @@
+/**
+ * THE PITCH CHROME - the reading apparatus around `/pitch/road`.
+ *
+ * `/pitch/road` is the canonical deck (ruling R). Its content was never the problem. The problem
+ * was that it is a DECK RENDERED AS A DOCUMENT: eighteen panels, each already built one-per-
+ * viewport (`lg:h-[100svh]`), served as a single continuous scroll with no pagination, no map of
+ * where you are, no print path, and no way to hand a shorter cut to a reader who is not a funder.
+ *
+ * So five pitch artifacts existed instead of one. `/pitch/document` re-told the same story in
+ * prose because the deck could not be printed. A PowerPoint sat in `deliverables/` because the
+ * deck could not be presented. Both drift. Neither is the source.
+ *
+ * This module holds the apparatus, not the content:
+ *
+ *   PANELS  - the reading order, with a human label for each, so a nav can name where you are.
+ *   PACKS   - which panels a given audience gets, and in what order.
+ *   OPENER  - the "if you read nothing else" block, five lines, at the top.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THERE ARE THREE PACKS AND NOT SIX
+ * ---------------------------------------------------------------------------
+ * The obvious move is a pack per audience in `audience.ts`. It is wrong, and the model says so.
+ * `buyer.frontDoor` is `/shop`, and `buyer.mustNeverSee` forbids the impact story ahead of the
+ * spec, which is the whole first half of this page. `community.mustNeverSee` forbids arriving
+ * with a proposal instead of a yarn, and this page is a proposal from panel one. `partner` reads
+ * `/pathways`, which is a different artifact answering a different question.
+ *
+ * A deck cut for those audiences would be a worse version of a surface that already serves them.
+ * So the packs here are only the audiences whose front door genuinely IS this page: the funder it
+ * was written for, the supporter who wants the story without the ask, and the press who need the
+ * photographs and a person to ring. Adding a fourth is not a feature; it is a `mustNeverSee`
+ * violation waiting to ship. `pitch-chrome.guards.test.ts` asserts exactly that.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THE OPENER IS NOT ALLOWED TO SAY
+ * ---------------------------------------------------------------------------
+ * A five-line summary at the top of a funder deck is the single highest-risk block of prose in the
+ * system, because it is the part that gets read, quoted and pasted. Three things are banned in it
+ * and the guards enforce all three:
+ *
+ *   - A bed count used as a threshold, and a payback period used as a promise. Both are
+ *     `funder.mustNeverSee`.
+ *   - Any site count or break-even claim. What a site costs to run for a year has four live
+ *     answers ($15,000 / $48,333 / $64,333 / $79,333) and break-even moves from two sites to five
+ *     across them. Until that is settled with Nic, "three sites" is a number with no basis.
+ *     See `deliverables/GOC-site-cost-decision.md`.
+ *   - Anything that softens "$0 signed". `funder.needsToSee` puts it plainly and first, and the
+ *     opener is the first thing there is.
+ */
+
+import { AUDIENCES, type AudienceId } from './audience';
+
+// ---------------------------------------------------------------------------
+// Panels
+// ---------------------------------------------------------------------------
+
+/** The chapters a reader is moved through. Used to group the nav, so eighteen panels read as five
+ *  parts rather than a list of eighteen. */
+export type PitchChapter = 'the-road' | 'the-places' | 'the-map' | 'the-money' | 'the-close';
+
+export const PITCH_CHAPTERS: { id: PitchChapter; label: string }[] = [
+  { id: 'the-road', label: 'The road' },
+  { id: 'the-places', label: 'The places' },
+  { id: 'the-map', label: 'The map' },
+  { id: 'the-money', label: 'The money' },
+  { id: 'the-close', label: 'The close' },
+];
+
+export interface PitchPanel {
+  /** The DOM id already on the section in `page.tsx`. Not invented here; mirrored. */
+  id: string;
+  /** Short enough for a nav chip. Long labels defeat the purpose. */
+  label: string;
+  chapter: PitchChapter;
+  /**
+   * Which packs include this panel. `funder` is every panel by definition: it is the deck as
+   * written. The other two are cuts.
+   */
+  packs: PitchPackId[];
+}
+
+export type PitchPackId = 'funder' | 'supporter' | 'press';
+
+/**
+ * Reading order, mirroring the DOM order produced by `page.tsx`. The stop panels come from
+ * `deckSlides` and the guard test asserts this list still matches that source, so a slide added to
+ * the deck fails the build here rather than silently vanishing from the nav and the slide mode.
+ */
+export const PITCH_PANELS: PitchPanel[] = [
+  { id: 'cover', label: 'Cover', chapter: 'the-road', packs: ['funder', 'supporter', 'press'] },
+  { id: 'road', label: 'The road', chapter: 'the-road', packs: ['funder', 'supporter', 'press'] },
+
+  { id: 'stop-1-kalgoorlie', label: 'Ninga Mia', chapter: 'the-places', packs: ['funder', 'supporter', 'press'] },
+  { id: 'stop-2-tennant-creek', label: 'Warumungu Country', chapter: 'the-places', packs: ['funder', 'supporter', 'press'] },
+  { id: 'stop-3-the-machine-with-a-name', label: 'Name it', chapter: 'the-places', packs: ['funder', 'supporter', 'press'] },
+  { id: 'stop-4-palm-island', label: 'Bwgcolman', chapter: 'the-places', packs: ['funder', 'supporter', 'press'] },
+  { id: 'the-stretch-bed', label: 'The Stretch Bed', chapter: 'the-places', packs: ['funder', 'supporter', 'press'] },
+  { id: 'stop-5-utopia', label: 'Urapuntja', chapter: 'the-places', packs: ['funder', 'supporter', 'press'] },
+  { id: 'stop-6-maningrida-and-the-farm', label: 'Manayingkarírra', chapter: 'the-places', packs: ['funder', 'supporter', 'press'] },
+  { id: 'stop-7-oonchiumpa', label: 'Mparntwe', chapter: 'the-places', packs: ['funder', 'supporter', 'press'] },
+
+  { id: 'map', label: 'Where things went', chapter: 'the-map', packs: ['funder', 'supporter', 'press'] },
+
+  // The money half. A supporter did not come for the unit economics and a press reader must never
+  // be handed a funding ask as though it were a fact about the organisation.
+  { id: 'model', label: 'The model', chapter: 'the-money', packs: ['funder'] },
+  { id: 'one-bed', label: 'One bed', chapter: 'the-money', packs: ['funder'] },
+  { id: 'the-stopwatch', label: 'The stopwatch', chapter: 'the-money', packs: ['funder'] },
+  { id: 'the-chain', label: 'What it costs', chapter: 'the-money', packs: ['funder'] },
+  { id: 'four-asks', label: 'The four asks', chapter: 'the-money', packs: ['funder'] },
+
+  { id: 'the-letter', label: 'The letter', chapter: 'the-close', packs: ['funder', 'supporter'] },
+  { id: 'closing', label: 'The promise', chapter: 'the-close', packs: ['funder', 'supporter', 'press'] },
+];
+
+// ---------------------------------------------------------------------------
+// Packs
+// ---------------------------------------------------------------------------
+
+export interface PitchPack {
+  id: PitchPackId;
+  label: string;
+  /** Which record in `audience.ts` this pack serves. The pack never restates that record. */
+  audience: AudienceId;
+  /** One line shown in the pack switcher, so a presenter picking a cut knows what it is. */
+  blurb: string;
+}
+
+export const PITCH_PACKS: PitchPack[] = [
+  {
+    id: 'funder',
+    label: 'Funder',
+    audience: 'funder',
+    blurb: 'The whole road, then the model as what the road produced. Every panel.',
+  },
+  {
+    id: 'supporter',
+    label: 'Supporter',
+    audience: 'supporter',
+    blurb: 'The road and the places, without the unit economics or the ask.',
+  },
+  {
+    id: 'press',
+    label: 'Press',
+    audience: 'press',
+    blurb: 'The story, the cleared photographs and the map. No funding ask.',
+  },
+];
+
+export const DEFAULT_PACK: PitchPackId = 'funder';
+
+/** Panels for a pack, in reading order. */
+export function panelsForPack(pack: PitchPackId): PitchPanel[] {
+  return PITCH_PANELS.filter((panel) => panel.packs.includes(pack));
+}
+
+/** Narrow an untrusted `?for=` query value. Anything unrecognised falls back to the funder deck,
+ *  which is the surface as written and therefore always safe. */
+export function resolvePack(raw: string | string[] | undefined): PitchPackId {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  const match = PITCH_PACKS.find((pack) => pack.id === value);
+  return match ? match.id : DEFAULT_PACK;
+}
+
+export function pitchPack(id: PitchPackId): PitchPack {
+  const found = PITCH_PACKS.find((pack) => pack.id === id);
+  if (!found) throw new Error(`Unknown pitch pack: ${id}`);
+  return found;
+}
+
+/** The `audience.ts` record a pack serves. Kept as a lookup rather than a copied field so the
+ *  constraints stay defined once. */
+export function audienceForPack(id: PitchPackId) {
+  const pack = pitchPack(id);
+  const record = AUDIENCES.find((entry) => entry.id === pack.audience);
+  if (!record) throw new Error(`Pack ${id} names an audience that does not exist: ${pack.audience}`);
+  return record;
+}
+
+// ---------------------------------------------------------------------------
+// The opener
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Appendices
+// ---------------------------------------------------------------------------
+
+/**
+ * The three surviving supporting pitch surfaces. They are appendices to this deck, not
+ * alternatives to it, and naming them here is what stops them drifting back into being parallel
+ * front doors: each is reachable FROM the deck, in the contents, labelled with the question it
+ * answers.
+ *
+ * Everything else under `/pitch/*` already redirects to `/pitch/road` in `next.config`.
+ */
+export interface PitchAppendix {
+  href: string;
+  label: string;
+  /** The question the deck raises that this surface answers. If it does not answer one, it should
+   *  not exist. */
+  answers: string;
+}
+
+export const PITCH_APPENDICES: PitchAppendix[] = [
+  {
+    href: '/pitch/funder-pathways',
+    label: 'Funder pathways',
+    answers: 'How a community request becomes a visible, priced pathway.',
+  },
+  {
+    href: '/pitch/community-narrative',
+    label: 'Community narrative',
+    answers: 'The storytellers, the themes, and what has been cleared to say.',
+  },
+  {
+    href: '/pitch/document',
+    label: 'Written document',
+    answers: 'The long-form version, for a reader who wants prose over panels.',
+  },
+];
+
+export const OPENER_HEADING = 'If you read nothing else';
+
+/**
+ * Five lines. Each one is a fact that already exists elsewhere in the system, restated in the
+ * plainest available form. Nothing here is new, and nothing here is a projection.
+ *
+ * The order is `funder.needsToSee` applied literally: the road, then the separation of the two
+ * pots, then the unmeasured thing named before they find it, then $0 signed.
+ */
+export const OPENER_LINES: string[] = [
+  'Communities asked for beds that survive heat, dust, freight and a crowded house. The Stretch Bed is that bed, and it is in seven places.',
+  'The goal is not a bigger Goods. It is a community that collects the plastic, makes the goods, and comes to own the making.',
+  'Production is meant to pay for itself. The wraparound around it is grant funded on purpose, and keeping the two apart is the point, not a caveat.',
+  'Freight is 35% of what a bed costs, more than plastic, diesel and labour together. That is the argument for making near community, and it is a cost argument rather than a values one.',
+  'Nothing is signed. No order for the coming year is on paper, and the deck is the case for why it should be, not evidence that it already is.',
+];
+
+/**
+ * Phrases the opener may never contain. Each is a real failure mode, not a style preference, and
+ * each is asserted case-insensitively by the guards.
+ *
+ * `three sites` and `break even` are here for a live reason: the per-site annual running cost is
+ * unresolved and the four candidate answers move break-even from two sites to five. Printing any
+ * of them as settled is the thing this whole week established must not happen.
+ */
+export const OPENER_BANNED = [
+  'break even',
+  'break-even',
+  'three sites',
+  'payback',
+  'guaranteed',
+] as const;
+// The "co-design" ban is deliberately NOT repeated here. It is a standing rule across all prose
+// (Ben, 2026-07-11) and `check:voice` enforces it repo-wide. Restating it in this list duplicated a
+// global rule and, because the literal itself is a retired phrase, tripped `check:retired-figures`.


### PR DESCRIPTION
`/pitch/road` is the canonical deck (ruling R) and its content was never the problem. It is a **deck rendered as a document**: eighteen panels, each already authored one-per-viewport, served as one continuous scroll with no pagination, no map of where you are, no print path, and no shorter cut for a reader who is not a funder. That is why five pitch artifacts existed instead of one.

New module `pitch-chrome.ts` holds the apparatus, not the content: the panel order (mirrored from `deckSlides`, guarded), the packs, and the opener. The client chrome works on the rendered DOM by panel id rather than owning the markup, so the server-rendered deck keeps its streaming and priority hints.

## What landed

- **Wayfinding.** Sticky contents bar grouped into five chapters, with scrollspy, plus an "If you read nothing else" block of five lines at the top.
- **Slide mode and print.** `?view=slides` shows one panel per screen with arrow keys and a counter; a print stylesheet puts one panel per page. Same DOM all three ways, so the deck cannot drift from itself the way `deliverables/Goods-Final-Pitch-Deck-2026-07-28.pptx` has.
- **Audience cuts.** `?for=funder|supporter|press`. State lives in the URL, so any cut is a sendable link.
- **Appendices.** The three surviving supporting surfaces are named as appendices and linked from the deck's contents.

## Two live defects fixed on the way

**The cover had a redirect loop.** The hero's "Open the slide deck" button linked to `/pitch/deck`, which `next.config` 302s straight back to `/pitch/road`. It now opens slide mode, which is what it was reaching for.

**Every appendix was signposting funders away from the front door.** `pitch-surface-notice.tsx` hardcoded `/pitch/funder-pathways` as "THE canonical funder surface" while ruling R, `audience.ts` (`funder.frontDoor`) and seven `next.config` redirects all said `/pitch/road`. It now reads the front door out of `audience.ts`, and a guard asserts it still derives rather than restates. A hardcoded constant is what drifted; a lookup cannot.

## Three packs, not six

The obvious move is a pack per audience. The model says it is wrong. `buyer.frontDoor` is `/shop` and `buyer.mustNeverSee` forbids the impact story ahead of the spec, which is this page's entire first half. `community.mustNeverSee` forbids arriving with a proposal instead of a yarn, and this page is a proposal from panel one. Cutting the deck for either would ship a known relationship-ending failure, so a guard refuses to add them.

## The opener is guarded hard

A five-line summary at the top of a funder deck is the highest-risk prose in the system, because it is the part that gets quoted and pasted. Banned and asserted: a bed count as a threshold, a payback period as a promise, and **any site count or break-even claim** (the per-site annual running cost has four live answers and break-even moves from two sites to five across them, see `deliverables/GOC-site-cost-decision.md`). It must say plainly that nothing is signed.

## What I did NOT do

I stopped short of retiring `/pitch/document`. It carries prose the deck does not (the competition table, why-now, the pains), so deleting it loses content rather than duplication. Retiring it properly is a content merge and a separate call.

## Gates

`tsc --noEmit` clean · 522 tests passing (19 new guards) · `check:audience` · `check:voice` · `check:retired-figures` · `npm run build` clean.

## Before merging

This changes a funder-facing surface, so please look at the Vercel preview first rather than merging on green.

- `/pitch/road` — scroll past the hero for the opener and the contents bar
- `/pitch/road?view=slides` — arrow keys, space, Escape
- `/pitch/road?for=press` — the short cut, no ask
- The PDF button, for the print path