### PR TITLE
Case study: name Homeland School Company

### DIFF
--- a/v2/src/lib/data/case-studies.ts
+++ b/v2/src/lib/data/case-studies.ts
@@ -62,7 +62,9 @@ export const CASE_STUDIES: CaseStudy[] = [
     partner: {
       name: 'Homeland School Company',
       role: 'a community-controlled homeland education organisation',
-      nameCleared: false,
+      // Ben, 2026-08-06: "Homeland School, yes 100%. They are going to be the public case
+      // study" — and we reach out to them as the film finishes.
+      nameCleared: true,
     },
     steps: [
       {


### PR DESCRIPTION
One flag: `nameCleared: true` on the Maningrida case study, per Ben's explicit direction today ("Homeland School, yes 100%, they are going to be the public case study"). Gates 10/10, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)