### PR TITLE
Newsletter: written in Empathy Ledger, syndicated through the consent gate

### DIFF
--- a/v2/src/app/news/page.tsx
+++ b/v2/src/app/news/page.tsx
@@ -1,7 +1,14 @@
 /**
- * /news — the newsletter, on the web. Issues are assemblies of already-cleared, already-
- * public artifacts (see news.ts). The email version is this page, sent; there is exactly
- * one source for both, so the newsletter can never say something the site does not.
+ * /news — the newsletter, on the web.
+ *
+ * WRITING HOME (Ben, 2026-08-06): issues are WRITTEN IN EMPATHY LEDGER as stories with
+ * story_type 'newsletter'. They reach this page through EL's canonical syndication gate
+ * (stories_for_site), so storytellers in an issue sit under EL's consent machinery —
+ * withdrawing consent in EL pulls them at the source and this page follows on the next
+ * render. GHL sends the same content by email; this page is the single web home.
+ *
+ * Until the first EL-authored issue is published, the local issue in news.ts renders as
+ * the fallback — the same pattern as FeaturedStories falling back to journeyStories.
  */
 import type { Metadata } from 'next';
 import Image from 'next/image';
@@ -10,6 +17,7 @@ import { NEWS_ISSUES } from '@/lib/data/news';
 import { MoneyPointer } from '@/components/money-pointer';
 import { NewsletterSignup } from '@/components/newsletter-signup';
 import { DOORS } from '@/lib/data/road-ending';
