### PR TITLE
Homepage: gate EL stories behind explicit review; fix hero autoplay on phones

### DIFF
--- a/v2/src/components/empathy-ledger/featured-stories.tsx
+++ b/v2/src/components/empathy-ledger/featured-stories.tsx
@@ -32,9 +32,17 @@ export async function FeaturedStories({
   viewAllLink = '/stories',
   maxStories = 3,
 }: FeaturedStoriesProps) {
-  const stories = await empathyLedger.getGoodsStories({ limit: maxStories });
+  const elStories = await empathyLedger.getGoodsStories({ limit: maxStories });
 
-  // If EL has stories, use them
+  // Published in EL is necessary but not sufficient for the FRONT PAGE (Ben, 2026-08-06):
+  // a 2026-07-27 bulk publish in EL put three stories here that no one had chosen for this
+  // surface. A story renders on the homepage only after Ben adds its id below, once the
+  // Empathy Ledger curation process has been through it. Empty list = the crafted local
+  // fallback. Other EL surfaces (/stories, /news) are not gated by this.
+  const HOMEPAGE_REVIEWED_STORY_IDS: string[] = [];
+  const stories = elStories.filter((s) => HOMEPAGE_REVIEWED_STORY_IDS.includes(s.id));
+
+  // If EL has homepage-reviewed stories, use them
   if (stories.length > 0) {
     return (
       <section className="py-16 md:py-20">

--- a/v2/src/components/marketing/hero.tsx
+++ b/v2/src/components/marketing/hero.tsx
@@ -35,17 +35,30 @@ export function Hero({
     <section className="relative min-h-[85vh] flex items-end overflow-hidden">
       {/* Full-bleed background — video or image */}
       {videoSrc ? (
-        <video
-          className="absolute inset-0 w-full h-full object-cover"
-          autoPlay
-          muted
-          loop
-          playsInline
-          poster={videoSrc.poster}
-        >
-          <source src={videoSrc.desktop} media="(min-width: 768px)" type="video/mp4" />
-          <source src={videoSrc.mobile} type="video/mp4" />
-        </video>
+        // Two <video> elements, not one video with media-queried <source> children:
+        // browsers ignore the `media` attribute on video sources, so phones were handed
+        // the desktop file, stalled, and Safari painted a dead play button (2026-08-06).
+        // Same pattern as every other background-video section.
+        <>
+          <video
+            className="absolute inset-0 hidden h-full w-full object-cover md:block"
+            src={videoSrc.desktop}
+            autoPlay
+            muted
+            loop
+            playsInline
+            poster={videoSrc.poster}
+          />
+          <video
+            className="absolute inset-0 h-full w-full object-cover md:hidden"
+            src={videoSrc.mobile}
+            autoPlay
+            muted
+            loop
+            playsInline
+            poster={videoSrc.poster}
+          />
+        </>
       ) : imageSrc ? (
         <Image
           src={imageSrc}


### PR DESCRIPTION
EL bulk-publish (27 Jul) auto-took the homepage story slots; now gated behind an explicit reviewed-ids list (empty → crafted local three return). Hero split into two breakpoint-toggled videos: browsers ignore media on video sources, so phones fetched the 16MB desktop file and stalled (the dead play button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)