### PR TITLE
Homepage A revived + /invest + header/mobile menu + derived sitemap

### DIFF
--- a/v2/scripts/check-money-prose.mjs
+++ b/v2/scripts/check-money-prose.mjs
@@ -44,6 +44,8 @@ const ALLOWED_APP_PREFIXES = [
   'wiki/community/tracking-model', // one sourced story fact ($3M/yr of washers into dumps)
   'partner', // the public capital page: its ask renders from ask-surface.ts (import-locked),
   //           and its QBE lines state the program terms per ruling V
+  'invest', // the structural how-to-back-Goods page: renders ENTITY_DOORS from ask-surface.ts
+  //          (import-locked, carries the $750 list price); all other money is <MoneyPointer />
   'wiki/products/washing-machine', // the sourced "$3M/yr of washers" story fact
   'pathways/', // consent-shaped per-community numbers; its own rules live in that module
   'field-notes/', // trip stories quote real invoices with consent-cleared context

--- a/v2/src/app/invest/page.tsx
+++ b/v2/src/app/invest/page.tsx
@@ -1,0 +1,201 @@
+/**
+ * /invest — how to put money into Goods, explained structurally (Ben, 2026-08-06).
+ *
+ * The page /partner never was: not the capital ask (that lives on /partner and, with
+ * figures, on /pitch/road) but the STRUCTURE — the three entities, which door fits which
+ * giver, and the levels of community life the work supports. Written for a philanthropic
+ * family, a corporate, or an individual asking "where would my money actually go, and
+ * where does it do the most?"
+ *
+ * The three doors render from ENTITY_DOORS in ask-surface.ts (import-locked; the doors
+ * are never restated), the same source the deck and the audience model read. The route is
+ * allowlisted in check-money-prose.mjs for exactly that reason, like /partner. Entity
+ * naming is exact (ruling K): Goods sells through A Curious Tractor Pty Ltd; Goods on
+ * Country is a business name of The Butterfly Movement Ltd, the DGR charity. Ownership is
+ * a pathway, never claimed complete.
+ */
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { ENTITY_DOORS, ENTITY_NOTES } from '@/lib/data/ask-surface';
+import { MoneyPointer } from '@/components/money-pointer';
+
+export const metadata: Metadata = {
+  title: 'Invest in Goods — the three doors',
+  description:
+    'How a philanthropic family, a corporate or an individual can back Goods: tax-deductible gifts to the charity, orders and repayable capital to the trading company, and the pathway to community ownership.',
+};
+
+const DISPLAY_FONT = { fontFamily: 'var(--font-display, Georgia, serif)' } as const;
+
+/**
+ * The levels the work supports. Each line is grounded in something that happened and is
+ * already public on this site; nothing here is a measured-outcome claim. The bed is the
+ * entry point, never the whole point.
+ */
+const LEVELS = [
+  {
+    title: 'Health',
+    line: 'A washable bed off the ground is health hardware. Crowded, bedless houses sit at the start of the scabies-to-rheumatic-heart-disease chain; that chain is why the work exists.',
+    link: { label: 'The story', href: '/story' },
+  },
+  {
+    title: 'Enterprise',
+    line: 'Beds are made, sold and freighted as a real business. The plant is containerised so the making itself can move to community, with jobs and a pathway to community ownership.',
+    link: { label: 'How it is made', href: '/process' },
+  },
+  {
+    title: 'Young people',
+    line: 'Build days put young people on the tools: the Alice Springs build with Oonchiumpa, the forty-bed Maningrida run. One young builder wanted to keep building.',
+    link: { label: 'The Maningrida run', href: '/case-studies/maningrida' },
+  },
+  {
+    title: 'Learning',
+    line: 'The work runs through schools and community organisations: the school washing machine at Maningrida, plans open-sourced, the making taught rather than kept.',
+    link: { label: 'The communities', href: '/communities' },
+  },
+] as const;
+
+const GIVERS = [
+  {
+    who: 'A philanthropic family or foundation',
+    fit: 'Tax-deductible gifts through the charity door. Gifts fund the community work and the block, never company equity, so the philanthropy is structurally separated from the trading.',
+    doorVerb: 'Donate',
+  },
+  {
+    who: 'A corporate',
+    fit: 'Buy beds for the communities you work with, sponsor a run, or bring repayable capital to the bridge. Procurement is revenue, not philanthropy, and it is the most direct help there is.',
+    doorVerb: 'Buy / Order',
+  },
+  {
+    who: 'An impact investor or lender',
+    fit: 'Repayable finance sits in the trading company, priced for what the money proves: a facility standing up, a production run measured, a community site running.',
+    doorVerb: 'Invest (repayable)',
+  },
+] as const;
+
+export default function InvestPage() {
+  return (
+    <>
+      {/* Lead: the model, not the ask */}
+      <section className="relative isolate flex min-h-[52vh] items-end overflow-hidden bg-foreground">
+        <Image
+          src="/images/community/maningrida/kids-carrying-orange-bed.jpg"
+          alt="Kids carrying an orange Stretch Bed in Maningrida"
+          fill
+          priority
+          sizes="100vw"
+          className="object-cover opacity-80"
+        />
+        <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/30 to-black/75" />
+        <div className="relative container mx-auto px-4 pb-14 md:pb-16">
+          <p className="mb-3 text-sm uppercase tracking-widest text-white/70">Back the work</p>
+          <h1 className="max-w-3xl text-4xl font-semibold leading-tight text-white md:text-5xl" style={DISPLAY_FONT}>
+            Support communities where they are at. The bed is the entry point, never the whole point.
+          </h1>
+          <p className="mt-4 max-w-2xl text-lg text-white/80">
+            One piece of work touches health, enterprise, young people and learning at once. Here is
+            the structure your money moves through, so you can pick the door that does the most with it.
+          </p>
+        </div>
+      </section>
+
+      {/* The levels */}
+      <section className="bg-background py-16 md:py-20">
+        <div className="container mx-auto px-4">
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {LEVELS.map((level) => (
+              <div key={level.title} className="rounded-2xl border border-border bg-muted/20 p-7">
+                <h2 className="mb-2 text-xl font-semibold text-foreground" style={DISPLAY_FONT}>
+                  {level.title}
+                </h2>
+                <p className="mb-4 text-sm leading-relaxed text-muted-foreground">{level.line}</p>
+                <Link href={level.link.href} className="text-sm font-semibold text-[#C45C3E]">
+                  {level.link.label} →
+                </Link>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* The three entities, from the locked doors */}
+      <section className="bg-muted/30 py-16 md:py-20">
+        <div className="container mx-auto px-4">
+          <p className="mb-3 text-sm uppercase tracking-widest text-[#C45C3E]">The three doors</p>
+          <h2 className="mb-4 max-w-3xl text-3xl font-semibold text-foreground md:text-4xl" style={DISPLAY_FONT}>
+            Three doors, three legal entities. They are not interchangeable, and that is the point.
+          </h2>
+          <p className="mb-10 max-w-2xl text-base text-muted-foreground">
+            Australian law separates gifts from trade, and Goods keeps that separation visible so no
+            one has to take it on faith. Goods sells through A Curious Tractor Pty Ltd; Goods on
+            Country is a registered business name of The Butterfly Movement Ltd, the charity.
+          </p>
+          <div className="grid gap-6 md:grid-cols-3">
+            {ENTITY_DOORS.map((door) => (
+              <div key={door.verb} className="flex flex-col rounded-2xl border-t-4 border-[#C45C3E] bg-background p-7 shadow-sm">
+                <h3 className="text-2xl font-semibold text-foreground" style={DISPLAY_FONT}>
+                  {door.verb}
+                </h3>
+                <p className="mt-1 text-sm font-medium text-[#6F7F5C]">{door.entity}</p>
+                <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">{door.what}</p>
+              </div>
+            ))}
+          </div>
+          <ul className="mt-8 max-w-3xl space-y-2">
+            {ENTITY_NOTES.map((note) => (
+              <li key={note.slice(0, 40)} className="text-xs leading-relaxed text-muted-foreground">
+                · {note}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* Which giver, which door */}
+      <section className="bg-background py-16 md:py-20">
+        <div className="container mx-auto px-4">
+          <h2 className="mb-10 max-w-3xl text-3xl font-semibold text-foreground md:text-4xl" style={DISPLAY_FONT}>
+            Where you can make the most impact
+          </h2>
+          <div className="space-y-6">
+            {GIVERS.map((giver) => {
+              const door = ENTITY_DOORS.find((d) => d.verb === giver.doorVerb);
+              return (
+                <div key={giver.who} className="grid gap-4 rounded-2xl border border-border p-7 md:grid-cols-[1fr_2fr_auto] md:items-center">
+                  <h3 className="text-lg font-semibold text-foreground" style={DISPLAY_FONT}>
+                    {giver.who}
+                  </h3>
+                  <p className="text-sm leading-relaxed text-muted-foreground">{giver.fit}</p>
+                  <p className="text-sm font-semibold text-[#C45C3E]">{door?.verb}</p>
+                </div>
+              );
+            })}
+          </div>
+          <div className="mt-10 max-w-2xl">
+            <MoneyPointer />
+          </div>
+        </div>
+      </section>
+
+      {/* One action */}
+      <section className="bg-foreground py-14 md:py-16">
+        <div className="container mx-auto flex flex-col items-start gap-6 px-4 md:flex-row md:items-center md:justify-between">
+          <p className="max-w-2xl text-xl text-background" style={DISPLAY_FONT}>
+            Tell us who you are and what you can bring. We will tell you plainly which door fits and
+            what it does.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Button size="lg" className="bg-[#C45C3E] text-white hover:opacity-90" asChild>
+              <Link href="/partner#start">Start the conversation</Link>
+            </Button>
+            <Button size="lg" variant="outline" className="border-white bg-transparent text-white hover:bg-white/10" asChild>
+              <Link href="/pitch/road">Read the whole road</Link>
+            </Button>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/v2/src/app/page.tsx
+++ b/v2/src/app/page.tsx
@@ -1,495 +1,441 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { Hero, ImpactStats } from '@/components/marketing';
-import { AssemblySequence } from '@/components/pitch/assembly-sequence';
-import { CyclingImage } from '@/components/pitch/cycling-image';
-import { MediaSlot } from '@/components/ui/media-slot';
 import { Button } from '@/components/ui/button';
-import { brand } from '@/lib/data/content';
-import { PLASTIC_KG_PER_BED, STRETCH_BED } from '@/lib/data/products';
+import {
+  HOME_HERO,
+  HOME_PROVENANCE,
+  HOME_STORY_COMPACT,
+  HOME_BED_SECTION,
+  HOME_FACILITY_SECTION,
+  HOME_VOICES,
+  HOME_ROAD,
+  HOME_DOORS,
+  homeFeatureVideo,
+  homeVoiceQuote,
+} from '@/lib/data/home';
 import { videoUrl } from '@/lib/data/media';
-import { canonVideoSrc } from '@/lib/data/canon-videos';
-import { FeaturedStories } from '@/components/empathy-ledger/featured-stories';
-import { FieldNotesTile } from '@/components/marketing/field-notes-tile';
 import { getStoryOverrides } from '@/lib/field-notes/overrides';
 import { createClient } from '@/lib/supabase/server';
 import { MediaSwapZone, type SwapFolder } from '@/components/admin/media-swap-picker';
 
+// Homepage A — "The Bed on Country" (Ben's picked mock, 2026-07-26; revived 2026-08-06).
+// Every word renders from lib/data/home.ts, which home.guards.test.ts holds
+// against canon, consent, the road spine and the audience-model doors. Nothing
+// narrative is authored here. Images can be re-picked by an admin through the
+// Empathy Ledger swap picker (orange pill, local dev or signed in); overrides
+// layer over the guarded defaults via data/field-note-overrides.json, slug 'home'.
+
 const HOME_SLUG = 'home';
 
-// '26.9mm' — pole outside diameter, derived from the canonical frame spec.
-const POLE_OD = STRETCH_BED.materials.frame.detail.split(' ')[0];
+const DISPLAY_FONT = { fontFamily: 'var(--font-display, Georgia, serif)' } as const;
+
+const DOOR_TONES = {
+  terracotta: '#C45C3E',
+  sage: '#6F7F5C',
+  teal: '#3E6363',
+  gold: '#C9A227',
+} as const;
 
 const HOME_FOLDERS: SwapFolder[] = [
   { label: 'All recent', emoji: '🕘', tags: [] },
+  { label: 'Website images', emoji: '🖼', tags: ['__website__'] },
   { label: 'All Stretch Bed', emoji: '🛏', tags: ['product:stretch-bed'] },
+  { label: 'May 2026 trip', emoji: '📅', tags: ['trip:may-2026'] },
+  { label: 'Maningrida', emoji: '🌅', tags: ['community:maningrida'] },
   { label: 'Alice build', emoji: '🛠', tags: ['event:alice-build'] },
   { label: 'Utopia delivery', emoji: '🏠', tags: ['community:utopia-homelands', 'event:bed-delivery'] },
-  { label: 'Oonchiumpa young people', emoji: '👥', tags: ['participant:oonchiumpa-young-people'] },
-  { label: 'May 2026 trip', emoji: '📅', tags: ['trip:may-2026'] },
 ];
 
 export default async function HomePage() {
-  // Admin-only swap widget. Local dev or signed-in user gets the orange
-  // swap pill on every media slot. Public visitors see no chrome.
+  // Admin-only swap widget: local dev or a signed-in user sees the orange
+  // swap pill on each media slot. Public visitors get no chrome.
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  const isLocalDev = process.env.NODE_ENV !== 'production';
-  const canSwap = !!user || isLocalDev;
+  const canSwap = !!user || process.env.NODE_ENV !== 'production';
 
-  // Manual overrides from data/field-note-overrides.json under slug 'home'.
-  // Keys: materials.0..3, feature-video.image / .videoDesktop / .videoMobile / .poster
   const overrides = getStoryOverrides(HOME_SLUG);
   const ov = (key: string, fallback: string) => overrides[key] || fallback;
+
+  // Hero can be overridden to a VIDEO through the picker's smart routing:
+  // a video pick writes hero.videoDesktop/videoMobile/poster and clears
+  // hero.image; a photo pick does the reverse.
+  const heroImage = ov('hero.image', HOME_HERO.image);
+  const heroVideoDesktop = overrides['hero.videoDesktop'];
+  const heroVideoMobile = overrides['hero.videoMobile'];
+  const heroPoster = overrides['hero.poster'];
+
+  // The Maningrida film renders only once its canon slot has a cleared pick.
+  const featureFilm = homeFeatureVideo();
+
   return (
     <>
-      {/* 1. Hero: Video bg, Stretch Bed as hero product */}
-      <Hero
-        title={brand.hero.home.headline}
-        subtitle={brand.hero.home.subheadline}
-        primaryCta={{ text: 'Shop the Stretch Bed', href: '/shop/stretch-bed-single' }}
-        secondaryCta={{ text: 'Back the work', href: '/partner' }}
-        videoSrc={canonVideoSrc('video-hero', {
-          desktop: videoUrl('hero-desktop.mp4'),
-          mobile: videoUrl('hero-mobile.mp4'),
-          poster: '/video/hero-poster.jpg',
-        })}
-        imageSrc="/images/media-pack/lying-on-stretch-bed.jpg"
-        imageAlt="A young man lying full-length on a Stretch Bed on country: recycled plastic legs, galvanised steel poles, heavy-duty canvas"
-      />
-
-      {/* 2. The Stretch Bed: Materials + Assembly + Price comparison */}
-      <section className="py-16 md:py-20 bg-background">
-        <div className="container mx-auto px-4">
-          <div className="max-w-5xl mx-auto">
-            <p className="text-sm uppercase tracking-widest text-accent mb-4">
-              The Stretch Bed
-            </p>
-            <h2
-              className="text-3xl md:text-4xl font-light text-foreground mb-4 leading-snug"
-              style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
+      {/* 1. Hero */}
+      <section className="relative isolate flex min-h-[76vh] items-end overflow-hidden bg-foreground">
+        {heroVideoDesktop ? (
+          <>
+            <video
+              className="absolute inset-0 hidden h-full w-full object-cover sm:block"
+              src={heroVideoDesktop}
+              poster={heroPoster}
+              autoPlay
+              muted
+              loop
+              playsInline
+            />
+            <video
+              className="absolute inset-0 h-full w-full object-cover sm:hidden"
+              src={heroVideoMobile || heroVideoDesktop}
+              poster={heroPoster}
+              autoPlay
+              muted
+              loop
+              playsInline
+            />
+          </>
+        ) : (
+          <Image
+            src={heroImage}
+            alt={HOME_HERO.imageAlt}
+            fill
+            priority
+            sizes="100vw"
+            className="object-cover"
+          />
+        )}
+        <div className="absolute inset-0 bg-gradient-to-b from-black/0 via-black/20 to-black/70" />
+        {canSwap && (
+          <MediaSwapZone
+            slug={HOME_SLUG}
+            overrideKey="hero.image"
+            currentUrl={heroVideoDesktop || heroImage}
+            tagQuery={['trip:may-2026']}
+            kind="any"
+            label="swap hero"
+            folders={HOME_FOLDERS}
+            smartMediaRoute
+          />
+        )}
+        <div className="relative container mx-auto px-4 pb-14 md:pb-20">
+          <h1
+            className="max-w-3xl text-4xl font-semibold leading-tight text-white md:text-6xl"
+            style={DISPLAY_FONT}
+          >
+            {HOME_HERO.headline}
+          </h1>
+          <div className="mt-8 flex flex-wrap gap-4">
+            <Button size="lg" className="text-white hover:opacity-90" style={{ backgroundColor: DOOR_TONES.terracotta }} asChild>
+              <Link href={HOME_HERO.primaryCta.href}>{HOME_HERO.primaryCta.label}</Link>
+            </Button>
+            <Button
+              size="lg"
+              variant="outline"
+              className="border-white bg-transparent text-white hover:bg-white/10"
+              asChild
             >
-              Three materials. No tools. Five minutes.
-            </h2>
-            <p className="text-lg text-muted-foreground mb-12 max-w-2xl">
-              {STRETCH_BED.specs.weight}, supports {STRETCH_BED.specs.loadCapacity}, designed to last {STRETCH_BED.specs.designLifespan}. Each bed diverts {PLASTIC_KG_PER_BED}kg of plastic from landfill.
-            </p>
-
-            <div className="grid gap-12 lg:grid-cols-2 items-start">
-              {/* Left: 4 material boxes */}
-              <div className="grid gap-4 grid-cols-2">
-                {[
-                  {
-                    key: 'materials.0',
-                    fallback: '/images/pitch/bed-frame-legs.jpg',
-                    alt: 'Recycled HDPE plastic legs, pressed from community waste',
-                    label: 'Recycled plastic legs',
-                    title: 'Recycled Plastic Frame',
-                    body: `HDPE legs from community plastic. ${PLASTIC_KG_PER_BED}kg diverted per bed.`,
-                  },
-                  {
-                    key: 'materials.1',
-                    fallback: '/images/pitch/bed-poles.jpg',
-                    alt: `Galvanised steel pole, ${POLE_OD} OD`,
-                    label: 'Steel pole',
-                    title: 'Galvanised Steel Poles',
-                    body: `Two ${POLE_OD} poles thread through canvas sleeves.`,
-                  },
-                  {
-                    key: 'materials.2',
-                    fallback: '/images/pitch/bed-canvas.jpg',
-                    alt: 'Heavy-duty Australian canvas with Goods. branding',
-                    label: 'Canvas',
-                    title: 'Heavy-Duty Canvas',
-                    body: 'Washable, repairable, built for remote conditions.',
-                  },
-                  {
-                    key: 'materials.3',
-                    fallback: '/images/media-pack/nic-with-elder-on-verandah.jpg',
-                    alt: 'Nic sitting on a Stretch Bed with an elder on a verandah, ongoing support and connection',
-                    label: 'Support system',
-                    title: 'Support System',
-                    body: 'Every bed tracked. Ask questions, stay connected, get support.',
-                  },
-                ].map((card) => {
-                  const src = ov(card.key, card.fallback);
-                  return (
-                    <div
-                      key={card.key}
-                      className="rounded-xl border border-border overflow-hidden bg-muted/30"
-                    >
-                      <div className="relative">
-                        <MediaSlot src={src} alt={card.alt} label={card.label} aspect="4/3" />
-                        {canSwap && (
-                          <MediaSwapZone
-                            slug={HOME_SLUG}
-                            overrideKey={card.key}
-                            currentUrl={src}
-                            tagQuery={['product:stretch-bed']}
-                            kind="photo"
-                            label="swap"
-                            broadTag="product:stretch-bed"
-                            folders={HOME_FOLDERS}
-                          />
-                        )}
-                      </div>
-                      <div className="p-3">
-                        <h3 className="font-semibold text-foreground text-sm mb-0.5">{card.title}</h3>
-                        <p className="text-xs text-muted-foreground">{card.body}</p>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-
-              {/* Right: Assembly sequence + price comparison */}
-              <div>
-                <AssemblySequence />
-              </div>
-            </div>
+              <Link href={HOME_HERO.secondaryCta.href}>{HOME_HERO.secondaryCta.label}</Link>
+            </Button>
           </div>
         </div>
       </section>
 
-      {/* 2b. Full-bleed video band — beds being made.
-          Sits as a visual pause between the materials breakdown and the
-          production-flow grid. Default = local building-together loop.
-          Admin can swap to any EL video via the orange pill. */}
-      {(() => {
-        const videoDesktop = ov('feature-video.videoDesktop', '/video/building-together-desktop.mp4');
-        const videoMobile = ov('feature-video.videoMobile', '/video/building-together-mobile.mp4');
-        const poster = ov('feature-video.poster', '/video/building-together-poster.jpg');
-        const overrideImage = overrides['feature-video.image']; // photo-mode fallback when admin picks a still
-        return (
-          <section className="relative isolate overflow-hidden bg-foreground">
-            {overrideImage ? (
-              /* eslint-disable-next-line @next/next/no-img-element */
-              <img
-                src={overrideImage}
-                alt="Beds assembled on Country"
-                className="absolute inset-0 h-full w-full object-cover opacity-70"
-              />
-            ) : (
-              <>
-                <video
-                  className="absolute inset-0 hidden h-full w-full object-cover opacity-70 sm:block"
-                  src={videoDesktop}
-                  poster={poster}
-                  autoPlay
-                  muted
-                  loop
-                  playsInline
-                />
-                <video
-                  className="absolute inset-0 h-full w-full object-cover opacity-70 sm:hidden"
-                  src={videoMobile}
-                  poster={poster}
-                  autoPlay
-                  muted
-                  loop
-                  playsInline
-                />
-              </>
-            )}
-            <div className="absolute inset-0 bg-gradient-to-b from-foreground/30 via-foreground/40 to-foreground/70" />
-            <div className="relative container mx-auto px-4 py-24 md:py-32">
-              <div className="max-w-3xl mx-auto text-center text-background">
-                <p className="text-xs uppercase tracking-[0.25em] text-background/70 mb-4">
-                  Toward manufacturing on Country
-                </p>
-                <h2
-                  className="text-3xl md:text-5xl font-light leading-tight"
-                  style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
-                >
-                  Beds assembled by the people who&rsquo;ll sleep on them.
-                </h2>
-              </div>
-            </div>
-            {canSwap && (
-              <MediaSwapZone
-                slug={HOME_SLUG}
-                overrideKey="feature-video.image"
-                currentUrl={overrideImage || videoDesktop}
-                tagQuery={['use:process']}
-                kind="any"
-                label="swap video"
-                broadTag="product:stretch-bed"
-                folders={HOME_FOLDERS}
-                smartMediaRoute
-              />
-            )}
-          </section>
-        );
-      })()}
-
-      {/* 3. From Rubbish to Bed: 5-step production flow, dark bg */}
-      <section className="py-16 md:py-20 bg-foreground text-background">
-        <div className="container mx-auto px-4">
-          <div className="max-w-5xl mx-auto">
-            <p className="text-sm uppercase tracking-widest text-background/40 mb-4">
-              Toward On-Country Manufacturing
-            </p>
-            <h2
-              className="text-3xl md:text-4xl font-light mb-4 leading-snug"
-              style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
+      {/* 2. Provenance strip */}
+      <section className="bg-foreground py-4">
+        <div className="container mx-auto flex flex-wrap items-center justify-center gap-x-12 gap-y-2 px-4">
+          {HOME_PROVENANCE.map((item) => (
+            <span
+              key={item}
+              className="font-mono text-xs uppercase tracking-widest text-background/60"
             >
-              From rubbish to bed
-            </h2>
-            <p className="text-background/60 mb-12 max-w-2xl">
-              A containerised production plant that turns community plastic waste into bed components. Local people do the making.
+              {item}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      {/* 3. Compact story */}
+      <section className="bg-background py-16 md:py-20">
+        <div className="container mx-auto px-4">
+          <div className="max-w-4xl">
+            <p className="mb-4 text-sm uppercase tracking-widest text-accent">
+              {HOME_STORY_COMPACT.eyebrow}
             </p>
-
-            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 mb-12">
-              {/* Step 1: Collect */}
-              <div className="rounded-xl bg-background/5 border border-background/10 overflow-hidden">
-                <MediaSlot
-                  src="/images/process/color-samples.jpg"
-                  alt="Sorted recycled plastic from community waste"
-                  label="Collect"
-                  aspect="4/3"
-                />
-                <div className="p-5">
-                  <div className="flex items-center gap-3 mb-2">
-                    <div className="w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold flex-shrink-0">1</div>
-                    <h3 className="text-lg font-semibold text-background">Collect</h3>
-                  </div>
-                  <p className="text-sm text-background/60 leading-relaxed">Local people gather plastic waste from around community. Sorted by colour, cleaned, ready for shredding.</p>
-                </div>
-              </div>
-
-              {/* Step 2: Shred */}
-              <div className="rounded-xl bg-background/5 border border-background/10 overflow-hidden">
-                <MediaSlot
-                  src="/images/process/container-factory.jpg"
-                  alt="Plastic shredder inside containerised production plant"
-                  label="Shred"
-                  aspect="4/3"
-                />
-                <div className="p-5">
-                  <div className="flex items-center gap-3 mb-2">
-                    <div className="w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold flex-shrink-0">2</div>
-                    <h3 className="text-lg font-semibold text-background">Shred</h3>
-                  </div>
-                  <p className="text-sm text-background/60 leading-relaxed">Plastic goes into the shredder: a containerised unit that stays on site between production runs.</p>
-                </div>
-              </div>
-
-              {/* Step 3: Press */}
-              <div className="rounded-xl bg-background/5 border border-background/10 overflow-hidden">
-                <CyclingImage
-                  images={[
-                    { src: '/images/process/hydraulic-press.jpg', alt: 'Hydraulic press compressing recycled plastic into sheets' },
-                    { src: '/images/process/pressed-sheets.jpg', alt: 'Stack of pressed recycled plastic legs in multiple colours' },
-                  ]}
-                  aspect="4/3"
-                />
-                <div className="p-5">
-                  <div className="flex items-center gap-3 mb-2">
-                    <div className="w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold flex-shrink-0">3</div>
-                    <h3 className="text-lg font-semibold text-background">Press</h3>
-                  </div>
-                  <p className="text-sm text-background/60 leading-relaxed">Shredded plastic is heated and pressed into durable sheets. Each colour is unique, made from whatever plastic the community collected.</p>
-                </div>
-              </div>
-
-              {/* Step 4: Cut */}
-              <div className="rounded-xl bg-background/5 border border-background/10 overflow-hidden">
-                <MediaSlot
-                  src="/images/process/cnc-cutter.jpg"
-                  alt="CNC router cutting bed leg components from pressed plastic sheet"
-                  label="Cut"
-                  aspect="4/3"
-                />
-                <div className="p-5">
-                  <div className="flex items-center gap-3 mb-2">
-                    <div className="w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold flex-shrink-0">4</div>
-                    <h3 className="text-lg font-semibold text-background">Cut</h3>
-                  </div>
-                  <p className="text-sm text-background/60 leading-relaxed">A CNC router cuts bed leg components from the pressed sheets. Precise, repeatable, minimal waste.</p>
-                </div>
-              </div>
-
-              {/* Step 5: Assemble */}
-              <div className="rounded-xl bg-background/5 border border-background/10 overflow-hidden">
-                <CyclingImage
-                  images={[
-                    { src: '/images/pitch/bed-seq-1-leg-pole.jpg', alt: 'First pole threads through canvas sleeve' },
-                    { src: '/images/pitch/bed-seq-2-legs-pole.jpg', alt: 'Second pole through the other side' },
-                    { src: '/images/pitch/bed-seq-3-all-parts.jpg', alt: 'Both poles thread through the X-leg holes' },
-                    { src: '/images/pitch/bed-assembled.jpg', alt: 'Assembled Stretch Bed' },
-                  ]}
-                  aspect="4/3"
-                />
-                <div className="p-5">
-                  <div className="flex items-center gap-3 mb-2">
-                    <div className="w-8 h-8 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold flex-shrink-0">5</div>
-                    <h3 className="text-lg font-semibold text-background">Assemble</h3>
-                  </div>
-                  <p className="text-sm text-background/60 leading-relaxed">Thread a pole through each canvas sleeve and the X-leg holes, then tension. Done in under 5 minutes, no tools.</p>
-                </div>
-              </div>
-            </div>
-
-            <div className="text-center">
-              <p className="text-background/40 text-sm">~30 beds per week &middot; {PLASTIC_KG_PER_BED}kg plastic diverted per bed</p>
-            </div>
+            <p
+              className="text-2xl font-semibold leading-snug text-foreground md:text-3xl"
+              style={DISPLAY_FONT}
+            >
+              {HOME_STORY_COMPACT.line}
+            </p>
+            <Link
+              href={HOME_STORY_COMPACT.link.href}
+              className="mt-6 inline-block text-base font-semibold"
+              style={{ color: DOOR_TONES.terracotta }}
+            >
+              {HOME_STORY_COMPACT.link.label} →
+            </Link>
           </div>
         </div>
       </section>
 
-      {/* 3b. Designed in community — the Oonchiumpa partnership.
-          Bridges "how it's made" (production) and "what it adds up to"
-          (impact). Lands the relationship before the numbers. */}
-      <section className="py-16 md:py-20 bg-background">
-        <div className="container mx-auto px-4">
-          <div className="max-w-6xl mx-auto grid gap-12 md:grid-cols-2 md:items-center">
-            <div>
-              <div className="flex items-center gap-3 mb-5">
-                <Image
-                  src="/images/partners/oonchiumpa.png"
-                  alt="Oonchiumpa Consultancy"
-                  width={560}
-                  height={350}
-                  className="h-12 sm:h-14 w-auto"
-                />
-                <span aria-hidden className="text-2xl text-muted-foreground/40">
-                  ×
-                </span>
-                <span className="text-sm uppercase tracking-[0.2em] text-muted-foreground">
-                  Goods on Country
-                </span>
-              </div>
-
-              <p className="text-sm uppercase tracking-widest text-accent mb-4">
-                Designed in community
+      {/* 3b. The Maningrida feature film — appears when the canon slot has a
+          cleared pick. A produced edit with sound: click-to-play with controls,
+          never an autoplay background. */}
+      {featureFilm && (
+        <section className="bg-foreground py-16 md:py-24">
+          <div className="container mx-auto px-4">
+            <div className="mx-auto max-w-4xl">
+              <p className="mb-4 text-sm uppercase tracking-widest" style={{ color: DOOR_TONES.gold }}>
+                {featureFilm.copy.eyebrow}
               </p>
-              <h2
-                className="text-3xl md:text-4xl font-light text-foreground mb-5 leading-snug"
-                style={{ fontFamily: 'var(--font-display, Georgia, serif)' }}
-              >
-                Two years around the fire with the Bloomfield family.
+              <h2 className="mb-6 text-3xl font-semibold text-background md:text-4xl" style={DISPLAY_FONT}>
+                {featureFilm.copy.title}
               </h2>
-              <p className="text-lg text-muted-foreground mb-4 leading-relaxed">
-                Oonchiumpa Consultancy is a 100% Aboriginal-owned business in Alice Springs. The
-                Stretch Bed and Pakkimjalki Kari washing machine were both designed there, in
-                community, with Elders and young people pulling apart prototypes and putting them
-                back together.
-              </p>
-              <p className="text-lg text-muted-foreground mb-7 leading-relaxed">
-                What started as a design partnership is becoming an enterprise: a production
-                facility in Alice Springs, young people building beds, and a pipeline from local
-                knowledge to local jobs.
-              </p>
-
-              <blockquote
-                className="border-l-4 pl-5 mb-7 text-lg italic leading-relaxed text-foreground/85"
-                style={{ borderColor: 'var(--color-accent, #8B9D77)', fontFamily: 'Georgia, serif' }}
-              >
-                “We want to create a safe space for our young people. There’s a lack of housing,
-                which leads to a lack of sleep, which leads to low school attendance.”
-                <footer className="not-italic mt-2 text-sm text-muted-foreground font-sans">
-                  Kristy Bloomfield, Director, Oonchiumpa Consultancy
-                </footer>
-              </blockquote>
-
-              <Button asChild size="lg">
-                <Link href="/partners/oonchiumpa">
-                  See the Oonchiumpa partnership →
+              <video
+                className="w-full rounded-2xl"
+                src={videoUrl(featureFilm.desktopFile)}
+                poster={featureFilm.poster ?? undefined}
+                controls
+                preload="none"
+                playsInline
+              />
+              <div className="mt-5 flex flex-wrap items-center justify-between gap-4">
+                <p className="max-w-2xl text-base text-background/60">{featureFilm.copy.caption}</p>
+                <Link
+                  href={featureFilm.copy.link.href}
+                  className="text-base font-semibold"
+                  style={{ color: DOOR_TONES.gold }}
+                >
+                  {featureFilm.copy.link.label} →
                 </Link>
-              </Button>
+              </div>
             </div>
+          </div>
+        </section>
+      )}
 
-            <div className="space-y-3">
-              {(() => {
-                const heroSrc = ov('oonchiumpa.hero', '/images/product/stretch-bed-kids-building.jpg');
-                return (
-                  <div className="relative aspect-[4/3] w-full overflow-hidden rounded-3xl bg-muted shadow-sm">
+      {/* 4. The Stretch Bed, with buy */}
+      <section className="bg-muted/30 py-16 md:py-24">
+        <div className="container mx-auto px-4">
+          <div className="grid items-center gap-12 lg:grid-cols-2">
+            <div className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl bg-muted">
+              <Image
+                src={ov('bed.image', HOME_BED_SECTION.image)}
+                alt={HOME_BED_SECTION.imageAlt}
+                fill
+                sizes="(max-width: 1024px) 100vw, 50vw"
+                className="object-cover"
+              />
+              {canSwap && (
+                <MediaSwapZone
+                  slug={HOME_SLUG}
+                  overrideKey="bed.image"
+                  currentUrl={ov('bed.image', HOME_BED_SECTION.image)}
+                  tagQuery={['product:stretch-bed']}
+                  kind="photo"
+                  label="swap"
+                  broadTag="product:stretch-bed"
+                  folders={HOME_FOLDERS}
+                />
+              )}
+            </div>
+            <div>
+              <p className="mb-4 text-sm uppercase tracking-widest" style={{ color: DOOR_TONES.terracotta }}>
+                {HOME_BED_SECTION.eyebrow}
+              </p>
+              <h2 className="mb-4 text-3xl font-semibold text-foreground md:text-4xl" style={DISPLAY_FONT}>
+                {HOME_BED_SECTION.title}
+              </h2>
+              <p className="mb-7 max-w-xl text-lg leading-relaxed text-muted-foreground">
+                {HOME_BED_SECTION.body}
+              </p>
+              <div className="flex flex-wrap items-center gap-5">
+                <Button size="lg" className="text-white hover:opacity-90" style={{ backgroundColor: DOOR_TONES.terracotta }} asChild>
+                  <Link href={HOME_BED_SECTION.buyCta.href}>{HOME_BED_SECTION.buyCta.label}</Link>
+                </Button>
+                <Link
+                  href={HOME_BED_SECTION.moreLink.href}
+                  className="text-base font-semibold"
+                  style={{ color: DOOR_TONES.terracotta }}
+                >
+                  {HOME_BED_SECTION.moreLink.label} →
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 5. The production facility, six stages */}
+      <section className="bg-background py-16 md:py-24">
+        <div className="container mx-auto px-4">
+          <div className="grid items-center gap-12 lg:grid-cols-2">
+            <div>
+              <p className="mb-4 text-sm uppercase tracking-widest" style={{ color: DOOR_TONES.sage }}>
+                {HOME_FACILITY_SECTION.eyebrow}
+              </p>
+              <h2 className="mb-4 text-3xl font-semibold text-foreground md:text-4xl" style={DISPLAY_FONT}>
+                {HOME_FACILITY_SECTION.title}
+              </h2>
+              <p className="mb-7 max-w-xl text-lg leading-relaxed text-muted-foreground">
+                {HOME_FACILITY_SECTION.body}
+              </p>
+              <div className="mb-7 flex flex-wrap gap-2.5">
+                {HOME_FACILITY_SECTION.stages.map((stage) => (
+                  <span
+                    key={stage.id}
+                    title={stage.line}
+                    className="rounded-full border px-3.5 py-1.5 text-sm font-medium"
+                    style={{ borderColor: DOOR_TONES.sage, color: DOOR_TONES.sage }}
+                  >
+                    {stage.label}
+                  </span>
+                ))}
+              </div>
+              <div className="flex flex-wrap gap-6">
+                {HOME_FACILITY_SECTION.links.map((link) => (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="text-base font-semibold"
+                    style={{ color: DOOR_TONES.sage }}
+                  >
+                    {link.label} →
+                  </Link>
+                ))}
+              </div>
+            </div>
+            <div className="relative aspect-[4/3] w-full overflow-hidden rounded-2xl bg-muted">
+              <Image
+                src={ov('facility.image', HOME_FACILITY_SECTION.image)}
+                alt={HOME_FACILITY_SECTION.imageAlt}
+                fill
+                sizes="(max-width: 1024px) 100vw, 50vw"
+                className="object-cover"
+              />
+              {canSwap && (
+                <MediaSwapZone
+                  slug={HOME_SLUG}
+                  overrideKey="facility.image"
+                  currentUrl={ov('facility.image', HOME_FACILITY_SECTION.image)}
+                  tagQuery={['use:process']}
+                  kind="photo"
+                  label="swap"
+                  folders={HOME_FOLDERS}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* 6. Voices */}
+      <section className="bg-muted/30 py-16 md:py-24">
+        <div className="container mx-auto px-4">
+          <p className="mb-4 text-sm uppercase tracking-widest" style={{ color: DOOR_TONES.terracotta }}>
+            {HOME_VOICES.eyebrow}
+          </p>
+          <h2 className="mb-10 max-w-3xl text-3xl font-semibold text-foreground md:text-4xl" style={DISPLAY_FONT}>
+            {HOME_VOICES.title}
+          </h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {HOME_VOICES.cards.map((card, i) => {
+              const imgKey = `voices.${i}.image`;
+              const imgSrc = ov(imgKey, card.image);
+              return (
+                <figure key={card.name} className="overflow-hidden rounded-2xl border border-border bg-background">
+                  <div className="relative aspect-[4/3] w-full bg-muted">
                     <Image
-                      src={heroSrc}
-                      alt="The Oonchiumpa team with a Stretch Bed at the Alice Springs production facility"
+                      src={imgSrc}
+                      alt={card.imageAlt}
                       fill
-                      sizes="(max-width: 768px) 100vw, 50vw"
+                      sizes="(max-width: 768px) 100vw, 33vw"
                       className="object-cover"
                     />
                     {canSwap && (
                       <MediaSwapZone
                         slug={HOME_SLUG}
-                        overrideKey="oonchiumpa.hero"
-                        currentUrl={heroSrc}
-                        tagQuery={['participant:oonchiumpa-young-people']}
+                        overrideKey={imgKey}
+                        currentUrl={imgSrc}
+                        tagQuery={['__website__']}
                         kind="photo"
                         label="swap"
-                        broadTag="product:stretch-bed"
                         folders={HOME_FOLDERS}
                       />
                     )}
                   </div>
-                );
-              })()}
-              <div className="grid grid-cols-3 gap-3">
-                {[
-                  { key: 'oonchiumpa.thumb1', fallback: '/images/partners/centrecorp/utopia/hero-elder-bed.jpg', alt: 'Two men seated with a Stretch Bed' },
-                  { key: 'oonchiumpa.thumb2', fallback: '/images/partners/centrecorp/utopia/community-build.jpg', alt: 'A young person with a Stretch Bed at the Alice Springs build' },
-                  { key: 'oonchiumpa.thumb3', fallback: '/images/partners/centrecorp/utopia/verandah-test.jpg', alt: 'Building a Stretch Bed leg from recycled plastic in Alice Springs' },
-                ].map((t) => {
-                  const src = ov(t.key, t.fallback);
-                  return (
-                    <div key={t.key} className="relative aspect-square w-full overflow-hidden rounded-xl bg-muted">
-                      <Image
-                        src={src}
-                        alt={t.alt}
-                        fill
-                        sizes="(max-width: 768px) 33vw, 17vw"
-                        className="object-cover"
-                      />
-                      {canSwap && (
-                        <MediaSwapZone
-                          slug={HOME_SLUG}
-                          overrideKey={t.key}
-                          currentUrl={src}
-                          tagQuery={['product:stretch-bed']}
-                          kind="photo"
-                          label="swap"
-                          broadTag="product:stretch-bed"
-                          folders={HOME_FOLDERS}
-                        />
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+                  <div className="p-6">
+                    <blockquote className="text-base leading-relaxed text-foreground/90" style={DISPLAY_FONT}>
+                      &ldquo;{homeVoiceQuote(card)}&rdquo;
+                    </blockquote>
+                    <figcaption className="mt-3 text-sm text-muted-foreground">
+                      <span className="font-semibold text-foreground">{card.name}</span> · {card.place}
+                    </figcaption>
+                  </div>
+                </figure>
+              );
+            })}
           </div>
+          <Link
+            href={HOME_VOICES.link.href}
+            className="mt-8 inline-block text-base font-semibold"
+            style={{ color: DOOR_TONES.terracotta }}
+          >
+            {HOME_VOICES.link.label} →
+          </Link>
         </div>
       </section>
 
-      {/* 4. Impact Stats */}
-      <ImpactStats />
-
-      {/* 4b. Field notes — most recent published scrollytelling story.
-          Self-hides until at least one story has published: true. */}
-      <FieldNotesTile />
-
-      {/* 5. Community Voices: from Empathy Ledger */}
-      <FeaturedStories
-        title="Community Voices"
-        subtitle="32 storytellers across remote Australia have shaped and validated the Goods approach"
-        maxStories={3}
-      />
-
-      {/* 6. Final CTA — single clear next step */}
-      <section className="bg-accent py-16 md:py-20">
-        <div className="container mx-auto px-4 text-center">
-          <h2 className="text-3xl font-bold text-accent-foreground md:text-4xl">
-            {brand.oneLiner}
-          </h2>
-          <p className="mx-auto mt-4 max-w-2xl text-lg text-accent-foreground/80">
-            Community-designed. Assembled on Country. Built to last more than ten years in remote Australia.
+      {/* 7. The road, as lessons */}
+      <section className="bg-foreground py-16 md:py-24 text-background">
+        <div className="container mx-auto px-4">
+          <p className="mb-4 text-sm uppercase tracking-widest" style={{ color: DOOR_TONES.gold }}>
+            {HOME_ROAD.eyebrow}
           </p>
-          <div className="mt-8 flex justify-center">
-            <Button size="lg" className="bg-background text-foreground hover:bg-background/90" asChild>
-              <Link href="/shop/stretch-bed-single">Shop the Stretch Bed</Link>
-            </Button>
+          <h2 className="mb-12 max-w-3xl text-3xl font-semibold leading-snug md:text-4xl" style={DISPLAY_FONT}>
+            {HOME_ROAD.title}
+          </h2>
+          <ol className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-4 lg:grid-cols-7">
+            {HOME_ROAD.stops.map((stop, i) => (
+              <li key={stop.id} className="flex flex-col items-center gap-2.5 text-center">
+                <span
+                  aria-hidden
+                  className="h-3.5 w-3.5 rounded-full"
+                  style={{ backgroundColor: i === HOME_ROAD.stops.length - 1 ? DOOR_TONES.terracotta : 'rgba(255,255,255,0.35)' }}
+                />
+                <span className="text-sm text-background/70" title={stop.what}>
+                  {stop.taught}
+                </span>
+              </li>
+            ))}
+          </ol>
+          <p className="mt-12 max-w-2xl text-lg text-background/60" style={DISPLAY_FONT}>
+            {HOME_ROAD.gapLine}
+          </p>
+          <Button
+            size="lg"
+            variant="outline"
+            className="mt-8 border-[#C9A227] bg-transparent text-[#C9A227] hover:bg-[#C9A227]/10"
+            asChild
+          >
+            <Link href={HOME_ROAD.cta.href}>{HOME_ROAD.cta.label}</Link>
+          </Button>
+        </div>
+      </section>
+
+      {/* 8. Four doors, one per audience next-action */}
+      <section className="bg-background py-16 md:py-24">
+        <div className="container mx-auto px-4">
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+            {HOME_DOORS.map((door) => (
+              <div key={door.title} className="flex flex-col rounded-2xl border border-border bg-muted/20 p-8">
+                <h3 className="mb-2 text-2xl font-semibold text-foreground" style={DISPLAY_FONT}>
+                  {door.title}
+                </h3>
+                <p className="mb-6 flex-1 text-base leading-relaxed text-muted-foreground">{door.body}</p>
+                <Button className="self-start text-white hover:opacity-90" style={{ backgroundColor: DOOR_TONES[door.tone] }} asChild>
+                  <Link href={door.cta.href}>{door.cta.label}</Link>
+                </Button>
+              </div>
+            ))}
           </div>
         </div>
       </section>

--- a/v2/src/app/sitemap.ts
+++ b/v2/src/app/sitemap.ts
@@ -1,117 +1,93 @@
 import { MetadataRoute } from 'next';
 import { createServiceClient } from '@/lib/supabase/server';
+import { ROUTE_AUDIENCES } from '@/lib/data/route-audience';
+import { CASE_STUDIES } from '@/lib/data/case-studies';
+import { communityLocations } from '@/lib/data/content';
+import { tripStories } from '@/lib/data/trip-stories';
+
+/**
+ * The sitemap DERIVES from route-audience.ts instead of restating it (2026-08-06).
+ *
+ * The hand-kept list rotted both ways at once: it advertised /impact and /community
+ * (proxy-gated, so Google got a login page) and /about (verdict: redirect), while missing
+ * the best public content on the site — the communities, the case studies, the field
+ * notes, /news. Because route-audience.ts is guarded against the filesystem and the proxy
+ * on every build (check:audience), deriving from it means a route that is added, gated,
+ * redirected or retired updates the sitemap in the same commit, with no second list to
+ * forget.
+ *
+ * A route earns a sitemap entry when ALL of:
+ *   - access is 'open' (the guard derives gating from src/proxy.ts, so this is real)
+ *   - verdict is 'keep' or 'rewrite' (redirect/retire/plumbing routes are not content)
+ *   - it is static (dynamic families are enumerated from their own data modules below)
+ *   - its family does not set robots noindex (the pitch/print/export surfaces)
+ */
+
+// Families that noindex themselves (robots in their metadata). A page asking not to be
+// indexed must not be advertised. Kept as prefixes because the noindex decision is per
+// family, not per route.
+const NOINDEX_PREFIXES = [
+  '/pitch',
+  '/onepagers',
+  '/export',
+  '/kit',
+  '/pathways',
+  '/site',
+  '/deck',
+  '/canberra', // airport-QR landing: reached by scan, not search
+];
+
+// Editorial weight for the front doors; everything else gets a sane default.
+const PRIORITY: Record<string, number> = {
+  '/': 1,
+  '/shop': 0.9,
+  '/shop/stretch-bed-single': 0.95,
+  '/story': 0.85,
+  '/communities': 0.85,
+  '/process': 0.8,
+  '/sponsor': 0.8,
+  '/partner': 0.75,
+  '/news': 0.7,
+};
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.goodsoncountry.com').replace(/\/$/, '');
-  const now = new Date();
 
-  // Static pages
-  const staticPages: MetadataRoute.Sitemap = [
-    {
-      url: baseUrl,
-      lastModified: now,
-      changeFrequency: 'weekly',
-      priority: 1,
-    },
-    {
-      url: `${baseUrl}/shop`,
-      lastModified: now,
-      changeFrequency: 'daily',
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/shop/stretch-bed-single`,
-      lastModified: now,
-      changeFrequency: 'weekly',
-      priority: 0.95,
-    },
-    {
-      url: `${baseUrl}/shop/washing-machine`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/about`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/process`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.85,
-    },
-    {
-      url: `${baseUrl}/impact`,
-      lastModified: now,
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/stories`,
-      lastModified: now,
-      changeFrequency: 'weekly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/story`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.65,
-    },
-    {
-      url: `${baseUrl}/community`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.65,
-    },
-    {
-      url: `${baseUrl}/sponsor`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/partner`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.75,
-    },
-    {
-      url: `${baseUrl}/partners/centrecorp`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.85,
-    },
-    {
-      url: `${baseUrl}/wiki/support/faq`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.65,
-    },
-    {
-      url: `${baseUrl}/wiki/products/stretch-bed`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.65,
-    },
-    {
-      url: `${baseUrl}/basket-bed-plans`,
-      lastModified: now,
-      changeFrequency: 'yearly',
-      priority: 0.4,
-    },
-    {
-      url: `${baseUrl}/contact`,
-      lastModified: now,
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
-  ];
+  const staticPages: MetadataRoute.Sitemap = ROUTE_AUDIENCES.filter(
+    (r) =>
+      r.access === 'open' &&
+      (r.verdict === 'keep' || r.verdict === 'rewrite') &&
+      !r.route.includes('[') &&
+      !NOINDEX_PREFIXES.some((p) => r.route === p || r.route.startsWith(`${p}/`)),
+  ).map((r) => ({
+    url: `${baseUrl}${r.route === '/' ? '' : r.route}`,
+    changeFrequency: 'weekly' as const,
+    priority: PRIORITY[r.route] ?? 0.6,
+  }));
 
-  // Dynamic product pages
+  // Dynamic families, each enumerated from the module its pages already build from
+  // (the same lists generateStaticParams uses, so sitemap and pages cannot disagree).
+  const communityPages: MetadataRoute.Sitemap = communityLocations.map((c) => ({
+    url: `${baseUrl}/communities/${c.id}`,
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
+  }));
+
+  const caseStudyPages: MetadataRoute.Sitemap = CASE_STUDIES.filter((c) => c.published).map((c) => ({
+    url: `${baseUrl}/case-studies/${c.slug}`,
+    changeFrequency: 'monthly' as const,
+    priority: 0.8,
+  }));
+
+  const fieldNotePages: MetadataRoute.Sitemap = tripStories
+    .filter((s) => s.published)
+    .map((s) => ({
+      url: `${baseUrl}/field-notes/${s.slug}`,
+      changeFrequency: 'monthly' as const,
+      priority: 0.7,
+    }));
+
+  // Shop products from the live catalogue, with real lastModified.
   let productPages: MetadataRoute.Sitemap = [];
   try {
     const supabase = createServiceClient();
@@ -121,7 +97,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       .eq('is_active', true);
 
     if (products) {
-      const staticUrls = new Set(staticPages.map((p) => p.url));
+      const seen = new Set(staticPages.map((p) => p.url));
       productPages = products
         .map((product) => ({
           url: `${baseUrl}/shop/${product.slug}`,
@@ -129,15 +105,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           changeFrequency: 'weekly' as const,
           priority: 0.8,
         }))
-        .filter((p) => !staticUrls.has(p.url));
+        .filter((p) => !seen.has(p.url));
     }
   } catch (error) {
     console.error('Error fetching products for sitemap:', error);
   }
 
-  // Story detail pages resolve Empathy Ledger story ids (/stories/[id] calls
-  // empathyLedger.getStory), not the local stories table, so local slugs 404.
-  // Re-add story entries here from EL ids once the EL keys are restored.
-
-  return [...staticPages, ...productPages];
+  return [...staticPages, ...communityPages, ...caseStudyPages, ...fieldNotePages, ...productPages];
 }

--- a/v2/src/components/layout/site-header.tsx
+++ b/v2/src/components/layout/site-header.tsx
@@ -2,29 +2,50 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { Button } from '@/components/ui/button';
-import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { CartButton } from '@/components/cart';
+
+/**
+ * Site header, rebuilt 2026-08-06 (Ben: the old top menu never sat right, and the
+ * 300px mobile sheet was cramped). Desktop: a short nav in reading order plus the two
+ * CTAs. Mobile: a FULL-SCREEN overlay — big type a thumb cannot miss, the primary
+ * pages first, then the same four doors the homepage ends on, so wherever someone is
+ * they can reach their next step in one tap.
+ */
 
 type NavItem = { name: string; href: string; subtitle?: string };
 
 const navigation: NavItem[] = [
-  { name: 'Stretch Bed', href: '/shop/stretch-bed-single' },
-  { name: 'Pakkimjalki Kari', subtitle: 'Washing Machine', href: '/shop/washing-machine' },
-  { name: 'How It\'s Made', href: '/process' },
-  { name: 'Back the work', href: '/partner' },
-  // 'Field notes' nav entry pulled until Utopia is consent-cleared +
-  // published. Re-add this line when ready:
-  // { name: 'Field notes', href: '/field-notes' },
-  { name: 'Our Story', href: '/story' },
+  { name: 'The Stretch Bed', href: '/shop/stretch-bed-single' },
+  { name: 'How it’s made', href: '/process' },
+  { name: 'Communities', href: '/communities' },
+  { name: 'Our story', href: '/story' },
+  { name: 'Invest', href: '/invest' },
   { name: 'Contact', href: '/contact' },
+];
+
+/** The same four audience doors the homepage closes on (home.ts HOME_DOORS order). */
+const menuDoors = [
+  { name: 'Buy a bed', href: '/shop/stretch-bed-single', color: '#C45C3E' },
+  { name: 'Sponsor a bed', href: '/sponsor', color: '#C9A227' },
+  { name: 'Want this where you are?', href: '/communities', color: '#6F7F5C' },
+  { name: 'Back the making', href: '/invest', color: '#3E6363' },
 ];
 
 export function SiteHeader() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const pathname = usePathname();
+
+  // Close the overlay on navigation and lock body scroll while it is open.
+  useEffect(() => setMobileMenuOpen(false), [pathname]);
+  useEffect(() => {
+    document.body.style.overflow = mobileMenuOpen ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [mobileMenuOpen]);
 
   if (pathname?.startsWith('/admin')) {
     return null;
@@ -41,92 +62,120 @@ export function SiteHeader() {
             width={657}
             height={447}
             priority
-            className="h-12 w-auto object-contain"
+            className="h-11 w-auto object-contain"
           />
         </Link>
 
-        {/* Desktop Navigation */}
-        <div className="hidden md:flex md:items-center md:gap-6">
-          {navigation.map((item) => (
-            <Link
-              key={item.name}
-              href={item.href}
-              className="group text-sm font-medium text-foreground/80 transition-colors hover:text-primary"
-            >
-              <span>{item.name}</span>
-              {item.subtitle && (
-                <span className="ml-1 text-xs text-muted-foreground group-hover:text-primary/70">
-                  ({item.subtitle})
-                </span>
-              )}
-            </Link>
-          ))}
-        </div>
-
-        {/* CTA Buttons & Cart */}
-        <div className="hidden md:flex md:items-center md:gap-3">
-          <Button size="sm" variant="outline" asChild>
-            <Link href="/partner">Back the work</Link>
-          </Button>
-          <Button size="sm" asChild>
-            <Link href="/shop/stretch-bed-single">Buy Now</Link>
-          </Button>
-          <CartButton />
-        </div>
-
-        {/* Mobile Cart & Menu */}
-        <div className="flex items-center gap-2 md:hidden">
-          <CartButton />
-          <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
-            <SheetTrigger asChild>
-            <Button variant="ghost" size="icon" aria-label="Open menu">
-              <svg
-                className="h-6 w-6"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth="1.5"
-                stroke="currentColor"
+        {/* Desktop navigation */}
+        <div className="hidden lg:flex lg:items-center lg:gap-7">
+          {navigation.map((item) => {
+            const active = pathname === item.href || (item.href !== '/' && pathname?.startsWith(`${item.href}/`));
+            return (
+              <Link
+                key={item.name}
+                href={item.href}
+                className={`relative text-sm font-medium transition-colors hover:text-[#C45C3E] ${
+                  active ? 'text-[#C45C3E]' : 'text-foreground/70'
+                }`}
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
-                />
+                {item.name}
+                {active && (
+                  <span className="absolute -bottom-[22px] left-0 right-0 h-0.5 bg-[#C45C3E]" aria-hidden />
+                )}
+              </Link>
+            );
+          })}
+        </div>
+
+        {/* Desktop CTAs & cart */}
+        <div className="hidden lg:flex lg:items-center lg:gap-3">
+          <Button size="sm" className="bg-[#C45C3E] text-white hover:bg-[#C45C3E]/90" asChild>
+            <Link href="/shop/stretch-bed-single">Buy a bed</Link>
+          </Button>
+          <CartButton />
+        </div>
+
+        {/* Mobile: cart + menu trigger */}
+        <div className="flex items-center gap-2 lg:hidden">
+          <CartButton />
+          <button
+            type="button"
+            onClick={() => setMobileMenuOpen(true)}
+            aria-label="Open menu"
+            aria-expanded={mobileMenuOpen}
+            className="flex h-10 w-10 items-center justify-center rounded-md text-foreground hover:bg-muted"
+          >
+            <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.8" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 7h16.5M3.75 12h16.5m-16.5 5h16.5" />
+            </svg>
+          </button>
+        </div>
+      </nav>
+
+      {/* Full-screen mobile menu */}
+      {mobileMenuOpen && (
+        <div className="fixed inset-0 z-[60] flex flex-col bg-[#fbf8f1] lg:hidden" role="dialog" aria-modal="true">
+          <div className="flex h-16 items-center justify-between border-b border-[#2b2a26]/10 px-4">
+            <Link href="/" aria-label="Goods on Country home" onClick={() => setMobileMenuOpen(false)}>
+              <Image
+                src="/brand/canonical/goods-on-country-primary-ink.png"
+                alt="Goods on Country"
+                width={657}
+                height={447}
+                className="h-11 w-auto object-contain"
+              />
+            </Link>
+            <button
+              type="button"
+              onClick={() => setMobileMenuOpen(false)}
+              aria-label="Close menu"
+              className="flex h-10 w-10 items-center justify-center rounded-md text-[#2b2a26] hover:bg-black/5"
+            >
+              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" strokeWidth="1.8" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
               </svg>
-            </Button>
-          </SheetTrigger>
-          <SheetContent side="right" className="w-[300px] sm:w-[400px]">
-            <nav className="flex flex-col gap-4 mt-8">
-              {navigation.map((item) => (
+            </button>
+          </div>
+
+          <nav className="flex flex-1 flex-col justify-between overflow-y-auto px-6 pb-10 pt-8">
+            <div className="space-y-1">
+              {navigation.map((item, i) => (
                 <Link
                   key={item.name}
                   href={item.href}
-                  className="text-lg font-medium text-foreground/80 transition-colors hover:text-primary"
                   onClick={() => setMobileMenuOpen(false)}
+                  className="block py-2.5 text-3xl font-semibold text-[#2b2a26] transition-colors hover:text-[#C45C3E]"
+                  style={{ fontFamily: 'var(--font-display, Georgia, serif)', transitionDelay: `${i * 15}ms` }}
                 >
                   {item.name}
-                  {item.subtitle && (
-                    <span className="ml-2 text-sm text-muted-foreground">({item.subtitle})</span>
-                  )}
                 </Link>
               ))}
-              <div className="mt-4 flex flex-col gap-3">
-                <Button variant="outline" asChild>
-                  <Link href="/partner" onClick={() => setMobileMenuOpen(false)}>
-                    Back the work
+            </div>
+
+            <div className="mt-10">
+              <p className="mb-3 font-mono text-[10px] uppercase tracking-[0.2em] text-[#7a7363]">
+                Where do you want to go?
+              </p>
+              <div className="grid grid-cols-2 gap-2.5">
+                {menuDoors.map((door) => (
+                  <Link
+                    key={door.name}
+                    href={door.href}
+                    onClick={() => setMobileMenuOpen(false)}
+                    className="rounded-xl px-4 py-4 text-sm font-semibold leading-snug text-white"
+                    style={{ backgroundColor: door.color }}
+                  >
+                    {door.name}
                   </Link>
-                </Button>
-                <Button asChild>
-                  <Link href="/shop/stretch-bed-single" onClick={() => setMobileMenuOpen(false)}>
-                    Buy Now
-                  </Link>
-                </Button>
+                ))}
               </div>
-            </nav>
-          </SheetContent>
-          </Sheet>
+              <p className="mt-6 text-sm text-[#7a7363]">
+                hello@goodsoncountry.com
+              </p>
+            </div>
+          </nav>
         </div>
-      </nav>
+      )}
     </header>
   );
 }

--- a/v2/src/lib/data/home.guards.test.ts
+++ b/v2/src/lib/data/home.guards.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Guards for the homepage data module.
+ *
+ * The homepage is the most-read surface on the site, so its copy lives in
+ * home.ts as data and these tests hold the lines that must never drift:
+ * consent, canon figures, the locked stage model, the road spine, the
+ * audience-model doors, and the gitignored-media trap (a photo you can
+ * `ls` may still not ship).
+ */
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+import {
+  HOME_HERO,
+  HOME_PROVENANCE,
+  HOME_STORY_COMPACT,
+  HOME_FEATURE_COPY,
+  HOME_BED_SECTION,
+  HOME_FACILITY_SECTION,
+  HOME_VOICES,
+  HOME_ROAD,
+  HOME_DOORS,
+  homeVoiceQuote,
+} from './home';
+import { isClearedForExternal } from './cleared-voices';
+import { canonValue } from './canon';
+import { PLASTIC_KG_PER_BED } from './products';
+import { PUBLIC_STAGES } from './pathway-stages';
+import { ROAD_STOPS, THE_GAP } from './road-spine';
+
+const PUBLIC_DIR = join(__dirname, '../../../public');
+
+const allImages = [
+  HOME_HERO.image,
+  HOME_BED_SECTION.image,
+  HOME_FACILITY_SECTION.image,
+  ...HOME_VOICES.cards.map((c) => c.image),
+];
+
+describe('homepage guards', () => {
+  it('every named voice is cleared for external use', () => {
+    for (const card of HOME_VOICES.cards) {
+      expect(isClearedForExternal(card.name), `${card.name} is not on the external clearance list`).toBe(true);
+    }
+  });
+
+  it('every voice card resolves a real curated quote (never invented here)', () => {
+    for (const card of HOME_VOICES.cards) {
+      expect(homeVoiceQuote(card).length).toBeGreaterThan(10);
+    }
+  });
+
+  it('the price on the page is the canon stretch-price', () => {
+    const price = canonValue('stretch-price');
+    expect(HOME_BED_SECTION.price).toBe(price);
+    expect(HOME_BED_SECTION.buyCta.label).toContain(`$${price}`);
+    expect(HOME_DOORS[0].body).toContain(`$${price}`);
+  });
+
+  it('plastic figure comes from the product constant', () => {
+    expect(HOME_PROVENANCE[1]).toBe(`${PLASTIC_KG_PER_BED}kg of HDPE per bed`);
+    expect(HOME_BED_SECTION.body).toContain(`${PLASTIC_KG_PER_BED}kg`);
+  });
+
+  it('the stage chips are the locked six-stage model, not a local list', () => {
+    expect(HOME_FACILITY_SECTION.stages).toBe(PUBLIC_STAGES);
+    expect(HOME_FACILITY_SECTION.stages).toHaveLength(6);
+  });
+
+  it('the road band is the road spine: lessons, with the gap', () => {
+    expect(HOME_ROAD.stops).toBe(ROAD_STOPS);
+    expect(HOME_ROAD.gapLine).toBe(THE_GAP.line);
+  });
+
+  it('the forty-beds claim stays consistent with the spine (factory path is PROVEN)', () => {
+    const maningrida = ROAD_STOPS.find((s) => s.id === 'maningrida');
+    expect(maningrida?.what).toContain('Forty beds pressed');
+    expect(HOME_PROVENANCE[0]).toBe('40 beds pressed end to end');
+    expect(HOME_FACILITY_SECTION.body).toContain('Forty beds pressed');
+  });
+
+  it('every photo ships: exists under public/, never a starred-images path', () => {
+    for (const src of allImages) {
+      expect(src.startsWith('/images/'), `${src} must live under public/images`).toBe(true);
+      expect(src).not.toContain('starred-images');
+      expect(existsSync(join(PUBLIC_DIR, src)), `${src} not found in public/`).toBe(true);
+    }
+  });
+
+  it('the feature-film claim stays consistent with the register', () => {
+    expect(HOME_FEATURE_COPY.caption).toContain('Forty beds');
+  });
+
+  it('four doors, one per audience next-action, each pointing at its front door', () => {
+    expect(HOME_DOORS).toHaveLength(4);
+    const hrefs = HOME_DOORS.map((d) => d.cta.href);
+    expect(hrefs).toContain('/shop/stretch-bed-single'); // buyer
+    expect(hrefs).toContain('/sponsor'); // supporter
+    expect(hrefs).toContain('/communities'); // community
+    expect(hrefs).toContain('/pitch/road'); // funder
+  });
+
+  it('the community door proposes nothing and carries no price; the funder door no figures', () => {
+    const community = HOME_DOORS.find((d) => d.cta.href === '/communities');
+    expect(community?.body).not.toMatch(/\$\s?\d/);
+    expect(community?.body).not.toMatch(/facility proposal|cost model/i);
+    const funder = HOME_DOORS.find((d) => d.cta.href === '/pitch/road');
+    expect(funder?.body).not.toMatch(/\$\s?\d/);
+  });
+
+  it('ownership is a pathway, never claimed complete', () => {
+    const prose = [
+      HOME_STORY_COMPACT.line,
+      HOME_FACILITY_SECTION.title,
+      HOME_FACILITY_SECTION.body,
+      HOME_ROAD.title,
+      ...HOME_DOORS.map((d) => d.body),
+    ].join(' ');
+    expect(prose).not.toMatch(/community[- ]owned factory|now owns the making|ownership complete/i);
+  });
+});

--- a/v2/src/lib/data/home.ts
+++ b/v2/src/lib/data/home.ts
@@ -1,0 +1,184 @@
+/**
+ * HOMEPAGE A — "The Bed on Country". The single source for every word on `/`.
+ *
+ * Built 2026-07-26 from Ben's picked Pencil mock (design/goods-theory-of-change-v2.pen,
+ * frame "Homepage A"), merged as #171 and reverted unseen (#173). Revived 2026-08-06 for
+ * the wayfinding review, adapted to the audience model: hero → provenance → compact story →
+ * feature film (canon slot) → Stretch Bed with buy → facility with the six stages →
+ * voices → road-as-lessons → FOUR doors, one per audience next-action.
+ *
+ * Rules this module enforces by construction (asserted in home.guards.test.ts):
+ *   - Every named voice is on the external clearance list (cleared-voices.ts).
+ *   - Every quote is verbatim from curated-quotes.ts. No quote is ever written here.
+ *   - The stage chips are PUBLIC_STAGES (pathway-stages.ts), never a local list.
+ *   - The road band is ROAD_STOPS lessons (road-spine.ts), never place names alone.
+ *   - Numbers come from canon / products, never inline.
+ *   - Photo paths are git-tracked files under public/, never design/starred-images.
+ *   - The feature film renders from the 'video-maningrida-case-study' canon slot, so the
+ *     section appears when the cleared cut lands and no 13MB file ever enters git.
+ */
+import { canonValue } from './canon';
+import { canonVideo, type CanonVideoEntry } from './canon-videos';
+import { PLASTIC_KG_PER_BED } from './products';
+import { PUBLIC_STAGES } from './pathway-stages';
+import { ROAD_STOPS, THE_GAP } from './road-spine';
+import { getCuratedQuotes } from './curated-quotes';
+
+export const HOME_HERO = {
+  headline: 'A bed made on Country, from the plastic that was already here.',
+  image: '/images/community/maningrida/whole-run-at-sunset.jpg',
+  imageAlt:
+    'The whole run of finished Stretch Beds at Maningrida at sunset, people sitting on them after build day',
+  primaryCta: { label: 'Buy the Stretch Bed', href: '/shop/stretch-bed-single' },
+  secondaryCta: { label: 'Walk the road', href: '/story' },
+} as const;
+
+/** The strip under the hero. Short claims, each one already true elsewhere in code. */
+export const HOME_PROVENANCE = [
+  '40 beds pressed end to end',
+  `${PLASTIC_KG_PER_BED}kg of HDPE per bed`,
+  'Designed in community, led by community',
+  'Ownership is a pathway',
+] as const;
+
+export const HOME_STORY_COMPACT = {
+  eyebrow: 'About Goods',
+  line: 'Beds donated to remote communities kept disappearing. So communities started making their own: quality furniture, pressed from the plastic already on Country, on a road to owning the making itself.',
+  link: { label: 'Read the full story', href: '/story' },
+} as const;
+
+/**
+ * The Maningrida feature film. Resolves from the 'video-maningrida-case-study' canon
+ * slot (the film slot the case study also reads). While the slot is empty — the cut is
+ * still being cleared — this returns null and the homepage section does not render.
+ * A produced edit with sound renders click-to-play with controls, never autoplay.
+ */
+export function homeFeatureVideo(): (CanonVideoEntry & { copy: typeof HOME_FEATURE_COPY }) | null {
+  const v = canonVideo('video-maningrida-case-study');
+  if (!v) return null;
+  return { ...v, copy: HOME_FEATURE_COPY };
+}
+
+export const HOME_FEATURE_COPY = {
+  eyebrow: 'Maningrida, July 2026',
+  title: 'Our biggest build, in one community.',
+  caption:
+    'Forty beds and the school washing machine, built with the Gamardi community and Homeland School Company. Four minutes, worth the sound on.',
+  link: { label: 'The whole road that led here', href: '/story' },
+} as const;
+
+export const HOME_BED_SECTION = {
+  eyebrow: 'The Stretch Bed',
+  title: 'A bed built to stay.',
+  body: `Two steel poles thread through the canvas and the crossed recycled-plastic legs; tensioning locks it all together. ${PLASTIC_KG_PER_BED}kg of HDPE diverted per bed. Flat-packs, assembles anywhere, and the canvas is the structure.`,
+  image: '/images/community/maningrida/men-over-finished-bed.jpg',
+  imageAlt: 'Men looking over a finished Stretch Bed, the X-trestle tension design visible',
+  price: canonValue('stretch-price') as number,
+  buyCta: { label: `Buy the bed · $${canonValue('stretch-price')}`, href: '/shop/stretch-bed-single' },
+  moreLink: { label: 'More about the bed', href: '/shop' },
+} as const;
+
+export const HOME_FACILITY_SECTION = {
+  eyebrow: 'The production facility',
+  title: 'A factory that can move to community ownership.',
+  body: 'A containerised plant that shreds the plastic, presses the sheets and cuts the legs. Forty beds pressed end to end prove the process. Each community picks the pieces it wants to run, and the pathway is walked together.',
+  image: '/images/process/factory-panorama.jpg',
+  imageAlt: 'Panorama of the on-country production facility',
+  /** The six public stages, from the locked model. Render label only; line on hover/detail. */
+  stages: PUBLIC_STAGES,
+  links: [
+    { label: 'About the facility', href: '/process' },
+    { label: 'The pathways to ownership', href: '/pathways' },
+  ],
+} as const;
+
+export interface HomeVoiceCard {
+  /** Must be cleared for external use (cleared-voices.ts). */
+  name: string;
+  /** Where they speak from, for the byline. */
+  place: string;
+  /** Index into their curated quotes. The text is looked up, never copied. */
+  quoteIndex: number;
+  image: string;
+  imageAlt: string;
+}
+
+export const HOME_VOICES = {
+  eyebrow: 'Voices lead the road',
+  title: 'Every stop on the road is a person saying something.',
+  link: { label: 'All storytellers', href: '/storytellers' },
+  cards: [
+    {
+      name: 'Gloria Turner',
+      place: 'Kalgoorlie',
+      quoteIndex: 0,
+      image: '/images/people/gloria-turner.jpg',
+      imageAlt: 'Gloria Turner',
+    },
+    {
+      name: 'Dianne Stokes',
+      place: 'Tennant Creek',
+      quoteIndex: 0,
+      image: '/images/people/dianne-stokes.jpg',
+      imageAlt: 'Dianne Stokes',
+    },
+    {
+      name: 'Fred Campbell',
+      place: 'Alice Springs',
+      quoteIndex: 0,
+      image: '/images/people/fred-campbell.png',
+      imageAlt: 'Fred Campbell',
+    },
+  ] satisfies HomeVoiceCard[],
+} as const;
+
+/** Resolve a card's quote from the curated store. Throws if the voice has no quote there. */
+export function homeVoiceQuote(card: HomeVoiceCard): string {
+  const quotes = getCuratedQuotes(card.name);
+  const quote = quotes?.[card.quoteIndex];
+  if (!quote) throw new Error(`No curated quote for homepage voice "${card.name}".`);
+  return quote.text;
+}
+
+export const HOME_ROAD = {
+  eyebrow: 'The road to ownership',
+  title:
+    'The goal was never a bigger Goods. It is a community that can collect the plastic, make the goods, and come to own the making.',
+  /** The stops render as LESSONS (taught), never place names alone. */
+  stops: ROAD_STOPS,
+  gapLine: THE_GAP.line,
+  cta: { label: 'Walk all seven stops', href: '/story' },
+} as const;
+
+/**
+ * FOUR doors, one per audience next-action (audience.ts, applied 2026-08-06):
+ * buyer → shop, supporter → sponsor, community → a yarn with nothing proposed,
+ * funder → the road. The community door carries no prices and proposes nothing;
+ * the funder door carries no figures (one-money-surface rule).
+ */
+export const HOME_DOORS = [
+  {
+    title: 'Buy a bed',
+    body: `$${canonValue('stretch-price')}. Spec, freight and lead time up front.`,
+    cta: { label: 'Shop', href: '/shop/stretch-bed-single' },
+    tone: 'terracotta' as const,
+  },
+  {
+    title: 'Sponsor a bed',
+    body: 'One bed, one community, one receipt.',
+    cta: { label: 'Sponsor', href: '/sponsor' },
+    tone: 'gold' as const,
+  },
+  {
+    title: 'Want this where you are?',
+    body: 'See the communities the beds have gone to, and how each one set its own pace. It starts with a yarn, nothing proposed.',
+    cta: { label: 'The communities', href: '/communities' },
+    tone: 'sage' as const,
+  },
+  {
+    title: 'Back the making',
+    body: 'Repayable capital for the plant that communities come to own. The whole road, with evidence.',
+    cta: { label: 'See the pitch', href: '/pitch/road' },
+    tone: 'teal' as const,
+  },
+] as const;

--- a/v2/src/lib/data/route-audience.ts
+++ b/v2/src/lib/data/route-audience.ts
@@ -103,12 +103,15 @@ export const ROUTE_AUDIENCES: RouteAudience[] = [
     route: '/',
     audience: 'supporter',
     access: 'open',
+    // 2026-08-06: Homepage A revived (six-front-doors #171, reverted unseen #173, regrafted
+    // for the wayfinding review). Renders entirely from home.ts (guarded); ends on FOUR
+    // doors, one per audience next-action, so buyer/community/funder each find their front
+    // door from here without the supporter lead serving them first.
     leadsWithNow: {
-      heading: 'The Stretch Bed',
-      body: 'Recycled plastic, galvanised steel, heavy-duty canvas. 26kg, flat-packs, no tools. Every bed supports remote First Nations communities across Australia.',
+      heading: 'A bed made on Country, from the plastic that was already here.',
+      body: 'Beds donated to remote communities kept disappearing. So communities started making their own.',
     },
-    verdict: 'rewrite',
-    why: 'Supporter front page leading with the product spec. supporter.leadWith is "one face, one voice, one place"; this opens "The Stretch Bed / Recycled plastic, galvanised steel, heavy-duty canvas. 26kg, flat-packs, no tools." That is buyer copy.',
+    verdict: 'keep',
   },
   {
     route: '/about',

--- a/v2/src/lib/data/route-audience.ts
+++ b/v2/src/lib/data/route-audience.ts
@@ -1265,6 +1265,20 @@ export const ROUTE_AUDIENCES: RouteAudience[] = [
     why: 'a per-surface password gate',
   },
   {
+    route: '/invest',
+    audience: 'funder',
+    access: 'open',
+    // 2026-08-06 (Ben): the structural page /partner never was — the three entities as three
+    // doors (ENTITY_DOORS, import-locked), which giver fits which door, and the levels the
+    // work supports. Figures stay on /pitch/road; this page routes, /partner converses.
+    leadsWithNow: {
+      heading: 'Support communities where they are at. The bed is the entry point, never the whole point.',
+      eyebrow: 'Back the work',
+      body: 'One piece of work touches health, enterprise, young people and learning at once.',
+    },
+    verdict: 'keep',
+  },
+  {
     route: '/kit',
     audience: 'press',
     access: 'open',


### PR DESCRIPTION
Six-front-doors homepage regrafted (four audience doors, guarded home.ts); /invest renders ENTITY_DOORS; header rebuilt with full-screen mobile menu; sitemap derives from route-audience (17 stale URLs → 59 real). ⚠ Replaces the production homepage — walk the preview first (the #173 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)