+import { empathyLedger } from '@/lib/empathy-ledger/client';
 
 export const metadata: Metadata = {
   title: 'News — Goods on Country',
@@ -17,8 +25,71 @@ export const metadata: Metadata = {
     'The monthly letter: what happened in community, who is stepping up, and where the road to ownership is.',
 };
 
-export default function NewsPage() {
+export const revalidate = 300; // EL consent changes reach the page within five minutes.
+
+export default async function NewsPage() {
+  const elIssues = await empathyLedger.getNewsletterIssues();
+  const el = elIssues[0];
   const issue = NEWS_ISSUES.find((i) => i.published);
+  if (!el && !issue) return null;
+  // TS narrowing: past the EL branch below, issue is defined.
+
+
+  // An EL-authored issue takes over the whole letter body; the doors and signup stay.
+  if (el) {
+    return (
+      <article className="mx-auto max-w-3xl px-6 py-14">
+        <header>
+          <p className="font-mono text-[10px] uppercase tracking-[0.22em] text-[#c45c3e]">
+            The letter{el.publishedAt ? ` · ${new Date(el.publishedAt).toLocaleDateString('en-AU', { month: 'long', year: 'numeric' })}` : ''}
+          </p>
+          <h1 className="goods-pitch-display mt-3 text-4xl leading-tight md:text-5xl">{el.title}</h1>
+          {el.excerpt && <p className="mt-4 text-lg leading-8 text-[#6d675c]">{el.excerpt}</p>}
+        </header>
+        {el.isHtml ? (
+          <div
+            className="prose prose-stone mt-10 max-w-none"
+            dangerouslySetInnerHTML={{ __html: el.content }}
+          />
+        ) : (
+          <div className="mt-10 space-y-5">
+            {el.content.split(/\n\s*\n/).map((para, i) => (
+              <p key={i} className="text-base leading-7 text-[#2b2a26]">{para}</p>
+            ))}
+          </div>
+        )}
+        {elIssues.length > 1 && (
+          <section className="mt-12 border-t border-[#d9d1c3] pt-6">
+            <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-[#7a7363]">Earlier letters</h2>
+            <ul className="mt-3 space-y-2">
+              {elIssues.slice(1).map((prev) => (
+                <li key={prev.id} className="text-sm text-[#6d675c]">{prev.title}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+        <section className="mt-12">
+          <h2 className="border-b-2 border-[#2b2a26] pb-2 font-mono text-[11px] uppercase tracking-[0.18em]">
+            Three ways in
+          </h2>
+          <div className="mt-6 grid gap-6 sm:grid-cols-3">
+            {DOORS.map((door) => (
+              <div key={door.verb} className="border-t-2 border-[#c45c3e] pt-2">
+                <p className="goods-pitch-display text-xl">{door.verb}</p>
+                <p className="mt-1 text-sm leading-5 text-[#6d675c]">{door.entity}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-5"><MoneyPointer /></div>
+        </section>
+        <footer className="mt-14 border-t border-[#d9d1c3] pt-8">
+          <p className="text-sm leading-6 text-[#6d675c]">Get the letter by email:</p>
+          <div className="mt-4"><NewsletterSignup /></div>
+        </footer>
+      </article>
+    );
+  }
+
   if (!issue) return null;
 
   return (

--- a/v2/src/lib/empathy-ledger/client.ts
+++ b/v2/src/lib/empathy-ledger/client.ts
@@ -646,6 +646,63 @@ export const empathyLedger = {
    *
    * Returns {} on any failure (cockpit degrades to no verdict, never throws).
    */
+  /**
+   * Newsletter issues, written in Empathy Ledger and syndicated here (Ben, 2026-08-06).
+   *
+   * An issue is an EL story with story_type 'newsletter' that passes the canonical
+   * stories_for_site gate — published + public + explicit consent + not withdrawn +
+   * elder-review satisfied + syndication enabled. Writing happens in EL so storytellers
+   * ride under EL's consent machinery: withdrawing consent there pulls them from the
+   * issue at the source, and the site follows on the next render. We call the RPC and
+   * filter; we never reimplement the gate.
+   *
+   * Returns [] on any failure or when EL is disabled — /news falls back to the local
+   * issue in news.ts, exactly like FeaturedStories falls back to journeyStories.
+   */
+  async getNewsletterIssues(): Promise<
+    {
+      id: string;
+      title: string;
+      excerpt: string | null;
+      /** Raw EL content: HTML when it starts with a tag, plain/markdown-ish otherwise. */
+      content: string;
+      isHtml: boolean;
+      publishedAt: string | null;
+    }[]
+  > {
+    if (!ENABLE_EMPATHY_LEDGER || !EL_SUPABASE_URL || !EL_SUPABASE_KEY) return [];
+    try {
+      const rows = await fetchFromELSupabaseRpc<
+        {
+          id: string;
+          title: string | null;
+          excerpt: string | null;
+          summary: string | null;
+          content: string | null;
+          story_type: string | null;
+          published_at: string | null;
+          created_at: string | null;
+        }[]
+      >('stories_for_site', { p_site_slug: GOODS_SITE_SLUG });
+      return rows
+        .filter((r) => (r.story_type ?? '').toLowerCase() === 'newsletter' && r.content)
+        .sort((a, b) =>
+          (b.published_at ?? b.created_at ?? '').localeCompare(a.published_at ?? a.created_at ?? ''),
+        )
+        .map((r) => ({
+          id: r.id,
+          title: r.title ?? 'The letter',
+          excerpt: r.excerpt ?? r.summary,
+          content: r.content as string,
+          isHtml: /^\s*</.test(r.content as string),
+          publishedAt: r.published_at ?? r.created_at,
+        }));
+    } catch (error) {
+      logUnexpectedELSupabaseError('[EmpathyLedger] Failed to fetch newsletter issues:', error);
+      return [];
+    }
+  },
+
   async getGoodsSiteClearance(): Promise<Record<string, { cleared: number; candidate: number }>> {
     if (!ENABLE_EMPATHY_LEDGER || !EL_SUPABASE_URL || !EL_SUPABASE_KEY) return {};
     try {


### PR DESCRIPTION
The letter's writing home moves to Empathy Ledger (story_type 'newsletter'), reaching /news through the canonical stories_for_site gate so storytellers can be pulled at the source by consent withdrawal. Local news.ts issue remains the fallback until the first EL issue publishes. GHL sends the same content. Gates 10/10, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)